### PR TITLE
Resolve erro de metadados retornado em execução de código Delégua

### DIFF
--- a/packages/core/src/global/responses/LspResponse.ts
+++ b/packages/core/src/global/responses/LspResponse.ts
@@ -1,7 +1,7 @@
 import { AppError, LspError } from '../domain/errors'
 
 type LspResponseProps = {
-  result?: string
+  result?: any
   outputs?: string[]
   error?: LspError | null
   errors?: LspError[]

--- a/packages/lsp/src/DeleguaLsp.ts
+++ b/packages/lsp/src/DeleguaLsp.ts
@@ -70,15 +70,27 @@ export class DeleguaLsp implements LspProvider {
 
     resultadoFinal = resultadoRetornado?.valorRetornado?.valor
 
+    while ('valorRetornado' in resultadoFinal) {
+      resultadoFinal = resultadoFinal.valorRetornado.valor
+    }
+
+    resultadoFinal = Array.isArray(resultadoFinal)
+      ? resultadoFinal.map(this.pegarValorDeResultadoFinal)
+      : this.pegarValorDeResultadoFinal(resultadoFinal)
+
+    return new LspResponse({ result: resultadoFinal, outputs })
+  }
+
+  private pegarValorDeResultadoFinal(resultadoFinal: unknown) {
     if (
       typeof resultadoFinal === 'object' &&
       resultadoFinal !== null &&
       'valor' in resultadoFinal
     ) {
-      resultadoFinal = resultadoFinal.valor
+      return resultadoFinal.valor
     }
 
-    return new LspResponse({ result: resultadoFinal, outputs })
+    return resultadoFinal
   }
 
   getInput(code: string) {


### PR DESCRIPTION
## 🎯 Objetivo

Corrigir o bug em que a execução de código Delégua retornava metadados internos do interpretador (objetos com `valorRetornado`) junto ao resultado final, fazendo com que testes de desafios falhassem mesmo com a lógica correta.

## #️⃣ Issues relacionadas

fixes #335

## 🐛 Causa do bug

O interpretador Delégua pode retornar valores aninhados via objetos `{ valorRetornado: { valor: ... } }`. A lógica anterior de extração em `DeleguaLsp.execute()` fazia apenas uma verificação rasa (`'valor' in resultadoFinal`), não desaninhando completamente estruturas com múltiplos níveis de `valorRetornado`. Além disso, quando o resultado era um array, cada item poderia conter metadados sem ser processado individualmente.

## 📋 Changelog

- **`packages/lsp/src/DeleguaLsp.ts`**
  - Adicionado loop `while` para desaninhar recursivamente objetos com `valorRetornado` antes de processar o resultado final
  - Adicionado suporte a resultados do tipo array: cada item é mapeado via novo método privado `pegarValorDeResultadoFinal`
  - Extraído método privado `pegarValorDeResultadoFinal` para encapsular a lógica de limpeza de metadados de um valor individual

## 🧪 Como testar

1. Acesse o desafio "O Catálogo de Minerais Exclusivos" no ambiente de staging
2. Implemente a função `compararDados` conforme o código descrito na issue
3. Execute os testes do desafio
4. Verifique que os três testes passam sem expor metadados do interpretador no resultado

## 👀 Observações

- A abordagem com loop `while` garante que qualquer profundidade de aninhamento de `valorRetornado` seja resolvida, alinhando-se com a solução adotada em `delegua-node` (referenciada na issue)
- O método `pegarValorDeResultadoFinal` trata apenas o nível mais externo de metadados (`'valor' in obj`), sendo chamado após o desaninhamento completo do `valorRetornado`
