### PR TITLE
Refresh de sessão automática

### DIFF
--- a/apps/server/rest-client/auth/auth.rest
+++ b/apps/server/rest-client/auth/auth.rest
@@ -65,6 +65,14 @@ Content-Type: application/json
   "refreshToken": "refreshToken"
 }
 
+### Refresh session
+POST {{URL}}/refresh-session
+Content-Type: application/json
+
+{
+  "refreshToken": "xugtmelpndgf"
+}
+
 ### Fetch account
 GET {{URL}}/account
 Authorization: Bearer {{JWT}}

--- a/apps/server/src/rest/controllers/auth/RefreshSessionController.ts
+++ b/apps/server/src/rest/controllers/auth/RefreshSessionController.ts
@@ -1,0 +1,20 @@
+import type { Controller } from '@stardust/core/global/interfaces'
+import type { Http } from '@stardust/core/global/interfaces'
+import type { RestResponse } from '@stardust/core/global/responses'
+import type { AuthService } from '@stardust/core/auth/interfaces'
+import { Text } from '@stardust/core/global/structures'
+
+type Schema = {
+  body: {
+    refreshToken: string
+  }
+}
+
+export class RefreshSessionController implements Controller<Schema> {
+  constructor(private readonly service: AuthService) {}
+
+  async handle(http: Http<Schema>): Promise<RestResponse> {
+    const { refreshToken } = await http.getBody()
+    return await this.service.refreshSession(Text.create(refreshToken))
+  }
+}

--- a/apps/server/src/rest/controllers/auth/SignOutController.ts
+++ b/apps/server/src/rest/controllers/auth/SignOutController.ts
@@ -7,7 +7,6 @@ export class SignOutController implements Controller {
   constructor(private readonly authService: AuthService) {}
 
   async handle(_: Http): Promise<RestResponse> {
-    console.log('SignOutController')
     return await this.authService.signOut()
   }
 }

--- a/apps/server/src/rest/controllers/auth/index.ts
+++ b/apps/server/src/rest/controllers/auth/index.ts
@@ -8,3 +8,4 @@ export { ConfirmPasswordResetController } from './ConfirmPasswordResetController
 export { FetchSessionController } from './FetchSessionController'
 export { VerifyAuthenticationController } from './VerifyAuthenticationController'
 export { ResendSignUpEmailController } from './ResendSignUpEmailController'
+export { RefreshSessionController } from './RefreshSessionController'

--- a/apps/web/src/rest/controllers/auth/VerifyAuthRoutesController.ts
+++ b/apps/web/src/rest/controllers/auth/VerifyAuthRoutesController.ts
@@ -1,7 +1,12 @@
 import type { Controller, Http } from '@stardust/core/global/interfaces'
 import type { AuthService } from '@stardust/core/auth/interfaces'
+import type { SessionDto } from '@stardust/core/auth/structures/dtos'
 
-import { ROUTES } from '@/constants'
+import { COOKIES, ROUTES } from '@/constants'
+import { cookieActions } from '@/rpc/next-safe-action'
+import { RestResponse } from '@stardust/core/global/responses'
+import { HTTP_STATUS_CODE } from '@stardust/core/global/constants'
+import { Text } from '@stardust/core/global/structures'
 
 const PUBLIC_ROUTES = [
   ROUTES.landing,
@@ -11,6 +16,32 @@ const PUBLIC_ROUTES = [
 ]
 
 export const VerifyAuthRoutesController = (authService: AuthService): Controller => {
+  async function refreshAuthSession(http: Http) {
+    const refreshToken = await cookieActions.getCookie(COOKIES.refreshToken.key)
+    if (!refreshToken?.data) {
+      return new RestResponse<SessionDto>({ statusCode: HTTP_STATUS_CODE.unauthorized })
+    }
+
+    const response = await authService.refreshSession(Text.create(refreshToken.data))
+
+    if (response.isSuccessful) {
+      await Promise.all([
+        http.setCookie(
+          COOKIES.accessToken.key,
+          response.body.accessToken,
+          response.body.durationInSeconds,
+        ),
+        http.setCookie(
+          COOKIES.refreshToken.key,
+          response.body.refreshToken,
+          response.body.durationInSeconds,
+        ),
+      ])
+    }
+
+    return response
+  }
+
   return {
     async handle(http: Http) {
       const currentRoute = http.getCurrentRoute()
@@ -21,6 +52,11 @@ export const VerifyAuthRoutesController = (authService: AuthService): Controller
       const hasSession = response.isSuccessful
       const isRootRoute = currentRoute === ROUTES.landing
       const isSignInRoute = currentRoute === ROUTES.auth.signIn
+
+      if (!hasSession) {
+        const response = await refreshAuthSession(http)
+        if (response.isSuccessful) return http.redirect(currentRoute)
+      }
 
       if (!hasSession && !isPublicRoute) {
         return http.redirect(ROUTES.auth.signIn)

--- a/apps/web/src/rest/services/AuthService.ts
+++ b/apps/web/src/rest/services/AuthService.ts
@@ -53,6 +53,12 @@ export const AuthService = (restClient: RestClient): IAuthService => {
       })
     },
 
+    async refreshSession(refreshToken: Text) {
+      return await restClient.post('/auth/refresh-session', {
+        refreshToken: refreshToken.value,
+      })
+    },
+
     async confirmEmail(token: Text) {
       return await restClient.post('/auth/confirm-email', { token: token.value })
     },

--- a/packages/core/src/auth/interfaces/AuthService.ts
+++ b/packages/core/src/auth/interfaces/AuthService.ts
@@ -19,4 +19,5 @@ export interface AuthService {
   ): Promise<RestResponse>
   confirmEmail(token: Text): Promise<RestResponse<SessionDto>>
   confirmPasswordReset(token: Text): Promise<RestResponse<SessionDto>>
+  refreshSession(refreshToken: Text): Promise<RestResponse<SessionDto>>
 }


### PR DESCRIPTION
## 🎯 Objetivo
Fazer com que o usuário não precise fazer sign in novamente caso seu token de autenticação expire.

## #️⃣ Issues relacionadas
resolve #62

## 📋 Changelog
- Implementado o `refreshSession` do AuthService utilizando Supabase.
- Adicionado o `RefreshSessionController`.
- Registrada a rota de refresh de sessão.
- Atualizada a sessão de autenticação no `VerifyAuthRoutesController`.

## 👀 Observação
A intenção era chamar a rota de refresh session na função handleRestError da camada rest do `web`, porém Next.js não permite alterar cookies fora de um route handler ou server action, então só restou aplicar o mecanismo de refresh de sessão somente no middleware 🥲.
