### PR TITLE
Solução de bug de cadastro

### DIFF
--- a/apps/server/src/app/hono/routers/auth/AuthRouter.ts
+++ b/apps/server/src/app/hono/routers/auth/AuthRouter.ts
@@ -1,5 +1,4 @@
 import { Hono } from 'hono'
-import { zValidator } from '@hono/zod-validator'
 import { z } from 'zod'
 
 import {
@@ -25,14 +24,16 @@ import { SupabaseAuthService } from '@/rest/services'
 import { InngestEventBroker } from '@/queue/inngest/InngestEventBroker'
 import { HonoRouter } from '../../HonoRouter'
 import { HonoHttp } from '../../HonoHttp'
+import { ValidationMiddleware } from '../../middlewares'
 
 export class AuthRouter extends HonoRouter {
   private readonly router = new Hono().basePath('/auth')
+  private readonly validationMiddleware = new ValidationMiddleware()
 
   private registerSignInRoute(): void {
     this.router.post(
       '/sign-in',
-      zValidator(
+      this.validationMiddleware.validate(
         'json',
         z.object({
           email: emailSchema,
@@ -52,7 +53,7 @@ export class AuthRouter extends HonoRouter {
   private registerSignUpRoute(): void {
     this.router.post(
       '/sign-up',
-      zValidator(
+      this.validationMiddleware.validate(
         'json',
         z.object({
           email: emailSchema,
@@ -85,7 +86,7 @@ export class AuthRouter extends HonoRouter {
   private registerResendSignUpEmailRoute(): void {
     this.router.post(
       '/resend-email/sign-up',
-      zValidator(
+      this.validationMiddleware.validate(
         'json',
         z.object({
           email: emailSchema,
@@ -105,7 +106,7 @@ export class AuthRouter extends HonoRouter {
   private registerRefreshSessionRoute(): void {
     this.router.post(
       '/refresh-session',
-      zValidator(
+      this.validationMiddleware.validate(
         'json',
         z.object({
           refreshToken: stringSchema,
@@ -125,7 +126,7 @@ export class AuthRouter extends HonoRouter {
   private registerRequestPasswordResetRoute(): void {
     this.router.post(
       '/request-password-reset',
-      zValidator(
+      this.validationMiddleware.validate(
         'json',
         z.object({
           email: emailSchema,
@@ -145,7 +146,7 @@ export class AuthRouter extends HonoRouter {
   private registerConfirmEmailRoute(): void {
     this.router.post(
       '/confirm-email',
-      zValidator(
+      this.validationMiddleware.validate(
         'json',
         z.object({
           token: z.string(),
@@ -165,7 +166,7 @@ export class AuthRouter extends HonoRouter {
   private registerConfirmPasswordResetRoute(): void {
     this.router.post(
       '/confirm-password-reset',
-      zValidator(
+      this.validationMiddleware.validate(
         'json',
         z.object({
           token: z.string(),
@@ -185,7 +186,7 @@ export class AuthRouter extends HonoRouter {
   private registerResetPasswordRoute(): void {
     this.router.patch(
       '/reset-password',
-      zValidator(
+      this.validationMiddleware.validate(
         'json',
         z.object({
           newPassword: passwordSchema,

--- a/apps/server/src/rest/services/SupabaseAuthService.ts
+++ b/apps/server/src/rest/services/SupabaseAuthService.ts
@@ -62,6 +62,9 @@ export class SupabaseAuthService implements AuthService {
       },
     })
 
+    console.log('sign up service data', data)
+    console.log('sign up service error', error)
+
     if (error)
       switch (error?.code) {
         case this.AUTH_ERROR_CODES.weekPassword:

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
-    "@hookform/resolvers": "^3.10.0",
+    "@hookform/resolvers": "^5.2.1",
     "@monaco-editor/react": "^4.7.0",
     "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-alert-dialog": "^1.1.14",

--- a/apps/web/src/ui/auth/widgets/pages/SignUp/SignUpForm/SignUpFormView.tsx
+++ b/apps/web/src/ui/auth/widgets/pages/SignUp/SignUpForm/SignUpFormView.tsx
@@ -83,7 +83,7 @@ export const SignUpFormView = ({ id, profileService, isSubmitting, onSubmit }: P
       </div>
       {isPasswordValid && (
         <AnimatedContainer>
-          <Button className='mt-6' isLoading={isSubmitting}>
+          <Button type='submit' className='mt-6' isLoading={isSubmitting}>
             Criar conta
           </Button>
         </AnimatedContainer>

--- a/apps/web/src/ui/auth/widgets/pages/SignUp/SignUpForm/useSignUpForm.ts
+++ b/apps/web/src/ui/auth/widgets/pages/SignUp/SignUpForm/useSignUpForm.ts
@@ -51,7 +51,7 @@ export function useSignUpForm(
       if (response.isFailure) {
         setError('name', { message: 'Nome já utilizado por outro usuário' })
       }
-    } catch (error) {}
+    } catch {}
   }, [nameFieldWatch, profileService.verifyUserNameInUse, setError])
 
   const checkUserAlreadyExistsByEmail = useCallback(async () => {
@@ -64,7 +64,7 @@ export function useSignUpForm(
         setError('email', { message: 'E-mail já utilizado por outro usuário' })
         return false
       }
-    } catch (error) {}
+    } catch {}
   }, [emailFieldWatch, profileService.verifyUserEmailInUse, setError])
 
   function checkFieldIsValid(fieldName: keyof SignUpFormFields) {

--- a/apps/web/src/ui/playground/widgets/pages/Snippet/useSnippetPage.ts
+++ b/apps/web/src/ui/playground/widgets/pages/Snippet/useSnippetPage.ts
@@ -2,7 +2,7 @@
 
 import { type RefObject, useEffect, useState } from 'react'
 import z from 'zod'
-import { useForm } from 'react-hook-form'
+import { useForm, type Resolver } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 
 import type { SnippetDto } from '@stardust/core/playground/entities/dtos'
@@ -30,7 +30,8 @@ const snippetSchema = z.object({
   isSnippetPublic: booleanSchema,
 })
 
-type SnippetSchema = z.input<typeof snippetSchema>
+type SnippetFormInput = z.input<typeof snippetSchema>
+type SnippetForm = z.output<typeof snippetSchema>
 
 type UseSnippetPageParams = {
   playgroundService: PlaygroundService
@@ -55,8 +56,12 @@ export function useSnippetPage({
   const [snippetFieldErrors, setSnippetFieldErrors] = useState<Record<string, string[]>>(
     {},
   )
-  const { control, formState, getValues, reset, watch } = useForm<SnippetSchema>({
-    resolver: zodResolver(snippetSchema),
+  const { control, formState, getValues, reset, watch } = useForm<SnippetForm>({
+    resolver: zodResolver(snippetSchema) as unknown as Resolver<
+      SnippetForm,
+      any,
+      SnippetFormInput
+    >,
     defaultValues: {
       snippetId: snippet?.id.value,
       snippetTitle: snippet?.title.value ?? Snippet.DEFEAULT_TITLE,

--- a/apps/web/src/ui/playground/widgets/pages/Snippet/useSnippetPage.ts
+++ b/apps/web/src/ui/playground/widgets/pages/Snippet/useSnippetPage.ts
@@ -27,10 +27,10 @@ const snippetSchema = z.object({
   snippetId: idSchema,
   snippetTitle: titleSchema,
   snippetCode: stringSchema,
-  isSnippetPublic: booleanSchema.default(true),
+  isSnippetPublic: booleanSchema,
 })
 
-type SnippetSchema = z.infer<typeof snippetSchema>
+type SnippetSchema = z.input<typeof snippetSchema>
 
 type UseSnippetPageParams = {
   playgroundService: PlaygroundService
@@ -87,6 +87,7 @@ export function useSnippetPage({
     setIsLoading(true)
 
     const { snippetId, snippetTitle, snippetCode, isSnippetPublic } = getValues()
+    const isPublic = isSnippetPublic ?? true
 
     const hasSnippet = !snippetId
     if (hasSnippet) {
@@ -94,7 +95,7 @@ export function useSnippetPage({
         Snippet.create({
           title: snippetTitle,
           code: snippetCode,
-          isPublic: isSnippetPublic,
+          isPublic: isPublic,
           author: {
             id: userId.value,
           },
@@ -124,7 +125,7 @@ export function useSnippetPage({
 
     try {
       title = Name.create(snippetTitle)
-    } catch (error) {
+    } catch {
       setSnippetFieldErrors({
         snippetTitle: ['Título deve conter no mínimo 3 caracteres'],
       })
@@ -138,7 +139,7 @@ export function useSnippetPage({
         id: snippetId,
         title: title.value,
         code: snippetCode,
-        isPublic: isSnippetPublic,
+        isPublic: isPublic,
         author: {
           id: userId.value,
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,18 +115,6 @@
         "vite-tsconfig-paths": "^5.1.4"
       }
     },
-    "apps/studio/node_modules/@hookform/resolvers": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.1.1.tgz",
-      "integrity": "sha512-J/NVING3LMAEvexJkyTLjruSm7aOFx7QX21pzkiJfMoNG0wl5aFEjLTl7ay7IQb9EWY6AkrBy7tHL2Alijpdcg==",
-      "license": "MIT",
-      "dependencies": {
-        "@standard-schema/utils": "^0.3.0"
-      },
-      "peerDependencies": {
-        "react-hook-form": "^7.55.0"
-      }
-    },
     "apps/studio/node_modules/@types/node": {
       "version": "20.19.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.8.tgz",
@@ -176,7 +164,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
-        "@hookform/resolvers": "^3.10.0",
+        "@hookform/resolvers": "^5.2.1",
         "@monaco-editor/react": "^4.7.0",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-alert-dialog": "^1.1.14",
@@ -2250,12 +2238,15 @@
       }
     },
     "node_modules/@hookform/resolvers": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.10.0.tgz",
-      "integrity": "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.1.tgz",
+      "integrity": "sha512-u0+6X58gkjMcxur1wRWokA7XsiiBJ6aK17aPZxhkoYiK5J+HcTx0Vhu9ovXe6H+dVpO6cjrn2FkJTryXEMlryQ==",
       "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
       "peerDependencies": {
-        "react-hook-form": "^7.0.0"
+        "react-hook-form": "^7.55.0"
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {


### PR DESCRIPTION
## 🎯 Objetivo
Resolver o erro de não ser possível enviar dados de cadastro via formulário.

## 🐛 Causa do bug
Por algum motivo o atributo `type` do botão do formulário de cadastro não estava mais com valor `submit`, impedindo do formulário desencadear o evento de envio de dados.

## 📋 Changelog
- Atualizada a dependência `@hookform/resolvers` para a versão 5.2.1.
- Atualizado o tipo do botão no formulário de cadastrado e melhorado o tratamento de erros.
- Integrado o `ValidationMiddleware` para a validação de requisições.
- Atualizado o hook `useSnippetPage` para utilizar as novas definições de tipo.