### PR TITLE
Correção de erro no Speaker

### DIFF
--- a/apps/web/src/ui/global/widgets/components/Mdx/Alert/AlertView.tsx
+++ b/apps/web/src/ui/global/widgets/components/Mdx/Alert/AlertView.tsx
@@ -20,28 +20,30 @@ export const AlertView = ({
 }: AlertProps) => {
   return (
     <Animation hasAnimation={hasAnimation}>
-      <div className='not-prose flex w-full flex-col items-center'>
+      <div className='not-prose flex w-full flex-col'>
         {title && (
           <div className='mb-4'>
             <Title>{title}</Title>
           </div>
         )}
         <div>
-          <div className='flex w-full items-center'>
+          <div className='flex w-full flex-col gap-4 md:gap-2 md:items-center md:justify-center md:flex-row'>
             {picture && <Picture url={picture} />}
-            <span className='mr-3 block'>
-              <Image
-                src='/icons/alert.svg'
-                width={32}
-                height={32}
-                alt=''
-                className='skeleton'
-                onLoadingComplete={(image) => image.classList.remove('skeleton')}
-              />
-            </span>
-            <Content type='alert' hasAnimation={hasAnimation}>
-              {children}
-            </Content>
+            <div className='flex w-full items-center'>
+              <span className='mr-3 block'>
+                <Image
+                  src='/icons/alert.svg'
+                  width={32}
+                  height={32}
+                  alt=''
+                  className='skeleton'
+                  onLoadingComplete={(image) => image.classList.remove('skeleton')}
+                />
+              </span>
+              <Content type='alert' hasAnimation={hasAnimation}>
+                {children}
+              </Content>
+            </div>
           </div>
         </div>
       </div>

--- a/apps/web/src/ui/global/widgets/components/Mdx/Picture/PictureView.tsx
+++ b/apps/web/src/ui/global/widgets/components/Mdx/Picture/PictureView.tsx
@@ -14,7 +14,7 @@ export const PictureView = ({ url }: Props) => {
   const formattedImage = image.replace(REGEX.quotes, '')
 
   return (
-    <div className='relative mr-3 overflow-hidden rounded-md h-16 md:w-24 '>
+    <div className='relative mr-3 overflow-hidden rounded-md w-24 h-20 md:h-16'>
       <Image
         src={formattedImage}
         alt='Panda'

--- a/apps/web/src/ui/global/widgets/components/Mdx/Text/TextView.tsx
+++ b/apps/web/src/ui/global/widgets/components/Mdx/Text/TextView.tsx
@@ -24,7 +24,7 @@ export const TextView = ({
             <Title>{title}</Title>
           </div>
         )}
-        <div className='flex w-full flex-col items-center justify-center md:flex-row'>
+        <div className='flex w-full flex-col gap-4 md:gap-2 md:items-center md:justify-center md:flex-row'>
           {picture && <Picture url={picture} />}
           <Content type='default' hasAnimation={hasAnimation}>
             {children}

--- a/apps/web/src/ui/lesson/contexts/Speaker/useSpeakerContextProvider.ts
+++ b/apps/web/src/ui/lesson/contexts/Speaker/useSpeakerContextProvider.ts
@@ -1,11 +1,10 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import { STORAGE } from '@/constants/storage'
 import { useLocalStorage } from '@/ui/global/hooks/useLocalStorage'
 import type { SpeakerContextValue } from './SpeakerContextValue'
 
 export function useSpeakerContextProvider() {
-  const [isEnabled, setIsEnabled] = useState(true)
   const {
     get: getIsEnabledStorage,
     set: setIsEnabledStorage,
@@ -20,9 +19,10 @@ export function useSpeakerContextProvider() {
   const { get: getPitchStorage, set: setPitchStorage } = useLocalStorage<number>(
     STORAGE.keys.speakerPitch,
   )
-  const [volume, setVolume] = useState(1)
-  const [rate, setRate] = useState(1)
-  const [pitch, setPitch] = useState(1)
+  const [isEnabled, setIsEnabled] = useState(Boolean(getIsEnabledStorage()))
+  const [volume, setVolume] = useState(getVolumeStorage() ?? 1)
+  const [rate, setRate] = useState(getRateStorage() ?? 1)
+  const [pitch, setPitch] = useState(getPitchStorage() ?? 1)
 
   const contextValue: SpeakerContextValue = useMemo(() => {
     async function handleEnableToggle() {
@@ -70,13 +70,6 @@ export function useSpeakerContextProvider() {
     setIsEnabledStorage,
     removeIsEnabledStorage,
   ])
-
-  useEffect(() => {
-    setIsEnabled(Boolean(getIsEnabledStorage()))
-    setVolume(getVolumeStorage() ?? 1)
-    setRate(getRateStorage() ?? 1)
-    setPitch(getPitchStorage() ?? 1)
-  }, [getIsEnabledStorage, getVolumeStorage, getRateStorage, getPitchStorage])
 
   return contextValue
 }

--- a/apps/web/src/ui/lesson/widgets/pages/Lesson/QuizStage/OpenQuestion/index.tsx
+++ b/apps/web/src/ui/lesson/widgets/pages/Lesson/QuizStage/OpenQuestion/index.tsx
@@ -49,7 +49,7 @@ export function OpenQuestion({
                 let inputIndex = 0
 
                 if (text.includes('input')) {
-                  inputIndex = Number(text.slice(-1)) - 1
+                  inputIndex = Math.max(0, Number(text.slice(-1)) - 1)
                 }
                 const answer = answers[inputIndex]
 

--- a/packages/core/src/profile/domain/entities/User.ts
+++ b/packages/core/src/profile/domain/entities/User.ts
@@ -49,7 +49,6 @@ type UserProps = {
 
 export class User extends Entity<UserProps> {
   static create(dto: UserDto): User {
-    console.log('dto', dto)
     return new User(UserFactory.produce(dto), dto.id)
   }
 


### PR DESCRIPTION
## 🎯 Objetivo

Este PR resolve o `bug` do speaker de ler o primeiro bloco de texto mesmo desabilitad, como também busca melhorar a experiência do usuário e a organização do código na aplicação web, focando principalmente em ajustes de layout e na otimização de componentes de interface. Além disso, foram feitas melhorias na lógica interna para garantir um desempenho mais robusto e limpo, removendo logs desnecessários e corrigindo cálculos de índice.

## #️⃣ Issues relacionadas

resolve #140

## 🐛 Causa do bug

Ao carregar a página, o estado do Speaker era inicializado sempre como true e só passava para false após a busca das preferências do usuário no local storage. Esse atraso, de alguns milissegundos, era perceptível para o usuário.

## 📋 Changelog

- Removido `console.log` da criação de entidade de usuário.
- Melhorado o layout do componente `AlertView` reestruturando suas propriedades flex.
- Ajustadas as dimensões do componente `PictureView` para um melhor layout.
- Atualizado o layout do componente `TextView` com propriedades de `gap` aprimoradas.
- Otimizado `useSpeakerContextProvider` inicializando seu estado.
- Corrigido o cálculo de índice de entrada no componente `OpenQuestion`.

## 🧪 Como testar

1.  **Rodar a aplicação:** Inicie a aplicação web localmente.
2.  **Verificar componentes de UI:** Navegue para as telas que utilizam os componentes `AlertView`, `PictureView`, `TextView` e `OpenQuestion`.
3.  **Validar o layout:**
    - Confirme que os layouts dos componentes `AlertView`, `PictureView` e `TextView` estão renderizando corretamente, sem sobreposições ou espaçamentos incorretos.
    - Verifique se a funcionalidade de entrada de dados no componente `OpenQuestion` está funcionando como esperado, sem erros de índice.
4.  **Verificar a remoção do log:** Abra o console do navegador e confirme que o `console.log` relacionado à criação do usuário não está mais sendo exibido.

## 👀 Observação

Este PR também resolve um pequeno erro de não ser exibido campos de input em questões do tipo aberta na etapa de quiz da página de lição.