### PR TITLE
Solução do erro de desafio não resolvido

### DIFF
--- a/apps/server/rest-client/profile/users.rest
+++ b/apps/server/rest-client/profile/users.rest
@@ -138,7 +138,7 @@ Authorization: Bearer {{JWT}}
 Content-Type: application/json
 
 {
-  "challengeId": "56373af2-ac24-4bcd-a312-7d01bd7b5f53",
+  "challengeId": "3b8894e7-2616-4652-9165-45f9a3dad2f0",
   "maximumIncorrectAnswersCount": 10,
   "incorrectAnswersCount": 2
 }

--- a/packages/core/src/profile/use-cases/CompleteChallengeUseCase.ts
+++ b/packages/core/src/profile/use-cases/CompleteChallengeUseCase.ts
@@ -19,8 +19,8 @@ export class CompleteChallengeUseCase implements UseCase<Request, Response> {
     if (!user) throw new UserNotFoundError()
 
     const completedChallengeId = Id.create(challengeId)
-    user.completeChallenge(completedChallengeId)
     if (user.hasCompletedChallenge(completedChallengeId).isFalse) {
+      user.completeChallenge(completedChallengeId)
       await this.repository.addCompletedChallenge(completedChallengeId, user.id)
     }
 

--- a/packages/core/src/profile/use-cases/tests/CompleteChallengeUseCase.test.ts
+++ b/packages/core/src/profile/use-cases/tests/CompleteChallengeUseCase.test.ts
@@ -1,0 +1,72 @@
+import { mock, type Mock } from 'ts-jest-mocker'
+
+import type { UsersRepository } from '#profile/interfaces/UsersRepository'
+import { UserNotFoundError } from '#profile/errors/UserNotFoundError'
+import { Id } from '#global/domain/structures/Id'
+import { UsersFaker } from '#profile/domain/entities/fakers/UsersFaker'
+import { CompleteChallengeUseCase } from '../CompleteChallengeUseCase'
+
+describe('Complete Challenge Use Case', () => {
+  let repository: Mock<UsersRepository>
+  let useCase: CompleteChallengeUseCase
+
+  beforeEach(() => {
+    repository = mock<UsersRepository>()
+    repository.findById.mockImplementation()
+    repository.addCompletedChallenge.mockImplementation()
+    useCase = new CompleteChallengeUseCase(repository)
+  })
+
+  it('should throw an error if the user is not found', () => {
+    repository.findById.mockResolvedValue(null)
+
+    expect(
+      useCase.execute({
+        challengeId: Id.create().value,
+        userId: Id.create().value,
+      }),
+    ).rejects.toThrow(UserNotFoundError)
+  })
+
+  it('should complete the challenge', async () => {
+    const user = UsersFaker.fake()
+    repository.findById.mockResolvedValue(user)
+    user.completeChallenge = jest.fn()
+    const challengeId = Id.create()
+
+    await useCase.execute({
+      challengeId: challengeId.value,
+      userId: user.id.value,
+    })
+
+    expect(repository.addCompletedChallenge).toHaveBeenCalledWith(challengeId, user.id)
+    expect(user.completeChallenge).toHaveBeenCalledWith(challengeId)
+  })
+
+  it('should not complete the challenge if the user has already completed the challenge', async () => {
+    const challengeId = Id.create()
+    const user = UsersFaker.fake({ completedChallengesIds: [challengeId.value] })
+    repository.findById.mockResolvedValue(user)
+    user.completeChallenge = jest.fn()
+
+    await useCase.execute({
+      challengeId: challengeId.value,
+      userId: user.id.value,
+    })
+
+    expect(repository.addCompletedChallenge).not.toHaveBeenCalled()
+    expect(user.completeChallenge).not.toHaveBeenCalled()
+  })
+
+  it('should return the user dto', async () => {
+    const user = UsersFaker.fake()
+    repository.findById.mockResolvedValue(user)
+
+    const response = await useCase.execute({
+      challengeId: Id.create().value,
+      userId: user.id.value,
+    })
+
+    expect(response).toEqual(user.dto)
+  })
+})


### PR DESCRIPTION
## 🎯 Objetivo

Este Pull Request visa corrigir uma falha na lógica de conclusão de desafios, garantindo que a conclusão seja registrada apenas uma vez para evitar duplicidade de dados.

Para aumentar a confiabilidade e prevenir futuras regressões, foram adicionados testes unitários que validam o comportamento do caso de uso. Além disso, foi feita uma atualização de configuração no servidor para alinhar um parâmetro `challengeId` com as novas regras.

## #️⃣ Issues relacionadas

resolve #163

## 🐛 Causa do bug

A entidade `User` no use case `CompleteChallengeUseCase` estava completando o desafio de forma precoce, fazendo com que o repositório de usuários nunca adicionasse esse registro de desafio completado.

## 📋 Changelog

- Corrigido o registro de conclusão de desafio para que ocorra apenas uma vez.
- Adicionados testes unitários para o `CompleteChallengeUseCase` a fim de validar a lógica de conclusão.
- Alterado o `challengeId` na requisição de perfil de usuário para um novo valor.

## 🧪 Como testar 

1.  Execute a aplicação e a suíte de testes automatizados. Confirme que todos os novos testes para `CompleteChallengeUseCase` passam com sucesso.
2.  Utilizando uma ferramenta de API (como Postman ou Insomnia), realize uma chamada para completar um desafio para um usuário de teste.
3.  Verifique se a conclusão foi registrada corretamente (ex: no banco de dados ou no retorno da API).
4.  Realize a **mesma chamada novamente** para o mesmo usuário e o mesmo desafio.
5.  Valide que o sistema **não registrou uma nova conclusão** e que o status do usuário permanece inalterado.
6.  Inspecione a requisição ao perfil do usuário para garantir que o parâmetro `challengeId` está refletindo o novo valor configurado.