### PR TITLE
⚙️  config(web): configuring Terser plugin to not modify Delégua class names.

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,3 +1,6 @@
+// See: https://kentcdodds.com/blog/profile-a-react-app-for-performance#build-and-measure-the-production-app
+// See: https://nextjs.org/docs/api-reference/next.config.js/custom-webpack-config
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   productionBrowserSourceMaps: false,
@@ -19,14 +22,20 @@ const nextConfig = {
   // swcMinify: true,
   output: 'standalone',
   webpack: (config, { isServer }) => {
-    config.optimization.minimize = false;
+    // Opção 1 para desabilitar minificação.
+    // Desabilita tudo, e o Zod deixa de funcionar corretamente.
+    // config.optimization.minimizer = [];
 
-    if (!isServer) {
-      config.optimization.minimizer.forEach((minimizer) => {
-        if (minimizer.options && minimizer.options.terserOptions) {
-          minimizer.options.terserOptions.keep_classnames = true;
-        }
-      });
+    // Opção 2: Achar o terser e desligar algumas coisas.
+    const terser = config.optimization.minimizer.find((plugin) => plugin?.options?.terserOptions);
+
+    if (terser) {
+      console.log('Terser localizado', terser);
+      terser.options.terserOptions = {
+        ...terser.options.terserOptions,
+        keep_classnames: true,
+        keep_fnames: true,
+      };
     }
     return config;
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,7 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@designliquido/delegua": "^0.43.5",
+    "@designliquido/delegua": "^0.44.2",
     "@dnd-kit/core": "^6.1.0",
     "@dnd-kit/modifiers": "^6.0.1",
     "@dnd-kit/sortable": "^7.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -364,7 +364,7 @@
       "name": "@stardust/web",
       "version": "0.2.0",
       "dependencies": {
-        "@designliquido/delegua": "^0.43.5",
+        "@designliquido/delegua": "^0.44.2",
         "@dnd-kit/core": "^6.1.0",
         "@dnd-kit/modifiers": "^6.0.1",
         "@dnd-kit/sortable": "^7.0.2",
@@ -1626,9 +1626,9 @@
       }
     },
     "node_modules/@designliquido/delegua": {
-      "version": "0.43.5",
-      "resolved": "https://registry.npmjs.org/@designliquido/delegua/-/delegua-0.43.5.tgz",
-      "integrity": "sha512-4ykGutQGOI5ccxupgSZ4k6kDPzfWPygq2SQcG1Idicer0a9ZWn5bWH4JZ4HFdTwxp1ZfU+zN9vCCHu3W4FKjZQ==",
+      "version": "0.44.2",
+      "resolved": "https://registry.npmjs.org/@designliquido/delegua/-/delegua-0.44.2.tgz",
+      "integrity": "sha512-8aNZ0G+NdMltbRh7y+++Uy4RBO30EfYmU+BZkF6/LboLz4nbZpod1psD2MncU6jhXZ9YdzFDFrbuZO+IVuXUKw==",
       "license": "MIT",
       "dependencies": {
         "antlr4ts": "^0.5.0-alpha.4",


### PR DESCRIPTION
## 🎯 Objetivo

Fazer funcionar a avaliação de código de Delégua.

## #️⃣ Issues relacionadas

N/A

## 🐛 Causa do bug

Delégua usa muito a propriedade `constructor.name` das várias classes componentes. O Next.js usa um plugin, o Terser, que minifica esses nomes. Isso funciona bem para quando `constructor.name` não é usado.

## 📋 Changelog

## 👀 Observação

## 🧪 Como testar 