### PR TITLE
Solução de bug de não desbloquear a próxima estrela

### DIFF
--- a/apps/server/src/app/hono/routers/profile/UsersRouter.ts
+++ b/apps/server/src/app/hono/routers/profile/UsersRouter.ts
@@ -123,6 +123,7 @@ export class UsersRouter extends HonoRouter {
     this.router.put(
       '/:userId/reward/star-challenge',
       this.authMiddleware.verifyAuthentication,
+      this.spaceMiddleware.appendNextStarToBody,
       this.challengingMiddleware.appendChallengeRewardToBody,
       zValidator(
         'param',

--- a/apps/web/src/rest/services/PlaygroundService.ts
+++ b/apps/web/src/rest/services/PlaygroundService.ts
@@ -13,11 +13,11 @@ export const PlaygroundService = (restClient: RestClient): IPlaygroundService =>
       return restClient.get('/playground/snippets')
     },
 
-    saveSnippet(snippet: Snippet) {
+    createSnippet(snippet: Snippet) {
       return restClient.post('/playground/snippets', snippet)
     },
 
-    updateSnippet(snippet: Snippet) {
+    editSnippet(snippet: Snippet) {
       return restClient.put(`/playground/snippets/${snippet.id.value}`, snippet)
     },
 

--- a/apps/web/src/ui/challenging/widgets/slots/ChallengeResult/useChallengeResultSlot.ts
+++ b/apps/web/src/ui/challenging/widgets/slots/ChallengeResult/useChallengeResultSlot.ts
@@ -77,13 +77,16 @@ export function useChallengeResultSlot() {
   function handleUserAnswer() {
     if (!challenge || !user) return
 
-    if (challenge.isCompleted.isTrue) {
+    if (challenge.isCompleted.and(challenge.isStarChallenge).isTrue) {
+      showRewards()
       if (
         user.hasCompletedChallenge(challenge.id).or(challenge.author.isEqualTo(user))
           .isTrue
-      )
+      ) {
         leavePage(ROUTES.challenging.challenges.list)
-      else showRewards()
+      } else {
+        showRewards()
+      }
       return
     }
 

--- a/apps/web/src/ui/challenging/widgets/slots/ChallengeResult/useChallengeResultSlot.ts
+++ b/apps/web/src/ui/challenging/widgets/slots/ChallengeResult/useChallengeResultSlot.ts
@@ -83,7 +83,7 @@ export function useChallengeResultSlot() {
         user.hasCompletedChallenge(challenge.id).or(challenge.author.isEqualTo(user))
           .isTrue
       ) {
-        leavePage(ROUTES.challenging.challenges.list)
+        leavePage(ROUTES.space)
       } else {
         showRewards()
       }

--- a/apps/web/src/ui/challenging/widgets/slots/ChallengeResult/useChallengeResultSlot.ts
+++ b/apps/web/src/ui/challenging/widgets/slots/ChallengeResult/useChallengeResultSlot.ts
@@ -79,11 +79,20 @@ export function useChallengeResultSlot() {
 
     if (challenge.isCompleted.and(challenge.isStarChallenge).isTrue) {
       showRewards()
+      if (user.hasCompletedChallenge(challenge.id).isTrue) {
+        leavePage(ROUTES.space)
+      } else {
+        showRewards()
+      }
+      return
+    }
+
+    if (challenge.isCompleted.andNot(challenge.isStarChallenge).isTrue) {
       if (
         user.hasCompletedChallenge(challenge.id).or(challenge.author.isEqualTo(user))
           .isTrue
       ) {
-        leavePage(ROUTES.space)
+        leavePage(ROUTES.challenging.challenges.list)
       } else {
         showRewards()
       }

--- a/packages/core/src/challenging/domain/entities/Challenge.ts
+++ b/packages/core/src/challenging/domain/entities/Challenge.ts
@@ -149,6 +149,10 @@ export class Challenge extends Entity<ChallengeProps> {
     return Logical.create(this.props.author.id.value === userId.value)
   }
 
+  get isStarChallenge(): Logical {
+    return Logical.create(this.props.starId !== null)
+  }
+
   get maximumIncorrectAnswersCount(): Integer {
     const testsCasesCount = this.testCases.length
     return Integer.create(

--- a/packages/core/src/profile/domain/entities/User.ts
+++ b/packages/core/src/profile/domain/entities/User.ts
@@ -42,7 +42,6 @@ type UserProps = {
   canSeeRankingResult: Logical
   didBreakStreak: Logical
   lastWeekRankingPosition: RankingPosition | null
-  hasCompletedSpace: Logical
   createdAt: Date
 }
 

--- a/packages/core/src/profile/use-cases/CalculateRewardForStarCompletionUseCase.ts
+++ b/packages/core/src/profile/use-cases/CalculateRewardForStarCompletionUseCase.ts
@@ -29,7 +29,7 @@ export class CalculateRewardForStarCompletionUseCase
     const user = await this.findUser(Id.create(userId))
     const isLastSpaceStar = nextStarId === null
     const isNextStarUnlocked = isLastSpaceStar
-      ? user.hasCompletedSpace.isFalse
+      ? user.hasCompletedSpace.isTrue
       : user.hasUnlockedStar(Id.create(nextStarId)).isTrue
 
     const newXp = this.calculateXp(

--- a/packages/core/src/profile/use-cases/tests/CalculateRewardForChallengeCompletionUseCase.test.ts
+++ b/packages/core/src/profile/use-cases/tests/CalculateRewardForChallengeCompletionUseCase.test.ts
@@ -1,0 +1,148 @@
+import { mock, type Mock } from 'ts-jest-mocker'
+
+import type { UsersRepository } from '#profile/interfaces/UsersRepository'
+import { Id } from '#global/domain/structures/Id'
+import { UserNotFoundError } from '#profile/errors/UserNotFoundError'
+import { UsersFaker } from '#profile/domain/entities/fakers/UsersFaker'
+
+import { CalculateRewardForChallengeCompletionUseCase } from '../CalculateRewardForChallengeCompletionUseCase'
+
+describe('Calculate Reward For Challenge Completion Use Case', () => {
+  let repository: Mock<UsersRepository>
+  let useCase: CalculateRewardForChallengeCompletionUseCase
+
+  beforeEach(() => {
+    repository = mock<UsersRepository>()
+    repository.findById.mockImplementation()
+    useCase = new CalculateRewardForChallengeCompletionUseCase(repository)
+  })
+
+  it('should throw an error if the user is not found', () => {
+    expect(
+      useCase.execute({
+        userId: Id.create().value,
+        challengeId: Id.create().value,
+        challengeXp: 0,
+        challengeCoins: 0,
+        maximumIncorrectAnswersCount: 0,
+        incorrectAnswersCount: 0,
+      }),
+    ).rejects.toThrow(UserNotFoundError)
+  })
+
+  it('should discount the new xp in percentage based on the incorrect answers count and the accuracy percentage', async () => {
+    const user = UsersFaker.fake({ completedChallengesIds: [] })
+    repository.findById.mockResolvedValue(user)
+
+    let response = await useCase.execute({
+      maximumIncorrectAnswersCount: 10,
+      incorrectAnswersCount: 0,
+      userId: user.id.value,
+      challengeId: Id.create().value,
+      challengeXp: 100,
+      challengeCoins: 0,
+    })
+
+    expect(response.newXp).toBe(100) // 100% of 100 xp
+
+    response = await useCase.execute({
+      maximumIncorrectAnswersCount: 10,
+      incorrectAnswersCount: 2,
+      userId: user.id.value,
+      challengeId: Id.create().value,
+      challengeXp: 100,
+      challengeCoins: 0,
+    })
+
+    expect(response.newXp).toBe(80) // 80% of 100 xp
+
+    response = await useCase.execute({
+      maximumIncorrectAnswersCount: 10,
+      incorrectAnswersCount: 5,
+      userId: user.id.value,
+      challengeId: Id.create().value,
+      challengeXp: 100,
+      challengeCoins: 0,
+    })
+
+    expect(response.newXp).toBe(50) // 50% of 100 xp
+  })
+
+  it('should discount the new coins in percentage based on the incorrect answers count and the accuracy percentage', async () => {
+    const user = UsersFaker.fake({ completedChallengesIds: [] })
+    repository.findById.mockResolvedValue(user)
+
+    let response = await useCase.execute({
+      maximumIncorrectAnswersCount: 10,
+      incorrectAnswersCount: 0,
+      userId: user.id.value,
+      challengeId: Id.create().value,
+      challengeXp: 0,
+      challengeCoins: 100,
+    })
+
+    expect(response.newCoins).toBe(100) // 100% of 100 coins
+
+    response = await useCase.execute({
+      maximumIncorrectAnswersCount: 10,
+      incorrectAnswersCount: 2,
+      userId: user.id.value,
+      challengeId: Id.create().value,
+      challengeXp: 0,
+      challengeCoins: 100,
+    })
+
+    expect(response.newCoins).toBe(80) // 80% of 100 coins
+
+    response = await useCase.execute({
+      maximumIncorrectAnswersCount: 10,
+      incorrectAnswersCount: 5,
+      userId: user.id.value,
+      challengeId: Id.create().value,
+      challengeXp: 0,
+      challengeCoins: 100,
+    })
+
+    expect(response.newCoins).toBe(50) // 50% of 100 coins
+  })
+
+  it('should divide the new calculated xp by 2 if the user has completed the challenge', async () => {
+    const challengeId = Id.create().value
+    const user = UsersFaker.fake({
+      completedChallengesIds: [challengeId],
+      hasCompletedSpace: false,
+    })
+    repository.findById.mockResolvedValue(user)
+
+    const response = await useCase.execute({
+      maximumIncorrectAnswersCount: 10,
+      incorrectAnswersCount: 0,
+      userId: user.id.value,
+      challengeId,
+      challengeXp: 100,
+      challengeCoins: 0,
+    })
+
+    expect(response.newXp).toBe(50) // 50% of 100 xp
+  })
+
+  it('should divide the new calculated coins by 2 if the user has completed the challenge', async () => {
+    const challengeId = Id.create().value
+    const user = UsersFaker.fake({
+      completedChallengesIds: [challengeId],
+      hasCompletedSpace: false,
+    })
+    repository.findById.mockResolvedValue(user)
+
+    const response = await useCase.execute({
+      maximumIncorrectAnswersCount: 10,
+      incorrectAnswersCount: 0,
+      userId: user.id.value,
+      challengeId,
+      challengeXp: 0,
+      challengeCoins: 100,
+    })
+
+    expect(response.newCoins).toBe(50) // 50% of 100 coins
+  })
+})

--- a/packages/core/src/profile/use-cases/tests/CalculateRewardForStarCompletionUseCase.test.ts
+++ b/packages/core/src/profile/use-cases/tests/CalculateRewardForStarCompletionUseCase.test.ts
@@ -1,0 +1,192 @@
+import { mock, type Mock } from 'ts-jest-mocker'
+
+import type { UsersRepository } from '#profile/interfaces/UsersRepository'
+import { Id } from '#global/domain/structures/Id'
+import { UserNotFoundError } from '#profile/errors/UserNotFoundError'
+import { CalculateRewardForStarCompletionUseCase } from '../CalculateRewardForStarCompletionUseCase'
+import { UsersFaker } from '#profile/domain/entities/fakers/UsersFaker'
+import { PlanetsFaker } from '#space/domain/entities/tests/fakers/PlanetsFaker'
+
+describe('Calculate Reward For Star Completion Use Case', () => {
+  let repository: Mock<UsersRepository>
+  let useCase: CalculateRewardForStarCompletionUseCase
+
+  beforeEach(() => {
+    repository = mock<UsersRepository>()
+    repository.findById.mockImplementation()
+    useCase = new CalculateRewardForStarCompletionUseCase(repository)
+  })
+
+  it('should throw an error if the user is not found', () => {
+    expect(
+      useCase.execute({
+        userId: Id.create().value,
+        nextStarId: null,
+        questionsCount: 0,
+        incorrectAnswersCount: 0,
+      }),
+    ).rejects.toThrow(UserNotFoundError)
+  })
+
+  it('should calculate accuracy percentage based on the incorrect answers count and questions count', async () => {
+    const user = UsersFaker.fake()
+    repository.findById.mockResolvedValue(user)
+
+    let response = await useCase.execute({
+      incorrectAnswersCount: 0,
+      userId: user.id.value,
+      nextStarId: null,
+      questionsCount: 10,
+    })
+
+    expect(response.accuracyPercentage).toBe(100) // 100% accuracy
+
+    response = await useCase.execute({
+      incorrectAnswersCount: 2,
+      userId: user.id.value,
+      nextStarId: null,
+      questionsCount: 10,
+    })
+
+    expect(response.accuracyPercentage).toBe(80) // 80% accuracy
+
+    response = await useCase.execute({
+      incorrectAnswersCount: 5,
+      userId: user.id.value,
+      nextStarId: null,
+      questionsCount: 10,
+    })
+
+    expect(response.accuracyPercentage).toBe(50) // 50% accuracy
+  })
+
+  it('should discount the new xp in percentage based on the incorrect answers count and questions count', async () => {
+    const user = UsersFaker.fake()
+    repository.findById.mockResolvedValue(user)
+
+    let response = await useCase.execute({
+      incorrectAnswersCount: 0,
+      userId: user.id.value,
+      nextStarId: null,
+      questionsCount: 10,
+    })
+
+    expect(response.newXp).toBe(60) // 100% of 60 xp
+
+    response = await useCase.execute({
+      incorrectAnswersCount: 2,
+      userId: user.id.value,
+      nextStarId: null,
+      questionsCount: 10,
+    })
+
+    expect(response.newXp).toBe(48) // 80% of 60 xp
+
+    response = await useCase.execute({
+      incorrectAnswersCount: 5,
+      userId: user.id.value,
+      nextStarId: null,
+      questionsCount: 10,
+    })
+
+    expect(response.newXp).toBe(30) // 50% of 60 xp
+  })
+
+  it('should discount the new coins in percentage based on the incorrect answers count and questions count', async () => {
+    let user = UsersFaker.fake()
+    repository.findById.mockResolvedValue(user)
+
+    let response = await useCase.execute({
+      incorrectAnswersCount: 0,
+      userId: user.id.value,
+      nextStarId: null,
+      questionsCount: 10,
+    })
+
+    expect(response.newCoins).toBe(40) // 100% of 40 coins
+
+    response = await useCase.execute({
+      incorrectAnswersCount: 2,
+      userId: user.id.value,
+      nextStarId: null,
+      questionsCount: 10,
+    })
+
+    expect(response.newCoins).toBe(32) // 80% of 40 coins
+
+    response = await useCase.execute({
+      incorrectAnswersCount: 5,
+      userId: user.id.value,
+      nextStarId: null,
+      questionsCount: 10,
+    })
+
+    expect(response.newCoins).toBe(20) // 50% of 40 coins
+
+    user = UsersFaker.fake({
+      completedPlanetsIds: PlanetsFaker.fakeMany(8).map((planet) => planet.id.value),
+      hasCompletedSpace: true,
+    })
+    repository.findById.mockResolvedValue(user)
+
+    response = await useCase.execute({
+      incorrectAnswersCount: 0,
+      userId: user.id.value,
+      nextStarId: null,
+      questionsCount: 10,
+    })
+
+    expect(response.newCoins).toBe(20) // 50% of 40 coins
+  })
+
+  it('should divide the new calculated coins by 2 if the user has completed the next star', async () => {
+    const nextStarId = Id.create().value
+    const user = UsersFaker.fake({
+      unlockedStarsIds: [nextStarId],
+      hasCompletedSpace: false,
+    })
+    repository.findById.mockResolvedValue(user)
+
+    const response = await useCase.execute({
+      incorrectAnswersCount: 0,
+      userId: user.id.value,
+      nextStarId,
+      questionsCount: 10,
+    })
+
+    expect(response.newCoins).toBe(20) // 50% of 40 coins
+  })
+
+  it('should divide the new calculated xp by 2 if the user has completed the next star or the entirespace', async () => {
+    const nextStarId = Id.create().value
+    let user = UsersFaker.fake({
+      unlockedStarsIds: [nextStarId],
+      hasCompletedSpace: false,
+    })
+    repository.findById.mockResolvedValue(user)
+
+    let response = await useCase.execute({
+      incorrectAnswersCount: 0,
+      userId: user.id.value,
+      nextStarId,
+      questionsCount: 10,
+    })
+
+    expect(response.newXp).toBe(30) // 50% of 60 xp
+
+    user = UsersFaker.fake({
+      completedPlanetsIds: PlanetsFaker.fakeMany(8).map((planet) => planet.id.value),
+      hasCompletedSpace: true,
+    })
+    repository.findById.mockResolvedValue(user)
+
+    response = await useCase.execute({
+      incorrectAnswersCount: 0,
+      userId: user.id.value,
+      nextStarId: null,
+      questionsCount: 10,
+    })
+
+    expect(response.newXp).toBe(30) // 50% of 60 xp
+  })
+})

--- a/packages/core/src/space/domain/entities/tests/Planet.test.ts
+++ b/packages/core/src/space/domain/entities/tests/Planet.test.ts
@@ -1,12 +1,20 @@
 import { PlanetsFaker, StarsFaker } from './fakers'
 
-describe('Planet entity', () => {
+describe('Planet Entity', () => {
   it('should get the next star based on the given current star', () => {
     const currentStar = StarsFaker.fake({ number: 1 })
     const nextStar = StarsFaker.fake({ number: 2 })
     const planet = PlanetsFaker.fake({ stars: [currentStar.dto, nextStar.dto] })
 
-    expect(planet.getNextStar(currentStar.id.value)).toEqual(nextStar)
-    expect(planet.getNextStar(nextStar.id.value)).toBe(null)
+    expect(planet.getNextStar(currentStar)).toEqual(nextStar)
+    expect(planet.getNextStar(nextStar)).toBe(null)
+  })
+
+  it('should get the first star', () => {
+    const firstStar = StarsFaker.fake({ number: 1 })
+    const secondStar = StarsFaker.fake({ number: 2 })
+    const planet = PlanetsFaker.fake({ stars: [firstStar.dto, secondStar.dto] })
+
+    expect(planet.firstStar).toEqual(firstStar)
   })
 })

--- a/packages/core/src/space/use-cases/tests/GetNextStarUseCase.test.ts
+++ b/packages/core/src/space/use-cases/tests/GetNextStarUseCase.test.ts
@@ -1,0 +1,95 @@
+import { mock, type Mock } from 'ts-jest-mocker'
+
+import type { StarsRepository, PlanetsRepository } from '#space/interfaces/index'
+import { GetNextStarUseCase } from '../GetNextStarUseCase'
+import { StarNotFoundError } from '#space/domain/errors/StarNotFoundError'
+import { Id } from '#global/domain/structures/Id'
+import { StarsFaker } from '#space/domain/entities/tests/fakers/StarsFaker'
+import { PlanetNotFoundError } from '#space/domain/errors/PlanetNotFoundError'
+import { PlanetsFaker } from '#space/domain/entities/tests/fakers/PlanetsFaker'
+
+describe('Get Next Star Use Case', () => {
+  let starsRepository: Mock<StarsRepository>
+  let planetsRepository: Mock<PlanetsRepository>
+  let useCase: GetNextStarUseCase
+
+  beforeEach(() => {
+    starsRepository = mock<StarsRepository>()
+    planetsRepository = mock<PlanetsRepository>()
+    starsRepository.findById.mockImplementation()
+    planetsRepository.findByStar.mockImplementation()
+    planetsRepository.findByPosition.mockImplementation()
+    useCase = new GetNextStarUseCase(starsRepository, planetsRepository)
+  })
+
+  it('should throw an error if the current star is not found', () => {
+    starsRepository.findById.mockResolvedValue(null)
+
+    expect(useCase.execute({ currentStarId: Id.create().value })).rejects.toThrow(
+      StarNotFoundError,
+    )
+  })
+
+  it('should throw an error if the current planet is not found', () => {
+    const star = StarsFaker.fake()
+    starsRepository.findById.mockResolvedValue(star)
+    planetsRepository.findByStar.mockResolvedValue(null)
+
+    expect(useCase.execute({ currentStarId: star.id.value })).rejects.toThrow(
+      PlanetNotFoundError,
+    )
+  })
+
+  it('should try to find the next star in the next planet if the current star is the last one of the current planet', async () => {
+    const star = StarsFaker.fake()
+    const planet = PlanetsFaker.fake({ stars: [star.dto] })
+    starsRepository.findById.mockResolvedValue(star)
+    planetsRepository.findByStar.mockResolvedValue(planet)
+
+    await useCase.execute({ currentStarId: star.id.value })
+
+    expect(planetsRepository.findByPosition).toHaveBeenCalledWith(
+      planet.position.increment(),
+    )
+  })
+
+  it('should return the next star of the current planet', async () => {
+    const currentStar = StarsFaker.fake({ number: 1 })
+    const nextStar = StarsFaker.fake({ number: 2 })
+    const planet = PlanetsFaker.fake({ stars: [currentStar.dto, nextStar.dto] })
+    starsRepository.findById.mockResolvedValue(currentStar)
+    planetsRepository.findByStar.mockResolvedValue(planet)
+
+    const response = await useCase.execute({ currentStarId: currentStar.id.value })
+
+    expect(response).toEqual(nextStar.dto)
+  })
+
+  it('should try to find the next star in the next planet if the current star is the last one of the current planet', async () => {
+    const currentStar = StarsFaker.fake()
+    const nextStar = StarsFaker.fake()
+    const planet = PlanetsFaker.fake({ stars: [currentStar.dto] })
+    const nextPlanet = PlanetsFaker.fake({ stars: [nextStar.dto] })
+    starsRepository.findById.mockResolvedValue(currentStar)
+    planetsRepository.findByStar.mockResolvedValue(planet)
+    planetsRepository.findByPosition.mockResolvedValue(nextPlanet)
+
+    const response = await useCase.execute({ currentStarId: currentStar.id.value })
+
+    expect(planetsRepository.findByPosition).toHaveBeenCalledWith(
+      planet.position.increment(),
+    )
+    expect(response).toEqual(nextStar.dto)
+  })
+
+  it('should return null if no next star is found', async () => {
+    const currentStar = StarsFaker.fake()
+    const planet = PlanetsFaker.fake({ stars: [currentStar.dto] })
+    starsRepository.findById.mockResolvedValue(currentStar)
+    planetsRepository.findByStar.mockResolvedValue(planet)
+
+    const response = await useCase.execute({ currentStarId: currentStar.id.value })
+
+    expect(response).toBeNull()
+  })
+})


### PR DESCRIPTION
## 🎯 Objetivo
Soluciona o bug de não desbloquear a próxima estrela se a estrela atual for um desafio de código.

## #️⃣ Issues relacionadas
resolve #53

## 🐛 Causa do bug:
A rota responsável em lidar premiação de estrela-desafio não estava recebendo o id da próxima estrela por ausência do `middleware`  responsável por isso no sua implementação.

## 📋 Changelog
- Testado o caso de uso para obter a próxima estrela (Get Next Star).
- Testado o caso de uso para calcular a recompensa por conclusão de estrela.
- Testado o caso de uso para calcular a recompensa por conclusão de desafio.
- Corrigida a inclusão do próximo início (next start) no corpo da resposta de recompensa do usuário.
- Refatorado o redirecionamento do usuário para a página de espaço após a conclusão de um desafio de estrela.

## 👀 Observações
Durante os testes foi identificado um erro de lógica de verificação de existência da próxima estrela se a estrela atual é a última de todas. Eu irei abrir uma `issue` para detalhar esse erro.

