### PR TITLE
Correção de estabilidade no editor de casos de teste

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,9 @@ dist
 # Certificates
 google-key-file.json
 
+# Excalidraw
+.excalidraw
+
 # VSCode
 .vscode/
 

--- a/apps/web/src/ui/challenging/widgets/pages/ChallengeEditor/ChallengeTestCasesField/TestCaseInputs/useTestCaseParamsInput.ts
+++ b/apps/web/src/ui/challenging/widgets/pages/ChallengeEditor/ChallengeTestCasesField/TestCaseInputs/useTestCaseParamsInput.ts
@@ -1,27 +1,41 @@
-import { useEffect } from 'react'
-import { useFieldArray, useFormContext } from 'react-hook-form'
+import { useEffect, useMemo } from 'react'
+import { useFieldArray, useFormContext, useWatch } from 'react-hook-form'
 
 import type { ChallengeSchema } from '@stardust/validation/challenging/types'
 import { DEFAULT_VALUE_BY_DATA_TYPE_NAME } from '@stardust/core/challenging/constants'
 
 export function useTestCaseInputs(testCaseIndex: number) {
-  const { control, formState, watch } = useFormContext<ChallengeSchema>()
-  const { fields, append, remove } = useFieldArray({
+  const { control, formState, getValues } = useFormContext<ChallengeSchema>()
+  const { fields, replace } = useFieldArray({
     control,
     name: `testCases.${testCaseIndex}.inputs`,
   })
-  const functionParams = watch('function.params')
+  const functionParams = useWatch({
+    control,
+    name: 'function.params',
+  })
+  const functionParamsSignature = useMemo(() => {
+    if (!functionParams) return ''
+
+    return functionParams
+      .map((param) => `${param?.name ?? ''}:${param?.dataTypeName ?? ''}`)
+      .join('|')
+  }, [functionParams])
 
   useEffect(() => {
-    remove()
-    functionParams.forEach((param, index) => {
-      const value =
-        fields[index] !== undefined
-          ? fields[index].value
-          : DEFAULT_VALUE_BY_DATA_TYPE_NAME[param.dataTypeName]
-      append({ value })
-    })
-  }, [functionParams, append, remove])
+    if (!functionParams) return
+
+    const currentInputs = getValues(`testCases.${testCaseIndex}.inputs`) ?? []
+
+    replace(
+      functionParams.map((param, index) => ({
+        value:
+          typeof currentInputs[index]?.value !== 'undefined'
+            ? currentInputs[index].value
+            : DEFAULT_VALUE_BY_DATA_TYPE_NAME[param.dataTypeName],
+      })),
+    )
+  }, [functionParamsSignature, functionParams, getValues, replace, testCaseIndex])
 
   const testCaseError = formState.errors.testCases
     ? formState.errors.testCases[testCaseIndex]

--- a/apps/web/src/ui/challenging/widgets/pages/ChallengeEditor/ChallengeTestCasesField/TestCaseInputs/useTestCaseParamsInput.ts
+++ b/apps/web/src/ui/challenging/widgets/pages/ChallengeEditor/ChallengeTestCasesField/TestCaseInputs/useTestCaseParamsInput.ts
@@ -17,9 +17,7 @@ export function useTestCaseInputs(testCaseIndex: number) {
   const functionParamsSignature = useMemo(() => {
     if (!functionParams) return ''
 
-    return functionParams
-      .map((param) => `${param?.name ?? ''}:${param?.dataTypeName ?? ''}`)
-      .join('|')
+    return JSON.stringify(functionParams)
   }, [functionParams])
 
   useEffect(() => {
@@ -35,7 +33,7 @@ export function useTestCaseInputs(testCaseIndex: number) {
             : DEFAULT_VALUE_BY_DATA_TYPE_NAME[param.dataTypeName],
       })),
     )
-  }, [functionParamsSignature, functionParams, getValues, replace, testCaseIndex])
+  }, [functionParamsSignature, getValues, replace, testCaseIndex])
 
   const testCaseError = formState.errors.testCases
     ? formState.errors.testCases[testCaseIndex]

