### PR TITLE
Use case de completar o espaço

### DIFF
--- a/apps/server/rest-client/profile/users.rest
+++ b/apps/server/rest-client/profile/users.rest
@@ -125,8 +125,8 @@ Authorization: Bearer {{JWT}}
 Content-Type: application/json
 
 {
-  "starId": "506f5514-6b54-40ae-8833-392ecbe5e422",
-  "challengeId": "56373af2-ac24-4bcd-a312-7d01bd7b5f53",
+  "starId": "bda4c82c-9466-4619-bdd6-89f719c54c27",
+  "challengeId": "342d2f23-ab04-48fe-989d-a0f46ad17390",
   "maximumIncorrectAnswersCount": 10,
   "incorrectAnswersCount": 2,
   "secondsCount": 100

--- a/apps/server/src/app/hono/middlewares/ProfileMiddleware.ts
+++ b/apps/server/src/app/hono/middlewares/ProfileMiddleware.ts
@@ -3,11 +3,13 @@ import type { Context, Next } from 'hono'
 import { SupabaseUsersRepository } from '@/database'
 import {
   AppendUserCompletedChallengesIdsToBodyController,
+  AppendIsSolutionUpvotedToBodyController,
   AppendUserInfoToBodyController,
+  VerifyUserSocialAccountController,
+  CompleteSpaceController,
 } from '@/rest/controllers/profile/users'
-import { AppendIsSolutionUpvotedToBodyController } from '@/rest/controllers/profile/users'
-import { VerifyUserSocialAccountController } from '@/rest/controllers/profile/users'
 import { HonoHttp } from '../HonoHttp'
+import { InngestEventBroker } from '@/queue/inngest/InngestEventBroker'
 
 export class ProfileMiddleware {
   async appendUserCompletedChallengesIdsToBody(context: Context, next: Next) {
@@ -37,6 +39,14 @@ export class ProfileMiddleware {
     const http = new HonoHttp(context, next)
     const usersRepository = new SupabaseUsersRepository(http.getSupabase())
     const controller = new AppendUserInfoToBodyController(usersRepository)
+    await controller.handle(http)
+  }
+
+  async completeSpace(context: Context, next: Next) {
+    const http = new HonoHttp(context, next)
+    const repository = new SupabaseUsersRepository(http.getSupabase())
+    const eventBroker = new InngestEventBroker()
+    const controller = new CompleteSpaceController(repository, eventBroker)
     await controller.handle(http)
   }
 }

--- a/apps/server/src/app/hono/routers/profile/UsersRouter.ts
+++ b/apps/server/src/app/hono/routers/profile/UsersRouter.ts
@@ -32,7 +32,6 @@ import {
   ValidationMiddleware,
   ProfileMiddleware,
 } from '../../middlewares'
-import { InngestEventBroker } from '@/queue/inngest/InngestEventBroker'
 
 export class UsersRouter extends HonoRouter {
   private readonly router = new Hono().basePath('/users')
@@ -121,11 +120,7 @@ export class UsersRouter extends HonoRouter {
       async (context) => {
         const http = new HonoHttp(context)
         const repository = new SupabaseUsersRepository(http.getSupabase())
-        const eventBroker = new InngestEventBroker()
-        const controller = new RewardUserForStarCompletionController(
-          repository,
-          eventBroker,
-        )
+        const controller = new RewardUserForStarCompletionController(repository)
         const response = await controller.handle(http)
         return http.sendResponse(response)
       },

--- a/apps/server/src/app/hono/routers/profile/UsersRouter.ts
+++ b/apps/server/src/app/hono/routers/profile/UsersRouter.ts
@@ -153,6 +153,7 @@ export class UsersRouter extends HonoRouter {
           incorrectAnswersCount: integerSchema,
         }),
       ),
+      this.profileMiddleware.completeSpace,
       async (context) => {
         const http = new HonoHttp(context)
         const repository = new SupabaseUsersRepository(http.getSupabase())

--- a/apps/server/src/database/supabase/mappers/profile/SupabaseUserMapper.ts
+++ b/apps/server/src/database/supabase/mappers/profile/SupabaseUserMapper.ts
@@ -94,6 +94,7 @@ export class SupabaseUserMapper {
       streak: user.streak.value,
       can_see_ranking: user.canSeeRankingResult.value,
       did_break_streak: user.didBreakStreak.value,
+      has_completed_space: user.hasCompletedSpace.value,
     }
 
     return supabaseUser as unknown as SupabaseUser

--- a/apps/server/src/database/supabase/repositories/space/SupabasePlanetsRepository.ts
+++ b/apps/server/src/database/supabase/repositories/space/SupabasePlanetsRepository.ts
@@ -33,7 +33,7 @@ export class SupabasePlanetsRepository
       .single()
 
     if (error) {
-      throw new SupabasePostgreError(error)
+      return this.handleQueryPostgresError(error)
     }
 
     return SupabasePlanetMapper.toEntity(data)
@@ -47,7 +47,7 @@ export class SupabasePlanetsRepository
       .single()
 
     if (error) {
-      return null
+      return this.handleQueryPostgresError(error)
     }
 
     const { data: stars, error: starsError } = await this.supabase
@@ -56,7 +56,7 @@ export class SupabasePlanetsRepository
       .eq('planet_id', data?.id ?? '')
 
     if (starsError) {
-      throw new SupabasePostgreError(starsError)
+      return this.handleQueryPostgresError(starsError)
     }
 
     data.stars = stars

--- a/apps/server/src/rest/controllers/profile/users/CompleteSpaceController.ts
+++ b/apps/server/src/rest/controllers/profile/users/CompleteSpaceController.ts
@@ -1,0 +1,23 @@
+import type { Controller, EventBroker } from '@stardust/core/global/interfaces'
+import type { Http } from '@stardust/core/global/interfaces'
+import type { RestResponse } from '@stardust/core/global/responses'
+import type { UsersRepository } from '@stardust/core/profile/interfaces'
+import { CompleteSpaceUseCase } from '@stardust/core/profile/use-cases'
+
+type Schema = {
+  body: {
+    nextStarId: string | null
+  }
+}
+
+export class CompleteSpaceController implements Controller<Schema> {
+  constructor(private readonly repository: UsersRepository, private readonly eventBroker: EventBroker) {}
+
+  async handle(http: Http<Schema>): Promise<RestResponse> {
+    const userId = await http.getAccountId()
+    const { nextStarId } = await http.getBody()
+    const useCase = new CompleteSpaceUseCase(this.repository, this.eventBroker)
+    await useCase.execute({ userId, nextStarId })
+    return await http.pass()
+  }
+}

--- a/apps/server/src/rest/controllers/profile/users/RewardUserForStarCompletionController.ts
+++ b/apps/server/src/rest/controllers/profile/users/RewardUserForStarCompletionController.ts
@@ -20,10 +20,7 @@ type Schema = {
 }
 
 export class RewardUserForStarCompletionController implements Controller<Schema> {
-  constructor(
-    private readonly usersRepository: UsersRepository,
-    private readonly eventBroker: EventBroker,
-  ) {}
+  constructor(private readonly usersRepository: UsersRepository) {}
 
   async handle(http: Http<Schema>): Promise<RestResponse> {
     const { userId } = http.getRouteParams()
@@ -62,10 +59,7 @@ export class RewardUserForStarCompletionController implements Controller<Schema>
     questionsCount: number,
     incorrectAnswersCount: number,
   ) {
-    const useCase = new CalculateRewardForStarCompletionUseCase(
-      this.usersRepository,
-      this.eventBroker,
-    )
+    const useCase = new CalculateRewardForStarCompletionUseCase(this.usersRepository)
     return await useCase.execute({
       userId,
       nextStarId,

--- a/apps/server/src/rest/controllers/profile/users/index.ts
+++ b/apps/server/src/rest/controllers/profile/users/index.ts
@@ -12,3 +12,4 @@ export { AppendUserInfoToBodyController } from './AppendUserInfoToBodyController
 export { UpvoteCommentController } from './UpvoteCommentController'
 export { AppendIsSolutionUpvotedToBodyController } from './AppendIsSolutionUpvotedToBodyController'
 export { VerifyUserSocialAccountController } from './VerifyUserSocialAccountController'
+export { CompleteSpaceController } from './CompleteSpaceController'

--- a/packages/core/src/profile/use-cases/CalculateRewardForStarCompletionUseCase.ts
+++ b/packages/core/src/profile/use-cases/CalculateRewardForStarCompletionUseCase.ts
@@ -3,8 +3,6 @@ import type { UsersRepository } from '#profile/interfaces/UsersRepository'
 import { Percentage } from '#global/domain/structures/Percentage'
 import { Id } from '#global/domain/structures/Id'
 import { UserNotFoundError } from '#profile/errors/UserNotFoundError'
-import { EventBroker } from '#global/interfaces/EventBroker'
-import { SpaceCompletedEvent } from '#space/domain/events/SpaceCompletedEvent'
 
 type Request = {
   userId: string
@@ -25,10 +23,7 @@ export class CalculateRewardForStarCompletionUseCase
   static readonly COINS_INCREASE_BASE = 4
   static readonly XP_INCREASE_BASE = 6
 
-  constructor(
-    private readonly repository: UsersRepository,
-    private readonly broker: EventBroker,
-  ) {}
+  constructor(private readonly repository: UsersRepository) {}
 
   async execute({ userId, nextStarId, incorrectAnswersCount, questionsCount }: Request) {
     const user = await this.findUser(Id.create(userId))
@@ -51,17 +46,6 @@ export class CalculateRewardForStarCompletionUseCase
       questionsCount,
       incorrectAnswersCount,
     )
-
-    if (isLastSpaceStar && user.hasCompletedSpace.isFalse) {
-      user.completeSpace()
-      await this.repository.replace(user)
-
-      const event = new SpaceCompletedEvent({
-        userSlug: user.slug.value,
-        userName: user.name.value,
-      })
-      await this.broker.publish(event)
-    }
 
     return {
       newCoins,

--- a/packages/core/src/profile/use-cases/CompleteSpaceUseCase.ts
+++ b/packages/core/src/profile/use-cases/CompleteSpaceUseCase.ts
@@ -1,0 +1,41 @@
+import type { UseCase } from '#global/interfaces/UseCase'
+import type { UsersRepository } from '#profile/interfaces/UsersRepository'
+import type { EventBroker } from '#global/interfaces/EventBroker'
+import { Id } from '#global/domain/structures/Id'
+import { SpaceCompletedEvent } from '#space/domain/events/SpaceCompletedEvent'
+import { UserNotFoundError } from '../errors'
+
+type Request = {
+  userId: string
+  nextStarId: string | null
+}
+
+export class CompleteSpaceUseCase implements UseCase<Request, void> {
+  constructor(
+    private readonly repository: UsersRepository,
+    private readonly broker: EventBroker,
+  ) {}
+
+  async execute(request: Request): Promise<void> {
+    const user = await this.findUser(Id.create(request.userId))
+
+    const isLastSpaceStar = request.nextStarId === null
+
+    if (isLastSpaceStar && user.hasCompletedSpace.isFalse) {
+      user.completeSpace()
+      await this.repository.replace(user)
+
+      const event = new SpaceCompletedEvent({
+        userSlug: user.slug.value,
+        userName: user.name.value,
+      })
+      await this.broker.publish(event)
+    }
+  }
+
+  private async findUser(userId: Id) {
+    const user = await this.repository.findById(userId)
+    if (!user) throw new UserNotFoundError()
+    return user
+  }
+}

--- a/packages/core/src/profile/use-cases/index.ts
+++ b/packages/core/src/profile/use-cases/index.ts
@@ -17,3 +17,4 @@ export { ResetWeekStatusForAllUsersUseCase } from './ResetWeekStatusForAllUsersU
 export { UpdateRankingPositionsUseCase } from './UpdateRankingPositionsUseCase'
 export { UpdateTierUseCase } from './UpdateTierUseCase'
 export { VerifyUserSocialAccountUseCase } from './VerifyUserSocialAccountUseCase'
+export { CompleteSpaceUseCase } from './CompleteSpaceUseCase'

--- a/packages/core/src/profile/use-cases/tests/CompleteSpaceUseCase.test.ts
+++ b/packages/core/src/profile/use-cases/tests/CompleteSpaceUseCase.test.ts
@@ -1,0 +1,88 @@
+import { type Mock, mock } from 'ts-jest-mocker'
+
+import type { UsersRepository } from '#profile/interfaces/UsersRepository'
+import type { EventBroker } from '#global/interfaces/EventBroker'
+import { SpaceCompletedEvent } from '#space/domain/events/SpaceCompletedEvent'
+import { UserNotFoundError } from '#profile/errors/UserNotFoundError'
+import { UsersFaker } from '#profile/domain/entities/fakers/UsersFaker'
+import { CompleteSpaceUseCase } from '../CompleteSpaceUseCase'
+
+describe('CompleteSpaceUseCase', () => {
+  let repository: Mock<UsersRepository>
+  let eventBroker: Mock<EventBroker>
+  let useCase: CompleteSpaceUseCase
+
+  beforeEach(() => {
+    repository = mock<UsersRepository>()
+    eventBroker = mock<EventBroker>()
+    repository.findById.mockImplementation()
+    repository.replace.mockImplementation()
+    eventBroker.publish.mockImplementation()
+    useCase = new CompleteSpaceUseCase(repository, eventBroker)
+  })
+
+  it('should throw an error if the user is not found', async () => {
+    const user = UsersFaker.fake()
+    repository.findById.mockResolvedValue(null)
+    user.completeSpace = jest.fn()
+
+    expect(
+      useCase.execute({
+        userId: user.id.value,
+        nextStarId: null,
+      }),
+    ).rejects.toThrow(UserNotFoundError)
+  })
+
+  it('should complete the space and publish the space completed event if the next star is null', async () => {
+    const user = UsersFaker.fake()
+    repository.findById.mockResolvedValue(user)
+    user.completeSpace = jest.fn()
+
+    await useCase.execute({
+      userId: user.id.value,
+      nextStarId: null,
+    })
+
+    expect(user.completeSpace).toHaveBeenCalled()
+    expect(repository.replace).toHaveBeenCalledWith(user)
+    expect(eventBroker.publish).toHaveBeenCalledWith(
+      new SpaceCompletedEvent({
+        userSlug: user.slug.value,
+        userName: user.name.value,
+      }),
+    )
+  })
+
+  it('should not complete the space and publish the space completed event if the next star is not null', async () => {
+    const user = UsersFaker.fake()
+    repository.findById.mockResolvedValue(user)
+    user.completeSpace = jest.fn()
+
+    await useCase.execute({
+      userId: user.id.value,
+      nextStarId: 'next-star-id',
+    })
+
+    expect(user.completeSpace).not.toHaveBeenCalled()
+    expect(repository.replace).not.toHaveBeenCalled()
+    expect(eventBroker.publish).not.toHaveBeenCalled()
+  })
+
+  it('should not complete the space and publish the space completed event if the user has already completed the space', async () => {
+    const user = UsersFaker.fake({
+      hasCompletedSpace: true,
+    })
+    repository.findById.mockResolvedValue(user)
+    user.completeSpace = jest.fn()
+
+    await useCase.execute({
+      userId: user.id.value,
+      nextStarId: 'next-star-id',
+    })
+
+    expect(user.completeSpace).not.toHaveBeenCalled()
+    expect(repository.replace).not.toHaveBeenCalled()
+    expect(eventBroker.publish).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## 🎯 Objetivo

Este Pull Request tem como principal objetivo **implementar a funcionalidade de conclusão de "espaços" (spaces)** dentro da aplicação.

A mudança centraliza-se na criação de um novo *Use Case* e *Controller* para gerenciar o processo de completude, desde a requisição de API até a validação da lógica de negócio. Além disso, foram incluídos testes unitários para garantir a correta execução dessa nova regra e um tratamento de erro crucial para garantir a robustez das operações de banco de dados no repositório Supabase.

---

## 📋 Changelog

- O tratamento de erros de *query* do PostgreSQL foi corrigido no repositório Supabase.
- O *use case* de conclusão de espaço foi totalmente implementado.
- Os componentes `EventBroker` e `SpaceCompletedEvent` foram removidos do *use case* de cálculo de recompensa por conclusão de estrela, refatorando o *core*.
- Um novo `CompleteSpaceController` foi adicionado para lidar com as requisições de conclusão de espaço no servidor.
- Testes unitários foram incluídos para validar a lógica do novo *use case* `CompleteSpaceUseCase`.
- A *middleware* para tratamento de requisições de conclusão de espaço foi implementada.
- Os dados de desafio do usuário (`user challenge data`) foram atualizados na configuração do servidor.

---

## 🧪 Como testar

Para validar a correta implementação da funcionalidade de conclusão de espaços, siga os passos abaixo:

1.  **Instalação e Execução:** Certifique-se de que todas as dependências estejam instaladas (`npm install`) e inicie a aplicação (`npm run dev` ou similar).
2.  **Executar Testes:**
    * Rode os testes unitários (`npm test` ou o comando específico para testes de *core*).
    * Verifique se os testes para o `CompleteSpaceUseCase` (no commit `test(core): add unit tests...`) passaram com sucesso, validando a lógica de negócio.
3.  **Teste de API (Conclusão de Espaço):**
    * Use um cliente API (como Postman ou Insomnia) ou o *front-end* de desenvolvimento.
    * Envie uma requisição **POST** para o *endpoint* recém-criado, que é gerenciado pelo `CompleteSpaceController`. O *endpoint* deve ser algo como `/spaces/complete` ou similar, dependendo da sua rota.
    * Verifique se a requisição retorna o status **200 OK** e se a resposta reflete a conclusão bem-sucedida do espaço e o possível cálculo de recompensa.
4.  **Teste de Robustez (Tratamento de Erros):**
    * Se possível, simule um erro de *query* no PostgreSQL (por exemplo, tentando inserir dados inválidos ou não existentes) ao interagir com o `SupabaseBasePlanetsRepository`.
    * Confirme se o erro é capturado e tratado corretamente, sem quebrar a aplicação, conforme o *commit* de `fix(server): handle PostgreSQL query errors...`.