### PR TITLE
🐛 fix: disabling minification until Terser Plugin can be appropriately configured for Webpack.

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -22,68 +22,81 @@ const nextConfig = {
   swcMinify: true,
   output: 'standalone',
   webpack: (config, { isServer }) => {
-    // Handle Terser minification (webpack's default)
-    const terser = config.optimization.minimizer.find((plugin) => plugin?.options?.terserOptions);
-    if (terser) {
-      terser.options.terserOptions = {
-        ...terser.options.terserOptions,
-        keep_classnames: true,
-        keep_fnames: true,
-      };
-    }
+    // Código para verificar as configurações de otimização.
+    // Ao executar, o webpack atualmente usa duas funções anônimas, que com
+    // certeza não são funções do Terser.
+    // console.log('config.optimization', config.optimization);
+    // for (const eachMinimizer of config.optimization.minimizer) {
+    //   console.log(eachMinimizer, eachMinimizer.name);
+    // }
 
-    // Handle all minification plugins
-    config.optimization.minimizer = config.optimization.minimizer.map((plugin) => {
-      // Handle TerserPlugin
-      if (plugin.constructor.name === 'TerserPlugin') {
-        return {
-          ...plugin,
-          options: {
-            ...plugin.options,
-            terserOptions: {
-              ...plugin.options.terserOptions,
-              keep_classnames: true,
-              keep_fnames: true,
-            },
-          },
-        };
-      }
-      
-      // Handle SWC minification if it's being used
-      if (plugin.constructor.name === 'SwcMinifyPlugin') {
-        return {
-          ...plugin,
-          options: {
-            ...plugin.options,
-            compress: {
-              ...plugin.options.compress,
-              keep_classnames: true,
-              keep_fnames: true,
-            },
-            mangle: {
-              ...plugin.options.mangle,
-              keep_classnames: true,
-              keep_fnames: true,
-            },
-          },
-        };
-      }
-      
-      return plugin;
-    });
+    config.optimization.minimizer = [];
+    
+    // TODO: Configurar o Terser para fazer minificação seletiva de fontes e bibliotecas,
+    // conforme solução abaixo em comentário.
+    
+    // // Handle Terser minification (webpack's default)
+    // const terser = config.optimization.minimizer.find((plugin) => plugin?.options?.terserOptions);
+    // if (terser) {
+    //   terser.options.terserOptions = {
+    //     ...terser.options.terserOptions,
+    //     keep_classnames: true,
+    //     keep_fnames: true,
+    //   };
+    // }
 
-    // Exclude delegua package from minification
-    config.optimization.minimizer = config.optimization.minimizer.map((plugin) => {
-      if (plugin.constructor.name === 'TerserPlugin' && plugin.options.exclude) {
-        plugin.options.exclude = [
-          ...plugin.options.exclude,
-          /node_modules[/\\]delegua[/\\]/,
-        ];
-      } else if (plugin.constructor.name === 'TerserPlugin') {
-        plugin.options.exclude = [/node_modules[/\\]delegua[/\\]/];
-      }
-      return plugin;
-    });
+    // // Handle all minification plugins
+    // config.optimization.minimizer = config.optimization.minimizer.map((plugin) => {
+    //   // Handle TerserPlugin
+    //   if (plugin.constructor.name === 'TerserPlugin') {
+    //     return {
+    //       ...plugin,
+    //       options: {
+    //         ...plugin.options,
+    //         terserOptions: {
+    //           ...plugin.options.terserOptions,
+    //           keep_classnames: true,
+    //           keep_fnames: true,
+    //         },
+    //       },
+    //     };
+    //   }
+      
+    //   // Handle SWC minification if it's being used
+    //   if (plugin.constructor.name === 'SwcMinifyPlugin') {
+    //     return {
+    //       ...plugin,
+    //       options: {
+    //         ...plugin.options,
+    //         compress: {
+    //           ...plugin.options.compress,
+    //           keep_classnames: true,
+    //           keep_fnames: true,
+    //         },
+    //         mangle: {
+    //           ...plugin.options.mangle,
+    //           keep_classnames: true,
+    //           keep_fnames: true,
+    //         },
+    //       },
+    //     };
+    //   }
+      
+    //   return plugin;
+    // });
+
+    // // Exclude delegua package from minification
+    // config.optimization.minimizer = config.optimization.minimizer.map((plugin) => {
+    //   if (plugin.constructor.name === 'TerserPlugin' && plugin.options.exclude) {
+    //     plugin.options.exclude = [
+    //       ...plugin.options.exclude,
+    //       /node_modules[/\\]delegua[/\\]/,
+    //     ];
+    //   } else if (plugin.constructor.name === 'TerserPlugin') {
+    //     plugin.options.exclude = [/node_modules[/\\]delegua[/\\]/];
+    //   }
+    //   return plugin;
+    // });
 
     return config;
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "turbo": "^2.4.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "apps/email": {


### PR DESCRIPTION
## 🎯 Objetivo

O Webpack está vindo com duas funções anônimas na sua configuração de `optimization`, e uma delas minifica o código, mas não obedece a configurações para não minificar partes de Delégua que dependem de comparações usando `constructor.name`. Com isso, desabilitamos completamente a minificação por enquanto, até que possamos configurar o [`WebpackTerserPlugin`](https://webpack.js.org/plugins/terser-webpack-plugin/) apropriadamente.

## 🧪 Como testar 

Favor fazer deploy em staging.