--- a/apps/web/src/ui/challenging/widgets/pages/ChallengeEditor/ChallengeTestCasesField/useChallengeTestCasesField.ts
+++ b/apps/web/src/ui/challenging/widgets/pages/ChallengeEditor/ChallengeTestCasesField/useChallengeTestCasesField.ts
@@ -1,10 +1,9 @@
-import { useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import { useFieldArray, useFormContext } from 'react-hook-form'
 
 import type { ChallengeSchema } from '@stardust/validation/challenging/types'
 import type { DataTypeName } from '@stardust/core/challenging/types'
 import { DEFAULT_VALUE_BY_DATA_TYPE_NAME } from '@stardust/core/challenging/constants'
-import { DataType } from '@stardust/core/challenging/structures'
 
 export function useChallengeTestCasesField() {
   const { control, formState, setValue } = useFormContext<ChallengeSchema>()
@@ -13,6 +12,15 @@ export function useChallengeTestCasesField() {
     name: 'testCases',
   })
   const lastDataTypeNameRef = useRef<DataTypeName>('string')
+
+  useEffect(() => {
+    if (fields.length > 0) {
+      const lastTestCase = fields[fields.length - 1]
+      if (lastTestCase?.expectedOutput?.dataTypeName) {
+        lastDataTypeNameRef.current = lastTestCase.expectedOutput.dataTypeName
+      }
+    }
+  }, [])
 
   function handleExpectedOutputDataTypeNameChange(
     dataTypeName: DataTypeName,
@@ -30,11 +38,10 @@ export function useChallengeTestCasesField() {
 
   function handleAddTestCaseButtonClick() {
     const defaultValue = DEFAULT_VALUE_BY_DATA_TYPE_NAME[lastDataTypeNameRef.current]
-    const dataType = DataType.create(defaultValue)
     append({
       inputs: [],
       expectedOutput: {
-        value: dataType.value,
+        value: defaultValue,
         dataTypeName: lastDataTypeNameRef.current,
       },
       isLocked: false,

--- a/apps/web/src/ui/challenging/widgets/pages/ChallengeEditor/ChallengeTestCasesField/useChallengeTestCasesField.ts
+++ b/apps/web/src/ui/challenging/widgets/pages/ChallengeEditor/ChallengeTestCasesField/useChallengeTestCasesField.ts
@@ -1,3 +1,4 @@
+import { useRef } from 'react'
 import { useFieldArray, useFormContext } from 'react-hook-form'
 
 import type { ChallengeSchema } from '@stardust/validation/challenging/types'
@@ -11,11 +12,13 @@ export function useChallengeTestCasesField() {
     control,
     name: 'testCases',
   })
+  const lastDataTypeNameRef = useRef<DataTypeName>('string')
 
   function handleExpectedOutputDataTypeNameChange(
     dataTypeName: DataTypeName,
     testCaseIndex: number,
   ) {
+    lastDataTypeNameRef.current = dataTypeName
     const currentExpectedOutput = fields[testCaseIndex]?.expectedOutput
     if (currentExpectedOutput?.dataTypeName !== dataTypeName)
       setValue(
@@ -26,12 +29,13 @@ export function useChallengeTestCasesField() {
   }
 
   function handleAddTestCaseButtonClick() {
-    const dataType = DataType.create('')
+    const defaultValue = DEFAULT_VALUE_BY_DATA_TYPE_NAME[lastDataTypeNameRef.current]
+    const dataType = DataType.create(defaultValue)
     append({
       inputs: [],
       expectedOutput: {
         value: dataType.value,
-        dataTypeName: dataType.name,
+        dataTypeName: lastDataTypeNameRef.current,
       },
       isLocked: false,
     })

--- a/apps/web/src/ui/challenging/widgets/pages/ChallengeEditor/DataTypeInput/useDataTypeInput.ts
+++ b/apps/web/src/ui/challenging/widgets/pages/ChallengeEditor/DataTypeInput/useDataTypeInput.ts
@@ -1,14 +1,24 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import type { DataTypeName } from '@stardust/core/challenging/types'
 import type { DataType } from '@stardust/core/challenging/structures'
 import { DEFAULT_VALUE_BY_DATA_TYPE_NAME } from '@stardust/core/challenging/constants'
+
+function detectDataTypeName(value: unknown): DataTypeName {
+  if (Array.isArray(value)) return 'array'
+  if (typeof value === 'string') return 'string'
+  if (typeof value === 'number') return 'number'
+  if (typeof value === 'boolean') return 'boolean'
+
+  return 'undefined'
+}
 
 export function useDataTypeInput(
   selectedDataType: DataType,
   onChange: (value: unknown) => void,
 ) {
   const [dataType, setDataType] = useState<DataType>(selectedDataType)
+  const lastArrayItemDataTypeNameRef = useRef<DataTypeName>('string')
 
   function handleStringValueChange(value: string) {
     setDataType(dataType.changeValue(value))
@@ -32,6 +42,7 @@ export function useDataTypeInput(
   }
 
   function handleArrayItemDataTypeNameChange(dataTypeName: DataTypeName, index: number) {
+    lastArrayItemDataTypeNameRef.current = dataTypeName
     const updatedDataType = dataType.changeArrayItem(
       DEFAULT_VALUE_BY_DATA_TYPE_NAME[dataTypeName],
       index,
@@ -41,14 +52,25 @@ export function useDataTypeInput(
   }
 
   function handleAddArrayItemClick() {
-    setDataType(dataType.addArrayItem(undefined))
+    const defaultValue =
+      DEFAULT_VALUE_BY_DATA_TYPE_NAME[lastArrayItemDataTypeNameRef.current]
+    const updatedDataType = dataType.addArrayItem(defaultValue)
+    setDataType(updatedDataType)
+    onChange(updatedDataType.value)
   }
 
   function handleRemoveArrayItemClick(itemIndex: number) {
-    setDataType(dataType.removeArrayItem(itemIndex))
+    const updatedDataType = dataType.removeArrayItem(itemIndex)
+    setDataType(updatedDataType)
+    onChange(updatedDataType.value)
   }
 
   useEffect(() => {
+    if (selectedDataType.isArray() && selectedDataType.value.length > 0) {
+      const lastItem = selectedDataType.value[selectedDataType.value.length - 1]
+      lastArrayItemDataTypeNameRef.current = detectDataTypeName(lastItem)
+    }
+
     setDataType(selectedDataType)
   }, [selectedDataType])
 

--- a/apps/web/src/ui/challenging/widgets/pages/ChallengeEditor/DataTypeInput/useDataTypeInput.ts
+++ b/apps/web/src/ui/challenging/widgets/pages/ChallengeEditor/DataTypeInput/useDataTypeInput.ts
@@ -6,6 +6,7 @@ import { DEFAULT_VALUE_BY_DATA_TYPE_NAME } from '@stardust/core/challenging/cons
 
 function detectDataTypeName(value: unknown): DataTypeName {
   if (Array.isArray(value)) return 'array'
+  if (value === null) return 'undefined'
   if (typeof value === 'string') return 'string'
   if (typeof value === 'number') return 'number'
   if (typeof value === 'boolean') return 'boolean'
@@ -69,6 +70,8 @@ export function useDataTypeInput(
     if (selectedDataType.isArray() && selectedDataType.value.length > 0) {
       const lastItem = selectedDataType.value[selectedDataType.value.length - 1]
       lastArrayItemDataTypeNameRef.current = detectDataTypeName(lastItem)
+    } else if (!selectedDataType.isArray()) {
+      lastArrayItemDataTypeNameRef.current = selectedDataType.name
     }
 
     setDataType(selectedDataType)

--- a/documentation/prompts/resolve-pr-conversations-prompt.md
+++ b/documentation/prompts/resolve-pr-conversations-prompt.md
@@ -29,6 +29,7 @@ Analisar, implementar e resolver todas as conversas e feedbacks pendentes em um 
    * Verifique se as alterações atendem aos requisitos do PRD e Spec.
 
 5. **Finalização:**
+   * Resolvas as conversas do PR usando usando a mutation resolveReviewThread via GitHub GraphQL API
    * Forneça um resumo detalhado de quais conversas foram resolvidas e quais alterações de código foram realizadas.
 
 ---


### PR DESCRIPTION
## 🎯 Objetivo
Corrigir comportamentos instaveis no editor de desafios ao manipular casos de teste e listas tipadas, evitando loops de atualizacao e erros em runtime.

## 🐛 Causa do bug
A sincronizacao de campos de `testCases.inputs` era feita com `remove()` + `append()` em efeito reativo, o que podia gerar cascatas de re-renderizacao. Alem disso, a logica de memoria para itens de lista dependia de uma referencia de tipo em runtime que podia nao estar disponivel no fluxo de selecao de array.

## 📋 Changelog
- `apps/web/src/ui/challenging/widgets/pages/ChallengeEditor/ChallengeTestCasesField/TestCaseInputs/useTestCaseParamsInput.ts`
  - substitui sincronizacao por `useWatch` + `replace()`
  - preserva valores ja preenchidos com `getValues()`
  - aplica defaults apenas quando necessario
- `apps/web/src/ui/challenging/widgets/pages/ChallengeEditor/ChallengeTestCasesField/useChallengeTestCasesField.ts`
  - ajusta comportamento de tipos/defaults nos casos de teste
- `apps/web/src/ui/challenging/widgets/pages/ChallengeEditor/DataTypeInput/useDataTypeInput.ts`
  - adiciona mecanismo de memoria do ultimo tipo usado para arrays
  - garante `onChange` em adicao/remocao de itens para manter o formulario sincronizado
  - corrige inferencia de tipo do ultimo item sem dependencia de valor ausente em runtime
- `.gitignore`
  - adiciona exclusao para arquivos `.excalidraw`

## 🧪 Como testar
1. Executar a aplicacao web em desenvolvimento.
2. Acessar a tela de edicao/criacao de desafio.
3. Definir parametros de funcao e validar que os `inputs` dos casos de teste sincronizam sem travar.
4. Em campos com tipo `array`, trocar tipo de item, adicionar/remover itens e confirmar preservacao do ultimo tipo selecionado.
5. Validar que nao ocorre erro `DataType is not defined` ao selecionar lista.

## 👀 Observacoes
- A mudanca prioriza estabilidade da reatividade do formulario em cenarios dinamicos de `react-hook-form`.
- O objetivo foi manter compatibilidade com o comportamento atual do editor, reduzindo efeitos colaterais de sincronizacao.