### PR TITLE
Editor de questão de ordenação

### DIFF
--- a/apps/studio/src/ui/global/widgets/components/Sortable/SortableItem/SortableItemView.tsx
+++ b/apps/studio/src/ui/global/widgets/components/Sortable/SortableItem/SortableItemView.tsx
@@ -27,7 +27,7 @@ export const SortableItemView = ({ id, children, className, iconSize = 24 }: Pro
         {...attributes}
         {...listeners}
         className={cn(
-          'cursor-grab active:cursor-grabbing absolute top-1/2 -translate-y-1/2 z-10',
+          'cursor-grab active:cursor-grabbing absolute top-1/2 left-2 -translate-y-1/2 z-10',
           className,
         )}
       >

--- a/apps/studio/src/ui/lesson/widgets/pages/LessonQuizPage/QuestionEditor/CodeInput/CodeInputView.tsx
+++ b/apps/studio/src/ui/lesson/widgets/pages/LessonQuizPage/QuestionEditor/CodeInput/CodeInputView.tsx
@@ -25,7 +25,7 @@ export const CodeInputView = ({
       <div className='flex items-center gap-3'>
         {isEnabled && (
           <div className='flex items-center'>
-            <h3>trecho de código</h3>
+            <h3>Trecho de código</h3>
             <Button onClick={onDisableButtonClick} size='icon' variant='ghost'>
               <Icon name='trash' className='w-4 h-4' />
             </Button>

--- a/apps/studio/src/ui/lesson/widgets/pages/LessonQuizPage/QuestionEditor/DragAndDropListQuestionEditor/DragAndDropListQuestionEditorView.tsx
+++ b/apps/studio/src/ui/lesson/widgets/pages/LessonQuizPage/QuestionEditor/DragAndDropListQuestionEditor/DragAndDropListQuestionEditorView.tsx
@@ -1,0 +1,81 @@
+import type { Image, Text } from '@stardust/core/global/structures'
+
+import { Button } from '@/ui/shadcn/components/button'
+import { Icon } from '@/ui/global/widgets/components/Icon'
+import { AddItemButton } from '@/ui/lesson/widgets/components/AddItemButton'
+import { Sortable } from '@/ui/global/widgets/components/Sortable'
+import type { SortableItem } from '@/ui/global/widgets/components/Sortable/types'
+import { QuestionHeaderInput } from '../QuestionHeaderInput'
+
+type Props = {
+  stem: string
+  picture: Image
+  items: SortableItem<string>[]
+  onStemChange: (stem: Text) => void
+  onPictureChange: (picture: Image) => void
+  onItemRemove: (itemIndex: number) => void
+  onItemAdd: () => void
+  onItemLabelChange: (itemIndex: number, item: string) => void
+  onDragItemEnd: (newItems: SortableItem<string>[]) => void
+}
+
+export const DragAndDropListQuestionEditorView = ({
+  stem,
+  picture,
+  items,
+  onStemChange,
+  onPictureChange,
+  onItemRemove,
+  onItemAdd,
+  onItemLabelChange,
+  onDragItemEnd,
+}: Props) => {
+  return (
+    <div className='space-y-8'>
+      <QuestionHeaderInput
+        stem={stem}
+        picture={picture}
+        onPictureChange={onPictureChange}
+        onStemChange={onStemChange}
+      />
+
+      <div className='mt-6 space-y-3 w-full'>
+        <h3>Itens (ordem colocada será considerada como a correta)</h3>
+
+        <Sortable.Container
+          key={items.map((item) => item.value).join()}
+          items={items}
+          onDragEnd={onDragItemEnd}
+        >
+          {(items) =>
+            items.map((item) => (
+              <Sortable.Item key={item.index} id={item.index.toString()}>
+                <div className='flex items-center gap-2 rounded-md w-full px-4 pl-10 py-1 bg-purple-700'>
+                  <input
+                    defaultValue={item.value}
+                    onBlur={(event) => onItemLabelChange(item.index, event.target.value)}
+                    className='w-full text-sm text-zinc-100 bg-transparent border-none ring-0 outline-none'
+                  />
+
+                  <div className='flex items-center gap-1'>
+                    <Button
+                      variant='ghost'
+                      size='icon'
+                      onClick={() => onItemRemove(item.index)}
+                    >
+                      <Icon name='trash' className='w-4 h-4' />
+                    </Button>
+                  </div>
+                </div>
+              </Sortable.Item>
+            ))
+          }
+        </Sortable.Container>
+
+        <div className='w-max mx-auto'>
+          <AddItemButton onClick={onItemAdd}>Adicionar opção</AddItemButton>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/studio/src/ui/lesson/widgets/pages/LessonQuizPage/QuestionEditor/DragAndDropListQuestionEditor/index.tsx
+++ b/apps/studio/src/ui/lesson/widgets/pages/LessonQuizPage/QuestionEditor/DragAndDropListQuestionEditor/index.tsx
@@ -1,0 +1,33 @@
+import type { DragAndDropListQuestion } from '@stardust/core/lesson/entities'
+
+import { DragAndDropListQuestionEditorView } from './DragAndDropListQuestionEditorView'
+import { useDragAndDropListQuestionEditor } from './useDragAndDropListQuestionEditor'
+import { useQuizContext } from '@/ui/global/hooks/useQuizContext'
+
+export const DragAndDropListQuestionEditor = () => {
+  const { selectedQuestion, replaceSelectedQuestion } = useQuizContext()
+  const question = selectedQuestion.value as DragAndDropListQuestion
+  const {
+    sortableItems,
+    handleItemAdd,
+    handleItemRemove,
+    handleItemLabelChange,
+    handleStemInputChange,
+    handlePictureInputChange,
+    handleDragItemEnd,
+  } = useDragAndDropListQuestionEditor(question, replaceSelectedQuestion)
+
+  return (
+    <DragAndDropListQuestionEditorView
+      stem={question.stem.value}
+      picture={question.picture}
+      items={sortableItems}
+      onItemAdd={handleItemAdd}
+      onItemRemove={handleItemRemove}
+      onItemLabelChange={handleItemLabelChange}
+      onStemChange={handleStemInputChange}
+      onPictureChange={handlePictureInputChange}
+      onDragItemEnd={handleDragItemEnd}
+    />
+  )
+}

--- a/apps/studio/src/ui/lesson/widgets/pages/LessonQuizPage/QuestionEditor/DragAndDropListQuestionEditor/useDragAndDropListQuestionEditor.ts
+++ b/apps/studio/src/ui/lesson/widgets/pages/LessonQuizPage/QuestionEditor/DragAndDropListQuestionEditor/useDragAndDropListQuestionEditor.ts
@@ -1,0 +1,57 @@
+import type { SortableItem } from '@/ui/global/widgets/components/Sortable/types'
+import { Integer, SortableList, type Image, Text } from '@stardust/core/global/structures'
+import type { DragAndDropListQuestion } from '@stardust/core/lesson/entities'
+
+export function useDragAndDropListQuestionEditor(
+  question: DragAndDropListQuestion,
+  replaceSelectedQuestion: (question: DragAndDropListQuestion) => void,
+) {
+  function handleStemInputChange(stem: Text) {
+    question.stem = stem
+    replaceSelectedQuestion(question)
+  }
+
+  function handlePictureInputChange(picture: Image) {
+    question.picture = picture
+    replaceSelectedQuestion(question)
+  }
+
+  function handleItemAdd() {
+    question.addItem('')
+    replaceSelectedQuestion(question)
+  }
+
+  function handleItemRemove(itemIndex: number) {
+    question.removeItem(itemIndex)
+    replaceSelectedQuestion(question)
+  }
+
+  function handleItemLabelChange(itemOriginalPosition: number, itemLabel: string) {
+    question.changeItemLabel(itemOriginalPosition, itemLabel)
+    replaceSelectedQuestion(question)
+  }
+
+  function handleDragItemEnd(newItems: SortableItem<string>[]) {
+    question.sortableList = SortableList.create(
+      newItems.map((item, index) => ({
+        originalPosition: Integer.create(index),
+        label: Text.create(item.value),
+      })),
+      false,
+    )
+    replaceSelectedQuestion(question)
+  }
+
+  return {
+    sortableItems: question.sortableList.orderedItems.map((item) => ({
+      index: item.originalPosition.value,
+      value: item.label.value,
+    })),
+    handleStemInputChange,
+    handlePictureInputChange,
+    handleItemAdd,
+    handleItemRemove,
+    handleItemLabelChange,
+    handleDragItemEnd,
+  }
+}

--- a/apps/studio/src/ui/lesson/widgets/pages/LessonQuizPage/QuestionEditor/QuestionEditorView.tsx
+++ b/apps/studio/src/ui/lesson/widgets/pages/LessonQuizPage/QuestionEditor/QuestionEditorView.tsx
@@ -2,6 +2,7 @@ import type { QuestionType } from '@stardust/core/lesson/types'
 
 import { SelectionQuestionEditor } from './SelectionQuestionEditor'
 import { CheckboxQuestionEditor } from '../CheckboxEditor'
+import { DragAndDropListQuestionEditor } from './DragAndDropListQuestionEditor'
 
 type Props = {
   selectedQuestionType: QuestionType
@@ -12,6 +13,7 @@ export const QuestionEditorView = ({ selectedQuestionType }: Props) => {
     <div className='border border-zinc-700 rounded-md px-10 py-6'>
       {selectedQuestionType === 'selection' && <SelectionQuestionEditor />}
       {selectedQuestionType === 'checkbox' && <CheckboxQuestionEditor />}
+      {selectedQuestionType === 'drag-and-drop-list' && <DragAndDropListQuestionEditor />}
     </div>
   )
 }

--- a/packages/core/src/global/domain/structures/SortableList.ts
+++ b/packages/core/src/global/domain/structures/SortableList.ts
@@ -1,9 +1,9 @@
 import type { Logical } from './Logical'
+import type { Integer } from './Integer'
+import type { Text } from './Text'
 import { List } from './List'
 import { ShuffledList } from './ShuffledList'
 import { AppError } from '../errors'
-import type { Integer } from './Integer'
-import type { Text } from './Text'
 
 type Item = {
   originalPosition: Integer
@@ -13,8 +13,8 @@ type Item = {
 export class SortableList {
   private constructor(readonly items: Item[]) {}
 
-  static create(items: Item[]): SortableList {
-    return new SortableList(ShuffledList.create(items).items)
+  static create(items: Item[], shuffle: boolean = true): SortableList {
+    return new SortableList(shuffle ? ShuffledList.create(items).items : items)
   }
 
   static isSoratableList(list: unknown): list is SortableList {
@@ -29,6 +29,23 @@ export class SortableList {
     if (!item) throw new Error()
     currentItems.splice(toIndex, 0, item)
     return new SortableList(currentItems)
+  }
+
+  addItem(item: Item): SortableList {
+    return new SortableList([...this.items, item])
+  }
+
+  removeItem(itemOriginalPosition: Integer): SortableList {
+    const currentItems = [...this.items]
+    const itemIndex = this.getItemIndex(itemOriginalPosition)
+    currentItems.splice(itemIndex, 1)
+    return new SortableList(currentItems)
+  }
+
+  changeItemLabel(itemOriginalPosition: Integer, itemLabel: Text): SortableList {
+    const itemIndex = this.getItemIndex(itemOriginalPosition)
+    this.items[itemIndex].label = itemLabel
+    return new SortableList(this.items)
   }
 
   getItemByPosition(position: Integer): Item {

--- a/packages/core/src/lesson/domain/entities/DragAndDropListQuestion.ts
+++ b/packages/core/src/lesson/domain/entities/DragAndDropListQuestion.ts
@@ -53,8 +53,30 @@ export class DragAndDropListQuestion extends Question<DragAndDropListQuestionPro
     return this.sortableList.isEqualTo(userAnswer.value)
   }
 
+  addItem(itemLabel: string): void {
+    this.sortableList = this.sortableList.addItem({
+      originalPosition: Integer.create(this.sortableList.items.length + 1),
+      label: Text.create(itemLabel),
+    })
+  }
+
+  removeItem(itemOriginalPosition: number): void {
+    this.sortableList = this.sortableList.removeItem(Integer.create(itemOriginalPosition))
+  }
+
+  changeItemLabel(itemOriginalPosition: number, itemLabel: string): void {
+    this.props.sortableList = this.sortableList.changeItemLabel(
+      Integer.create(itemOriginalPosition),
+      Text.create(itemLabel),
+    )
+  }
+
   get sortableList(): SortableList {
     return this.props.sortableList
+  }
+
+  set sortableList(sortableList: SortableList) {
+    this.props.sortableList = sortableList
   }
 
   get dto(): DragAndDropListQuestionDto {


### PR DESCRIPTION
## 🎯 Objetivo
Adicionar o editor de questão de ordenação na página de edição de quiz.

## 📋 Changelog
- Adicionado o widget 'DragAndDropListQuestionEditor'.
- Mesclada a branch 'drag-and-drop-list-question-editor' na main.