### PR TITLE
Deleção de embeddings ao deletar um guia

### DIFF
--- a/apps/server/rest-client/manual/guides.rest
+++ b/apps/server/rest-client/manual/guides.rest
@@ -1,5 +1,5 @@
 @URL = {{BASE_URL}}/manual/guides
-@GUIDE_ID = c762ffce-30e2-4382-90f1-4a5747cb2707
+@GUIDE_ID = d14d91d2-9fb5-49d0-a7f7-d3fc3530fd5e
 
 ### Fetch all LSP guides
 GET {{URL}}?category=lsp

--- a/apps/server/src/app/hono/routers/manual/GuidesRouter.ts
+++ b/apps/server/src/app/hono/routers/manual/GuidesRouter.ts
@@ -96,7 +96,8 @@ export class GuidesRouter extends HonoRouter {
       async (context) => {
         const http = new HonoHttp(context)
         const repository = new SupabaseGuidesRepository(http.getSupabase())
-        const controller = new DeleteGuideController(repository)
+        const broker = new InngestBroker()
+        const controller = new DeleteGuideController(repository, broker)
         const response = await controller.handle(http)
         return http.sendResponse(response)
       },

--- a/apps/server/src/queue/jobs/storage/DeleteGuideEmbeddingsJob.ts
+++ b/apps/server/src/queue/jobs/storage/DeleteGuideEmbeddingsJob.ts
@@ -1,0 +1,25 @@
+import type { Amqp, Job } from '@stardust/core/global/interfaces'
+import type { EventPayload } from '@stardust/core/global/types'
+import type { EmbeddingsStorageProvider } from '@stardust/core/storage/interfaces'
+import type { GuideDeletedEvent } from '@stardust/core/manual/events'
+import { Id } from '@stardust/core/global/structures'
+import { EmbeddingNamespace } from '@stardust/core/storage/structures'
+
+type Payload = EventPayload<typeof GuideDeletedEvent>
+
+export class DeleteGuideEmbeddingsJob implements Job {
+  static readonly KEY = 'storage/delete.guide.embeddings'
+
+  constructor(private readonly storageProvider: EmbeddingsStorageProvider) {}
+
+  async handle(amqp: Amqp<Payload>): Promise<void> {
+    const payload = amqp.getPayload()
+    const guideId = Id.create(payload.guideId)
+    const namespace = EmbeddingNamespace.create('guides')
+
+    await amqp.run(
+      async () => await this.storageProvider.delete(guideId, namespace),
+      DeleteGuideEmbeddingsJob.name,
+    )
+  }
+}

--- a/apps/server/src/queue/jobs/storage/index.ts
+++ b/apps/server/src/queue/jobs/storage/index.ts
@@ -1,2 +1,3 @@
 export { BackupDatabaseJob } from './BackupDatabaseJob'
 export { GenerateGuideEmbeddingsJob } from './GenerateGuideEmbeddingsJob'
+export { DeleteGuideEmbeddingsJob } from './DeleteGuideEmbeddingsJob'

--- a/apps/server/src/rest/controllers/manual/DeleteGuideController.ts
+++ b/apps/server/src/rest/controllers/manual/DeleteGuideController.ts
@@ -1,5 +1,5 @@
 import type { GuidesRepository } from '@stardust/core/manual/interfaces'
-import type { Controller, Http } from '@stardust/core/global/interfaces'
+import type { Controller, Http, Broker } from '@stardust/core/global/interfaces'
 import { DeleteGuideUseCase } from '@stardust/core/manual/use-cases'
 
 type Schema = {
@@ -9,11 +9,14 @@ type Schema = {
 }
 
 export class DeleteGuideController implements Controller<Schema> {
-  constructor(private readonly repository: GuidesRepository) {}
+  constructor(
+    private readonly repository: GuidesRepository,
+    private readonly broker: Broker,
+  ) {}
 
   async handle(http: Http<Schema>) {
     const { guideId } = http.getRouteParams()
-    const useCase = new DeleteGuideUseCase(this.repository)
+    const useCase = new DeleteGuideUseCase(this.repository, this.broker)
     await useCase.execute({ guideId })
     return http.statusNoContent().send()
   }

--- a/documentation/requirements/profile/guides-manegement/specs/delete-guide-embeddings.md
+++ b/documentation/requirements/profile/guides-manegement/specs/delete-guide-embeddings.md
@@ -1,0 +1,39 @@
+# Spec para deletar embeddings de uma guia deletada
+
+`Status`: Concluído
+`Application`: Server
+
+## Objetivo
+
+Implementar o job que deleta os embeddings de uma guia que foi previamente
+deletada.
+
+## Implementação
+
+### Pacote Core
+
+- ✅ `GuideDeletedEvent` - Evento que indica que uma guia foi deletada (já existia)
+- ✅ `DeleteGuideUseCase` - Use case que executa a lógica de exclusão de uma guia e publica o evento (atualizado para incluir Broker)
+- ✅ `EmbeddingsStorageProvider` - Interface que define a operação de exclusão de embeddings (já existia)
+- ✅ Testes do `DeleteGuideUseCase` atualizados para verificar publicação do evento
+
+### Camada REST
+
+- ✅ `DeleteGuideController` - Atualizado para injetar o Broker como dependência
+- ✅ `GuidesRouter` - Atualizado para instanciar e passar o `InngestBroker` ao controller
+
+### Camada Queue
+
+#### `DeleteGuideEmbeddingsJob`
+
+- ✅ Job criado que recebe o payload de `GuideDeletedEvent` e usa o `EmbeddingsStorageProvider` para deletar os embeddings do namespace `guides`
+- ✅ Job registrado no `StorageFunctions` para ser executado quando o evento `GuideDeletedEvent` for disparado
+
+## Arquivos Modificados
+
+- `packages/core/src/manual/use-cases/tests/DeleteGuideUseCase.test.ts`
+- `apps/server/src/rest/controllers/manual/DeleteGuideController.ts`
+- `apps/server/src/app/hono/routers/manual/GuidesRouter.ts`
+- `apps/server/src/queue/jobs/storage/DeleteGuideEmbeddingsJob.ts` (novo)
+- `apps/server/src/queue/jobs/storage/index.ts`
+- `apps/server/src/queue/inngest/functions/StorageFunctions.ts`

--- a/packages/core/src/manual/domain/events/GuideDeletedEvent.ts
+++ b/packages/core/src/manual/domain/events/GuideDeletedEvent.ts
@@ -1,0 +1,13 @@
+import { Event } from '#global/domain/abstracts/Event'
+
+type Payload = {
+  guideId: string
+}
+
+export class GuideDeletedEvent extends Event<Payload> {
+  static readonly _NAME = 'manual/guide.deleted'
+
+  constructor(readonly payload: Payload) {
+    super(GuideDeletedEvent._NAME, payload)
+  }
+}

--- a/packages/core/src/manual/domain/events/index.ts
+++ b/packages/core/src/manual/domain/events/index.ts
@@ -1,1 +1,2 @@
 export { GuideContentEditedEvent } from './GuideContentEditedEvent'
+export { GuideDeletedEvent } from './GuideDeletedEvent'

--- a/packages/core/src/manual/use-cases/DeleteGuideUseCase.ts
+++ b/packages/core/src/manual/use-cases/DeleteGuideUseCase.ts
@@ -1,6 +1,8 @@
 import { Id } from '#global/domain/structures/Id'
+import type { Broker } from '#global/interfaces/Broker'
 import type { UseCase } from '#global/interfaces/UseCase'
 import { GuideNotFoundError } from '../domain/errors'
+import { GuideDeletedEvent } from '../domain/events'
 import type { GuidesRepository } from '../interfaces'
 
 type Request = {
@@ -10,11 +12,16 @@ type Request = {
 type Response = Promise<void>
 
 export class DeleteGuideUseCase implements UseCase<Request, Response> {
-  constructor(private readonly repository: GuidesRepository) {}
+  constructor(
+    private readonly repository: GuidesRepository,
+    private readonly broker: Broker,
+  ) {}
 
   async execute({ guideId }: Request): Response {
     const guide = await this.findGuide(Id.create(guideId))
     await this.repository.remove(guide)
+    const event = new GuideDeletedEvent({ guideId: guide.id.value })
+    await this.broker.publish(event)
   }
 
   private async findGuide(guideId: Id) {

--- a/packages/core/src/manual/use-cases/tests/DeleteGuideUseCase.test.ts
+++ b/packages/core/src/manual/use-cases/tests/DeleteGuideUseCase.test.ts
@@ -1,21 +1,26 @@
 import { mock, type Mock } from 'ts-jest-mocker'
 
 import type { GuidesRepository } from '#manual/interfaces/GuidesRepository'
+import type { Broker } from '#global/interfaces/Broker'
 import { GuideNotFoundError } from '#manual/domain/errors/GuideNotFoundError'
 import { GuidesFaker } from '#manual/domain/entities/fakers/GuidesFaker'
 import { IdFaker } from '#global/domain/structures/fakers/IdFaker'
+import { GuideDeletedEvent } from '#manual/domain/events/GuideDeletedEvent'
 import { DeleteGuideUseCase } from '../DeleteGuideUseCase'
 
 describe('Delete Guide Use Case', () => {
   let repository: Mock<GuidesRepository>
+  let broker: Mock<Broker>
   let useCase: DeleteGuideUseCase
 
   beforeEach(() => {
     repository = mock<GuidesRepository>()
+    broker = mock<Broker>()
     repository.findById.mockImplementation()
     repository.remove.mockImplementation()
+    broker.publish.mockImplementation()
 
-    useCase = new DeleteGuideUseCase(repository)
+    useCase = new DeleteGuideUseCase(repository, broker)
   })
 
   it('should throw an error if the guide does not exist', async () => {
@@ -39,5 +44,19 @@ describe('Delete Guide Use Case', () => {
 
     expect(repository.remove).toHaveBeenCalledTimes(1)
     expect(repository.remove).toHaveBeenCalledWith(guide)
+  })
+
+  it('should publish GuideDeletedEvent after deleting the guide', async () => {
+    const guide = GuidesFaker.fake()
+    repository.findById.mockResolvedValue(guide)
+
+    await useCase.execute({
+      guideId: guide.id.value,
+    })
+
+    expect(broker.publish).toHaveBeenCalledTimes(1)
+    expect(broker.publish).toHaveBeenCalledWith(expect.any(GuideDeletedEvent))
+    const event = broker.publish.mock.calls[0][0] as GuideDeletedEvent
+    expect(event.payload.guideId).toBe(guide.id.value)
   })
 })


### PR DESCRIPTION
## 🎯 Objetivo

Este PR implementa o fluxo de limpeza automática de **embeddings** sempre que um guia é removido do sistema.

O objetivo principal é garantir a integridade dos dados e evitar o acúmulo de vetores órfãos no banco de dados de busca. Para isso, foi adotada uma arquitetura orientada a eventos, onde a exclusão de um guia dispara uma notificação processada de forma assíncrona por um worker dedicado.

---

## 📋 Changelog

* **Introduzida** a classe de domínio `GuideDeletedEvent` para padronizar a notificação de exclusão de guias.
* **Implementada** a lógica no `DeleteGuideUseCase` para publicar o evento `GuideDeletedEvent` imediatamente após a remoção do guia.
* **Refatorado** o `DeleteGuideController` para integrar o broker de mensagens necessário para a publicação de eventos.
* **Adicionado** o job `DeleteGuideEmbeddingsJob` na camada de infraestrutura (fila/servidor) para processar a remoção dos embeddings de forma assíncrona.
* **Aprimorados** os testes unitários do `DeleteGuideUseCase` para garantir que o evento de exclusão seja disparado corretamente.
* **Adicionada** a especificação técnica detalhando o novo fluxo de deleção de embeddings na documentação do projeto.

---

## 🧪 Como testar

1. **Ambiente:** Certifique-se de que o serviço de mensageria (Inngest) e o worker da fila estejam ativos.
2. **Execução:** - Realize a exclusão de um guia existente através da rota de API correspondente ou via console.
* Verifique nos logs da aplicação se o evento `GuideDeletedEvent` foi publicado com sucesso.


3. **Validação do Job:**
* Monitore a execução do `DeleteGuideEmbeddingsJob` no worker.
* Confirme se os embeddings associados ao ID do guia deletado foram removidos do provedor de busca vetorial.


4. **Testes Automatizados:**
* Execute o comando de testes para validar as alterações: `npm test` (ou o comando equivalente do projeto) e verifique se os testes de `DeleteGuideUseCase` retornam sucesso