### PR TITLE
Testes automatizados para controllers do módulo challenging

### DIFF
--- a/apps/server/src/constants/env.ts
+++ b/apps/server/src/constants/env.ts
@@ -19,6 +19,8 @@ const env = {
   sentryDsn: process.env.SENTRY_DSN,
 }
 
+console.log('godAccountIds', env.godAccountIds)
+
 const envSchema = z.object({
   mode: z.enum(['development', 'production', 'test']),
   port: z.coerce.number().default(3333),

--- a/apps/server/src/constants/env.ts
+++ b/apps/server/src/constants/env.ts
@@ -19,8 +19,6 @@ const env = {
   sentryDsn: process.env.SENTRY_DSN,
 }
 
-console.log('godAccountIds', env.godAccountIds)
-
 const envSchema = z.object({
   mode: z.enum(['development', 'production', 'test']),
   port: z.coerce.number().default(3333),

--- a/apps/server/src/rest/controllers/challenging/challenges/tests/AppendChallengeRewardToBody.test.ts
+++ b/apps/server/src/rest/controllers/challenging/challenges/tests/AppendChallengeRewardToBody.test.ts
@@ -1,0 +1,41 @@
+import { mock, type Mock } from 'ts-jest-mocker'
+
+import type { ChallengesRepository } from '@stardust/core/challenging/interfaces'
+import { GetChallengeRewardUseCase } from '@stardust/core/challenging/use-cases'
+import type { Http } from '@stardust/core/global/interfaces'
+import { IdFaker } from '@stardust/core/global/structures/fakers'
+
+import { AppendChallengeRewardToBodyController } from '../AppendChallengeRewardToBody'
+
+describe('Append Challenge Reward To Body Controller', () => {
+  let http: Mock<Http<{ body: { challengeId: string } }>>
+  let repository: Mock<ChallengesRepository>
+  let controller: AppendChallengeRewardToBodyController
+
+  beforeEach(() => {
+    jest.restoreAllMocks()
+    http = mock()
+    repository = mock()
+    http.extendBody.mockImplementation()
+    http.pass.mockImplementation()
+    controller = new AppendChallengeRewardToBodyController(repository)
+  })
+
+  it('should append challenge reward to request body and pass to next controller', async () => {
+    const challengeId = IdFaker.fake().value
+    const reward = { xp: 40, coins: 20 }
+
+    http.getBody.mockResolvedValue({ challengeId })
+    const executeSpy = jest
+      .spyOn(GetChallengeRewardUseCase.prototype, 'execute')
+      .mockResolvedValue(reward)
+
+    await controller.handle(http)
+
+    expect(executeSpy).toHaveBeenCalledWith({ challengeId })
+    expect(http.extendBody).toHaveBeenCalledWith({
+      challengeReward: reward,
+    })
+    expect(http.pass).toHaveBeenCalled()
+  })
+})

--- a/apps/server/src/rest/controllers/challenging/challenges/tests/DeleteChallengeController.test.ts
+++ b/apps/server/src/rest/controllers/challenging/challenges/tests/DeleteChallengeController.test.ts
@@ -1,0 +1,42 @@
+import { mock, type Mock } from 'ts-jest-mocker'
+
+import type { ChallengesRepository } from '@stardust/core/challenging/interfaces'
+import { DeleteChallengeUseCase } from '@stardust/core/challenging/use-cases'
+import type { Http } from '@stardust/core/global/interfaces'
+import type { RestResponse } from '@stardust/core/global/responses'
+import { IdFaker } from '@stardust/core/global/structures/fakers'
+
+import { DeleteChallengeController } from '../DeleteChallengeController'
+
+describe('Delete Challenge Controller', () => {
+  let http: Mock<Http<{ routeParams: { challengeId: string } }>>
+  let repository: Mock<ChallengesRepository>
+  let controller: DeleteChallengeController
+
+  beforeEach(() => {
+    jest.restoreAllMocks()
+    http = mock()
+    repository = mock()
+    controller = new DeleteChallengeController(repository)
+  })
+
+  it('should delete challenge and return no content', async () => {
+    const challengeId = IdFaker.fake().value
+    const restResponse = mock<RestResponse>()
+
+    http.getRouteParams.mockReturnValue({ challengeId })
+    http.statusNoContent.mockReturnValue(http)
+    http.send.mockReturnValue(restResponse)
+
+    const executeSpy = jest
+      .spyOn(DeleteChallengeUseCase.prototype, 'execute')
+      .mockResolvedValue(undefined)
+
+    const response = await controller.handle(http)
+
+    expect(executeSpy).toHaveBeenCalledWith({ challengeId })
+    expect(http.statusNoContent).toHaveBeenCalled()
+    expect(http.send).toHaveBeenCalled()
+    expect(response).toBe(restResponse)
+  })
+})

--- a/apps/server/src/rest/controllers/challenging/challenges/tests/FetchAllChallengeCategories.test.ts
+++ b/apps/server/src/rest/controllers/challenging/challenges/tests/FetchAllChallengeCategories.test.ts
@@ -1,0 +1,34 @@
+import { mock, type Mock } from 'ts-jest-mocker'
+
+import { ChallengeCategoriesFaker } from '@stardust/core/challenging/entities/fakers'
+import type { ChallengesRepository } from '@stardust/core/challenging/interfaces'
+import type { Http } from '@stardust/core/global/interfaces'
+import type { RestResponse } from '@stardust/core/global/responses'
+
+import { FetchAllChallengeCategoriesController } from '../FetchAllChallengeCategories'
+
+describe('Fetch All Challenge Categories Controller', () => {
+  let http: Mock<Http>
+  let repository: Mock<ChallengesRepository>
+  let controller: FetchAllChallengeCategoriesController
+
+  beforeEach(() => {
+    http = mock()
+    repository = mock()
+    controller = new FetchAllChallengeCategoriesController(repository)
+  })
+
+  it('should fetch all categories and return their dtos', async () => {
+    const categories = [ChallengeCategoriesFaker.fake(), ChallengeCategoriesFaker.fake()]
+    const restResponse = mock<RestResponse>()
+
+    repository.findAllCategories.mockResolvedValue(categories)
+    http.send.mockReturnValue(restResponse)
+
+    const response = await controller.handle(http)
+
+    expect(repository.findAllCategories).toHaveBeenCalled()
+    expect(http.send).toHaveBeenCalledWith(categories.map((category) => category.dto))
+    expect(response).toBe(restResponse)
+  })
+})

--- a/apps/server/src/rest/controllers/challenging/challenges/tests/FetchAllChallengesController.test.ts
+++ b/apps/server/src/rest/controllers/challenging/challenges/tests/FetchAllChallengesController.test.ts
@@ -1,0 +1,97 @@
+import { mock, type Mock } from 'ts-jest-mocker'
+
+import { ChallengesFaker } from '@stardust/core/challenging/entities/fakers'
+import type { ChallengesRepository } from '@stardust/core/challenging/interfaces'
+import { ListChallengesUseCase } from '@stardust/core/challenging/use-cases'
+import type { Http } from '@stardust/core/global/interfaces'
+import { PaginationResponse, type RestResponse } from '@stardust/core/global/responses'
+import { IdFaker } from '@stardust/core/global/structures/fakers'
+
+import { FetchAllChallengesController } from '../FetchAllChallengesController'
+
+describe('Fetch All Challenges Controller', () => {
+  type Schema = {
+    queryParams: {
+      page: number
+      itemsPerPage: number
+      title: string
+      categoriesIds: string[]
+      difficulty: string
+      upvotesCountOrder: string
+      downvoteCountOrder: string
+      completionCountOrder: string
+      postingOrder: string
+      completionStatus: string
+      userId?: string
+      userCompletedChallengesIds?: string[]
+    }
+    body: {
+      userCompletedChallengesIds?: string[]
+    }
+  }
+
+  let http: Mock<Http<Schema>>
+  let repository: Mock<ChallengesRepository>
+  let controller: FetchAllChallengesController
+
+  beforeEach(() => {
+    jest.restoreAllMocks()
+    http = mock()
+    repository = mock()
+    controller = new FetchAllChallengesController(repository)
+  })
+
+  it('should call list challenges use case and send paginated response', async () => {
+    const accountId = IdFaker.fake().value
+    const userId = IdFaker.fake().value
+    const categoryId = IdFaker.fake().value
+    const userCompletedChallengesIds = [IdFaker.fake().value]
+    const queryParams = {
+      page: 2,
+      itemsPerPage: 12,
+      title: 'sorting',
+      categoriesIds: [categoryId],
+      difficulty: 'medium',
+      upvotesCountOrder: 'desc',
+      downvoteCountOrder: 'asc',
+      completionCountOrder: 'desc',
+      postingOrder: 'desc',
+      completionStatus: 'completed',
+      userId,
+    }
+    const pagination = new PaginationResponse([ChallengesFaker.fakeDto()], 1)
+    const restResponse = mock<RestResponse>()
+
+    http.getQueryParams.mockReturnValue(queryParams)
+    http.getBody.mockResolvedValue({ userCompletedChallengesIds })
+    http.getAccountId.mockResolvedValue(accountId)
+    http.sendPagination.mockReturnValue(restResponse)
+
+    const executeSpy = jest
+      .spyOn(ListChallengesUseCase.prototype, 'execute')
+      .mockResolvedValue(pagination)
+
+    const response = await controller.handle(http)
+
+    expect(executeSpy).toHaveBeenCalledWith({
+      accountId,
+      page: queryParams.page,
+      itemsPerPage: queryParams.itemsPerPage,
+      categoriesIds: queryParams.categoriesIds,
+      difficulty: queryParams.difficulty,
+      upvotesCountOrder: queryParams.upvotesCountOrder,
+      postingOrder: queryParams.postingOrder,
+      userId: queryParams.userId,
+      userCompletedChallengesIds,
+      title: queryParams.title,
+      completionStatus: queryParams.completionStatus,
+      shouldIncludePrivateChallenges: true,
+      shouldIncludeStarChallenges: false,
+      shouldIncludeOnlyAuthorChallenges: false,
+      completionCountOrder: queryParams.completionCountOrder,
+      downvoteCountOrder: queryParams.downvoteCountOrder,
+    })
+    expect(http.sendPagination).toHaveBeenCalledWith(pagination)
+    expect(response).toBe(restResponse)
+  })
+})

--- a/apps/server/src/rest/controllers/challenging/challenges/tests/FetchChallengeController.test.ts
+++ b/apps/server/src/rest/controllers/challenging/challenges/tests/FetchChallengeController.test.ts
@@ -1,0 +1,54 @@
+import { mock, type Mock } from 'ts-jest-mocker'
+
+import { ChallengesFaker } from '@stardust/core/challenging/entities/fakers'
+import type { ChallengesRepository } from '@stardust/core/challenging/interfaces'
+import { GetChallengeUseCase } from '@stardust/core/challenging/use-cases'
+import type { Http } from '@stardust/core/global/interfaces'
+import type { RestResponse } from '@stardust/core/global/responses'
+import { IdFaker } from '@stardust/core/global/structures/fakers'
+
+import { FetchChallengeController } from '../FetchChallengeController'
+
+describe('Fetch Challenge Controller', () => {
+  type Schema = {
+    routeParams: {
+      challengeSlug?: string
+      challengeId?: string
+      starId?: string
+    }
+  }
+
+  let http: Mock<Http<Schema>>
+  let repository: Mock<ChallengesRepository>
+  let controller: FetchChallengeController
+
+  beforeEach(() => {
+    jest.restoreAllMocks()
+    http = mock()
+    repository = mock()
+    controller = new FetchChallengeController(repository)
+  })
+
+  it('should fetch challenge with route params and send response', async () => {
+    const routeParams = {
+      challengeId: IdFaker.fake().value,
+      challengeSlug: 'sum-two-numbers',
+      starId: IdFaker.fake().value,
+    }
+    const challengeDto = ChallengesFaker.fakeDto({ id: routeParams.challengeId })
+    const restResponse = mock<RestResponse>()
+
+    http.getRouteParams.mockReturnValue(routeParams)
+    http.send.mockReturnValue(restResponse)
+
+    const executeSpy = jest
+      .spyOn(GetChallengeUseCase.prototype, 'execute')
+      .mockResolvedValue(challengeDto)
+
+    const response = await controller.handle(http)
+
+    expect(executeSpy).toHaveBeenCalledWith(routeParams)
+    expect(http.send).toHaveBeenCalledWith(challengeDto)
+    expect(response).toBe(restResponse)
+  })
+})

--- a/apps/server/src/rest/controllers/challenging/challenges/tests/FetchChallengeVoteController.test.ts
+++ b/apps/server/src/rest/controllers/challenging/challenges/tests/FetchChallengeVoteController.test.ts
@@ -1,0 +1,52 @@
+import { mock, type Mock } from 'ts-jest-mocker'
+
+import type { ChallengesRepository } from '@stardust/core/challenging/interfaces'
+import { GetChallengeVoteUseCase } from '@stardust/core/challenging/use-cases'
+import type { Http } from '@stardust/core/global/interfaces'
+import type { RestResponse } from '@stardust/core/global/responses'
+import { IdFaker } from '@stardust/core/global/structures/fakers'
+
+import { FetchChallengeVoteController } from '../FetchChallengeVoteController'
+
+describe('Fetch Challenge Vote Controller', () => {
+  type Schema = {
+    routeParams: {
+      challengeId: string
+    }
+  }
+
+  let http: Mock<Http<Schema>>
+  let repository: Mock<ChallengesRepository>
+  let controller: FetchChallengeVoteController
+
+  beforeEach(() => {
+    jest.restoreAllMocks()
+    http = mock()
+    repository = mock()
+    controller = new FetchChallengeVoteController(repository)
+  })
+
+  it('should fetch challenge vote with challenge and user ids', async () => {
+    const challengeId = IdFaker.fake().value
+    const userId = IdFaker.fake().value
+    const challengeVote = { challengeVote: 'upvote' }
+    const restResponse = mock<RestResponse>()
+
+    http.getRouteParams.mockReturnValue({ challengeId })
+    http.getAccount.mockResolvedValue({ id: userId } as never)
+    http.send.mockReturnValue(restResponse)
+
+    const executeSpy = jest
+      .spyOn(GetChallengeVoteUseCase.prototype, 'execute')
+      .mockResolvedValue(challengeVote as never)
+
+    const response = await controller.handle(http)
+
+    expect(executeSpy).toHaveBeenCalledWith({
+      challengeId,
+      userId,
+    })
+    expect(http.send).toHaveBeenCalledWith(challengeVote)
+    expect(response).toBe(restResponse)
+  })
+})

--- a/apps/server/src/rest/controllers/challenging/challenges/tests/FetchChallengesListController.test.ts
+++ b/apps/server/src/rest/controllers/challenging/challenges/tests/FetchChallengesListController.test.ts
@@ -1,0 +1,137 @@
+import { mock, type Mock } from 'ts-jest-mocker'
+
+import { ChallengesFaker } from '@stardust/core/challenging/entities/fakers'
+import type { ChallengesRepository } from '@stardust/core/challenging/interfaces'
+import { ListChallengesUseCase } from '@stardust/core/challenging/use-cases'
+import type { Http } from '@stardust/core/global/interfaces'
+import { PaginationResponse, type RestResponse } from '@stardust/core/global/responses'
+import { IdFaker } from '@stardust/core/global/structures/fakers'
+
+import { FetchChallengesListController } from '../FetchChallengesListController'
+
+describe('Fetch Challenges List Controller', () => {
+  type Schema = {
+    queryParams: {
+      page: number
+      itemsPerPage: number
+      title: string
+      categoriesIds: string[]
+      difficulty: string
+      upvotesCountOrder: string
+      downvoteCountOrder: string
+      completionCountOrder: string
+      postingOrder: string
+      completionStatus: string
+      shouldIncludeOnlyAuthorChallenges: boolean
+      shouldIncludePrivateChallenges: boolean
+      userId?: string
+      userCompletedChallengesIds?: string[]
+    }
+    body: {
+      userCompletedChallengesIds?: string[]
+    }
+  }
+
+  let http: Mock<Http<Schema>>
+  let repository: Mock<ChallengesRepository>
+  let controller: FetchChallengesListController
+
+  beforeEach(() => {
+    jest.restoreAllMocks()
+    http = mock()
+    repository = mock()
+    controller = new FetchChallengesListController(repository)
+  })
+
+  it('should call list use case using account id and send pagination', async () => {
+    const accountId = IdFaker.fake().value
+    const queryParams = {
+      page: 1,
+      itemsPerPage: 20,
+      title: 'array',
+      categoriesIds: [IdFaker.fake().value],
+      difficulty: 'easy',
+      upvotesCountOrder: 'desc',
+      downvoteCountOrder: 'asc',
+      completionCountOrder: 'desc',
+      postingOrder: 'desc',
+      completionStatus: 'all',
+      shouldIncludeOnlyAuthorChallenges: true,
+      shouldIncludePrivateChallenges: true,
+      userId: IdFaker.fake().value,
+    }
+    const userCompletedChallengesIds = [IdFaker.fake().value]
+    const pagination = new PaginationResponse([ChallengesFaker.fakeDto()], 1)
+    const restResponse = mock<RestResponse>()
+
+    http.getQueryParams.mockReturnValue(queryParams)
+    http.getBody.mockResolvedValue({ userCompletedChallengesIds })
+    http.getAccount.mockResolvedValue({ id: accountId } as never)
+    http.sendPagination.mockReturnValue(restResponse)
+
+    const executeSpy = jest
+      .spyOn(ListChallengesUseCase.prototype, 'execute')
+      .mockResolvedValue(pagination)
+
+    const response = await controller.handle(http)
+
+    expect(executeSpy).toHaveBeenCalledWith({
+      accountId,
+      page: queryParams.page,
+      itemsPerPage: queryParams.itemsPerPage,
+      categoriesIds: queryParams.categoriesIds,
+      difficulty: queryParams.difficulty,
+      upvotesCountOrder: queryParams.upvotesCountOrder,
+      downvoteCountOrder: queryParams.downvoteCountOrder,
+      completionCountOrder: queryParams.completionCountOrder,
+      postingOrder: queryParams.postingOrder,
+      userId: queryParams.userId,
+      userCompletedChallengesIds,
+      title: queryParams.title,
+      completionStatus: queryParams.completionStatus,
+      shouldIncludeOnlyAuthorChallenges: queryParams.shouldIncludeOnlyAuthorChallenges,
+      shouldIncludePrivateChallenges: queryParams.shouldIncludePrivateChallenges,
+      shouldIncludeStarChallenges: false,
+    })
+    expect(http.sendPagination).toHaveBeenCalledWith(pagination)
+    expect(response).toBe(restResponse)
+  })
+
+  it('should call list use case with undefined account id when no account exists', async () => {
+    const queryParams = {
+      page: 1,
+      itemsPerPage: 10,
+      title: '',
+      categoriesIds: [],
+      difficulty: 'all',
+      upvotesCountOrder: 'desc',
+      downvoteCountOrder: 'desc',
+      completionCountOrder: 'desc',
+      postingOrder: 'desc',
+      completionStatus: 'all',
+      shouldIncludeOnlyAuthorChallenges: false,
+      shouldIncludePrivateChallenges: false,
+      userId: undefined,
+    }
+    const pagination = new PaginationResponse([ChallengesFaker.fakeDto()], 1)
+    const restResponse = mock<RestResponse>()
+
+    http.getQueryParams.mockReturnValue(queryParams)
+    http.getBody.mockResolvedValue({})
+    http.getAccount.mockResolvedValue(undefined as never)
+    http.sendPagination.mockReturnValue(restResponse)
+
+    const executeSpy = jest
+      .spyOn(ListChallengesUseCase.prototype, 'execute')
+      .mockResolvedValue(pagination)
+
+    await controller.handle(http)
+
+    expect(executeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: undefined,
+        userCompletedChallengesIds: [],
+      }),
+    )
+  })
+})

--- a/apps/server/src/rest/controllers/challenging/challenges/tests/FetchCompletedChallengesCountByDifficultyLevelController.test.ts
+++ b/apps/server/src/rest/controllers/challenging/challenges/tests/FetchCompletedChallengesCountByDifficultyLevelController.test.ts
@@ -1,0 +1,56 @@
+import { mock, type Mock } from 'ts-jest-mocker'
+
+import type { ChallengesRepository } from '@stardust/core/challenging/interfaces'
+import { CountCompletedChallengesByDifficultyLevelUseCase } from '@stardust/core/challenging/use-cases'
+import type { Http } from '@stardust/core/global/interfaces'
+import type { RestResponse } from '@stardust/core/global/responses'
+import { IdFaker } from '@stardust/core/global/structures/fakers'
+
+import { FetchCompletedChallengesCountByDifficultyLevelController } from '../FetchCompletedChallengesCountByDifficultyLevelController'
+
+describe('Fetch Completed Challenges Count By Difficulty Level Controller', () => {
+  type Schema = {
+    body: {
+      userCompletedChallengesIds: string[]
+    }
+  }
+
+  let http: Mock<Http<Schema>>
+  let repository: Mock<ChallengesRepository>
+  let controller: FetchCompletedChallengesCountByDifficultyLevelController
+
+  beforeEach(() => {
+    jest.restoreAllMocks()
+    http = mock()
+    repository = mock()
+    controller = new FetchCompletedChallengesCountByDifficultyLevelController(repository)
+  })
+
+  it('should count completed challenges by difficulty and send response', async () => {
+    const userId = IdFaker.fake().value
+    const userCompletedChallengesIds = [IdFaker.fake().value, IdFaker.fake().value]
+    const output = {
+      percentage: { easy: 50, medium: 50, hard: 0 },
+      absolute: { easy: 1, medium: 1, hard: 0 },
+      total: { easy: 2, medium: 2, hard: 2 },
+    }
+    const restResponse = mock<RestResponse>()
+
+    http.getBody.mockResolvedValue({ userCompletedChallengesIds })
+    http.getAccount.mockResolvedValue({ id: userId } as never)
+    http.send.mockReturnValue(restResponse)
+
+    const executeSpy = jest
+      .spyOn(CountCompletedChallengesByDifficultyLevelUseCase.prototype, 'execute')
+      .mockResolvedValue(output)
+
+    const response = await controller.handle(http)
+
+    expect(executeSpy).toHaveBeenCalledWith({
+      userId,
+      userCompletedChallengesIds,
+    })
+    expect(http.send).toHaveBeenCalledWith(output)
+    expect(response).toBe(restResponse)
+  })
+})

--- a/apps/server/src/rest/controllers/challenging/challenges/tests/FetchPostedChallengesKpiController.test.ts
+++ b/apps/server/src/rest/controllers/challenging/challenges/tests/FetchPostedChallengesKpiController.test.ts
@@ -1,0 +1,42 @@
+import { mock, type Mock } from 'ts-jest-mocker'
+
+import type { ChallengesRepository } from '@stardust/core/challenging/interfaces'
+import { GetPostedChallengesKpiUseCase } from '@stardust/core/challenging/use-cases'
+import type { Http } from '@stardust/core/global/interfaces'
+import type { RestResponse } from '@stardust/core/global/responses'
+
+import { FetchPostedChallengesKpiController } from '../FetchPostedChallengesKpiController'
+
+describe('Fetch Posted Challenges Kpi Controller', () => {
+  let http: Mock<Http>
+  let repository: Mock<ChallengesRepository>
+  let controller: FetchPostedChallengesKpiController
+
+  beforeEach(() => {
+    jest.restoreAllMocks()
+    http = mock()
+    repository = mock()
+    controller = new FetchPostedChallengesKpiController(repository)
+  })
+
+  it('should fetch posted challenges kpi and send response', async () => {
+    const kpiDto = {
+      value: 30,
+      currentMonthValue: 18,
+      previousMonthValue: 12,
+    }
+    const restResponse = mock<RestResponse>()
+
+    http.send.mockReturnValue(restResponse)
+
+    const executeSpy = jest
+      .spyOn(GetPostedChallengesKpiUseCase.prototype, 'execute')
+      .mockResolvedValue(kpiDto)
+
+    const response = await controller.handle(http)
+
+    expect(executeSpy).toHaveBeenCalled()
+    expect(http.send).toHaveBeenCalledWith(kpiDto)
+    expect(response).toBe(restResponse)
+  })
+})

--- a/apps/server/src/rest/controllers/challenging/challenges/tests/PostChallengeController.test.ts
+++ b/apps/server/src/rest/controllers/challenging/challenges/tests/PostChallengeController.test.ts
@@ -1,0 +1,47 @@
+import { mock, type Mock } from 'ts-jest-mocker'
+
+import { ChallengesFaker } from '@stardust/core/challenging/entities/fakers'
+import type { ChallengesRepository } from '@stardust/core/challenging/interfaces'
+import { PostChallengeUseCase } from '@stardust/core/challenging/use-cases'
+import type { Broker, Http } from '@stardust/core/global/interfaces'
+import type { RestResponse } from '@stardust/core/global/responses'
+
+import { PostChallengeController } from '../PostChallengeController'
+
+describe('Post Challenge Controller', () => {
+  type Schema = {
+    body: ReturnType<typeof ChallengesFaker.fakeDto>
+  }
+
+  let http: Mock<Http<Schema>>
+  let repository: Mock<ChallengesRepository>
+  let broker: Mock<Broker>
+  let controller: PostChallengeController
+
+  beforeEach(() => {
+    jest.restoreAllMocks()
+    http = mock()
+    repository = mock()
+    broker = mock()
+    controller = new PostChallengeController(repository, broker)
+  })
+
+  it('should post challenge using body dto and send response', async () => {
+    const challengeDto = ChallengesFaker.fakeDto()
+    const responseDto = ChallengesFaker.fakeDto()
+    const restResponse = mock<RestResponse>()
+
+    http.getBody.mockResolvedValue(challengeDto)
+    http.send.mockReturnValue(restResponse)
+
+    const executeSpy = jest
+      .spyOn(PostChallengeUseCase.prototype, 'execute')
+      .mockResolvedValue(responseDto)
+
+    const response = await controller.handle(http)
+
+    expect(executeSpy).toHaveBeenCalledWith({ challengeDto })
+    expect(http.send).toHaveBeenCalledWith(responseDto)
+    expect(response).toBe(restResponse)
+  })
+})

--- a/apps/server/src/rest/controllers/challenging/challenges/tests/UpdateChallengeController.test.ts
+++ b/apps/server/src/rest/controllers/challenging/challenges/tests/UpdateChallengeController.test.ts
@@ -1,0 +1,52 @@
+import { mock, type Mock } from 'ts-jest-mocker'
+
+import { ChallengesFaker } from '@stardust/core/challenging/entities/fakers'
+import type { ChallengesRepository } from '@stardust/core/challenging/interfaces'
+import { UpdateChallengeUseCase } from '@stardust/core/challenging/use-cases'
+import type { Http } from '@stardust/core/global/interfaces'
+import type { RestResponse } from '@stardust/core/global/responses'
+import { IdFaker } from '@stardust/core/global/structures/fakers'
+
+import { UpdateChallengeController } from '../UpdateChallengeController'
+
+describe('Update Challenge Controller', () => {
+  type Schema = {
+    routeParams: {
+      challengeId: string
+    }
+    body: ReturnType<typeof ChallengesFaker.fakeDto>
+  }
+
+  let http: Mock<Http<Schema>>
+  let repository: Mock<ChallengesRepository>
+  let controller: UpdateChallengeController
+
+  beforeEach(() => {
+    jest.restoreAllMocks()
+    http = mock()
+    repository = mock()
+    controller = new UpdateChallengeController(repository)
+  })
+
+  it('should set route id on dto, update challenge and send response', async () => {
+    const challengeId = IdFaker.fake().value
+    const challengeDto = ChallengesFaker.fakeDto()
+    const updatedChallengeDto = ChallengesFaker.fakeDto({ id: challengeId })
+    const restResponse = mock<RestResponse>()
+
+    http.getRouteParams.mockReturnValue({ challengeId })
+    http.getBody.mockResolvedValue(challengeDto)
+    http.send.mockReturnValue(restResponse)
+
+    const executeSpy = jest
+      .spyOn(UpdateChallengeUseCase.prototype, 'execute')
+      .mockResolvedValue(updatedChallengeDto)
+
+    const response = await controller.handle(http)
+
+    expect(challengeDto.id).toBe(challengeId)
+    expect(executeSpy).toHaveBeenCalledWith({ challengeDto })
+    expect(http.send).toHaveBeenCalledWith(updatedChallengeDto)
+    expect(response).toBe(restResponse)
+  })
+})

--- a/apps/server/src/rest/controllers/challenging/challenges/tests/VoteChallengeController.test.ts
+++ b/apps/server/src/rest/controllers/challenging/challenges/tests/VoteChallengeController.test.ts
@@ -1,0 +1,62 @@
+import { mock, type Mock } from 'ts-jest-mocker'
+
+import type { ChallengesRepository } from '@stardust/core/challenging/interfaces'
+import { VoteChallengeUseCase } from '@stardust/core/challenging/use-cases'
+import type { Http } from '@stardust/core/global/interfaces'
+import type { RestResponse } from '@stardust/core/global/responses'
+import { IdFaker } from '@stardust/core/global/structures/fakers'
+
+import { VoteChallengeController } from '../VoteChallengeController'
+
+describe('Vote Challenge Controller', () => {
+  type Schema = {
+    routeParams: {
+      challengeId: string
+    }
+    body: {
+      challengeVote: string
+    }
+  }
+
+  let http: Mock<Http<Schema>>
+  let repository: Mock<ChallengesRepository>
+  let controller: VoteChallengeController
+
+  beforeEach(() => {
+    jest.restoreAllMocks()
+    http = mock()
+    repository = mock()
+    controller = new VoteChallengeController(repository)
+  })
+
+  it('should vote challenge with request route and body data', async () => {
+    const challengeId = IdFaker.fake().value
+    const userId = IdFaker.fake().value
+    const challengeVote = 'upvote'
+    const voteResponse = {
+      upvotesCount: 8,
+      downvotesCount: 2,
+      userChallengeVote: challengeVote as 'upvote',
+    }
+    const restResponse = mock<RestResponse>()
+
+    http.getRouteParams.mockReturnValue({ challengeId })
+    http.getBody.mockResolvedValue({ challengeVote })
+    http.getAccount.mockResolvedValue({ id: userId } as never)
+    http.send.mockReturnValue(restResponse)
+
+    const executeSpy = jest
+      .spyOn(VoteChallengeUseCase.prototype, 'execute')
+      .mockResolvedValue(voteResponse as never)
+
+    const response = await controller.handle(http)
+
+    expect(executeSpy).toHaveBeenCalledWith({
+      challengeId,
+      challengeVote,
+      userId,
+    })
+    expect(http.send).toHaveBeenCalledWith(voteResponse)
+    expect(response).toBe(restResponse)
+  })
+})

--- a/apps/server/src/rest/controllers/challenging/challenges/tests/index.test.ts
+++ b/apps/server/src/rest/controllers/challenging/challenges/tests/index.test.ts
@@ -1,0 +1,33 @@
+import {
+  AppendChallengeRewardToBodyController,
+  DeleteChallengeController,
+  FetchAllChallengeCategoriesController,
+  FetchAllChallengesController,
+  FetchChallengeController,
+  FetchChallengesListController,
+  FetchChallengeVoteController,
+  FetchCompletedChallengesCountByDifficultyLevelController,
+  FetchPostedChallengesKpiController,
+  PostChallengeController,
+  UpdateChallengeController,
+  VerifyChallengeManagementPermissionController,
+  VoteChallengeController,
+} from '..'
+
+describe('challenging/challenges controllers barrel exports', () => {
+  it('should export all challenge controllers', () => {
+    expect(AppendChallengeRewardToBodyController).toBeDefined()
+    expect(DeleteChallengeController).toBeDefined()
+    expect(FetchAllChallengeCategoriesController).toBeDefined()
+    expect(FetchAllChallengesController).toBeDefined()
+    expect(FetchChallengeController).toBeDefined()
+    expect(FetchChallengesListController).toBeDefined()
+    expect(FetchChallengeVoteController).toBeDefined()
+    expect(FetchCompletedChallengesCountByDifficultyLevelController).toBeDefined()
+    expect(FetchPostedChallengesKpiController).toBeDefined()
+    expect(PostChallengeController).toBeDefined()
+    expect(UpdateChallengeController).toBeDefined()
+    expect(VerifyChallengeManagementPermissionController).toBeDefined()
+    expect(VoteChallengeController).toBeDefined()
+  })
+})

--- a/documentation/agents/testing-agent.md
+++ b/documentation/agents/testing-agent.md
@@ -4,34 +4,34 @@ Agente especializado em **criar e manter testes automatizados**.
 
 ## Objetivo
 
-- Criar (ou ajustar) testes para o código-fonte fornecido, cobrindo **comportamento esperado**, **cenarios relevantes** e **regressoes**.
+- Criar (ou ajustar) testes para o código-fonte fornecido, cobrindo **comportamento esperado**, **cenários relevantes** e **regressões**.
 
 ## Regras
 
 - Antes de qualquer ação, leia `documentation/rules/rules.md` e siga as regras e documentos referenciados sobre testes.
 - Seja **direto** e **objetivo**.
-- Nao altere arquivos fora do escopo do teste, exceto quando for **estritamente necessario** para viabilizar a testabilidade; nesse caso, explique o motivo e o impacto.
-- Priorize testes **deterministicos**, **legiveis** e de **facil manutencao**.
+- Não altere arquivos fora do escopo do teste, exceto quando for **estritamente necessário** para viabilizar a testabilidade; nesse caso, explique o motivo e o impacto.
+- Priorize testes **determinísticos**, **legíveis** e de **fácil manutenção**.
 - Evite `mock` desnecessario e acoplamento excessivo a detalhes de implementacao.
-- Se faltar contexto, assuma a opcao **mais segura** e registre claramente a suposicao.
+- Se faltar contexto, assuma a opção **mais segura** e registre claramente a suposição.
 
-> ⚠️ Se uma mudanca de producao for inevitavel para testar com seguranca (ex: tornar uma funcao injetavel), mantenha o patch **minimo** e justifique.
+> ⚠️ Se uma mudança de produção for inevitável para testar com segurança (ex: tornar uma função injetável), mantenha o patch **mínimo** e justifique.
 
 ## Fluxo de trabalho
 
-1. Entenda rapidamente o comportamento a ser testado (entradas, saidas, efeitos colaterais, invariantes).
-2. Leia `documentation/rules/rules.md` e identifique o padrao de testes do projeto (framework, convencoes, estrutura de pastas).
+1. Entenda rapidamente o comportamento a ser testado (entradas, saídas, efeitos colaterais, invariantes).
+2. Leia `documentation/rules/rules.md` e identifique o padrão de testes do projeto (framework, convenções, estrutura de pastas).
 3. Inspecione apenas os arquivos relevantes (codigo + testes diretamente relacionados).
 4. Crie/ajuste testes cobrindo:
    - caminho feliz (happy path)
-   - bordas e validacoes
+   - bordas e validações
    - falhas esperadas e mensagens/erros relevantes
-   - regressao (se houver bug reportado)
-5. Valide consistencia dos testes: nomes, organizacao, `assertions` e estabilidade (sem dependencia de tempo/ordem/rede).
+   - regressão (se houver bug reportado)
+5. Valide consistência dos testes: nomes, organização, `assertions` e estabilidade (sem dependência de tempo/ordem/rede).
 6. Resuma o que foi feito e os proximos passos (se houver).
 
 ## Formato da resposta
 
-- **Diagnostico:** o que precisa ser testado e principais riscos
-- **Acao:** testes criados/alterados e cobertura aplicada
-- **Resumo:** resultado e observacoes
+- **Diagnóstico:** o que precisa ser testado e principais riscos
+- **Ação:** testes criados/alterados e cobertura aplicada
+- **Resumo:** resultado e observações

--- a/documentation/agents/testing-agent.md
+++ b/documentation/agents/testing-agent.md
@@ -1,0 +1,37 @@
+# Testing Agent
+
+Agente especializado em **criar e manter testes automatizados**.
+
+## Objetivo
+
+- Criar (ou ajustar) testes para o código-fonte fornecido, cobrindo **comportamento esperado**, **cenarios relevantes** e **regressoes**.
+
+## Regras
+
+- Antes de qualquer ação, leia `documentation/rules/rules.md` e siga as regras e documentos referenciados sobre testes.
+- Seja **direto** e **objetivo**.
+- Nao altere arquivos fora do escopo do teste, exceto quando for **estritamente necessario** para viabilizar a testabilidade; nesse caso, explique o motivo e o impacto.
+- Priorize testes **deterministicos**, **legiveis** e de **facil manutencao**.
+- Evite `mock` desnecessario e acoplamento excessivo a detalhes de implementacao.
+- Se faltar contexto, assuma a opcao **mais segura** e registre claramente a suposicao.
+
+> ⚠️ Se uma mudanca de producao for inevitavel para testar com seguranca (ex: tornar uma funcao injetavel), mantenha o patch **minimo** e justifique.
+
+## Fluxo de trabalho
+
+1. Entenda rapidamente o comportamento a ser testado (entradas, saidas, efeitos colaterais, invariantes).
+2. Leia `documentation/rules/rules.md` e identifique o padrao de testes do projeto (framework, convencoes, estrutura de pastas).
+3. Inspecione apenas os arquivos relevantes (codigo + testes diretamente relacionados).
+4. Crie/ajuste testes cobrindo:
+   - caminho feliz (happy path)
+   - bordas e validacoes
+   - falhas esperadas e mensagens/erros relevantes
+   - regressao (se houver bug reportado)
+5. Valide consistencia dos testes: nomes, organizacao, `assertions` e estabilidade (sem dependencia de tempo/ordem/rede).
+6. Resuma o que foi feito e os proximos passos (se houver).
+
+## Formato da resposta
+
+- **Diagnostico:** o que precisa ser testado e principais riscos
+- **Acao:** testes criados/alterados e cobertura aplicada
+- **Resumo:** resultado e observacoes

--- a/packages/core/src/challenging/domain/entities/fakers/ChallengeCategoriesFaker.ts
+++ b/packages/core/src/challenging/domain/entities/fakers/ChallengeCategoriesFaker.ts
@@ -1,0 +1,27 @@
+import { faker } from '@faker-js/faker'
+
+import type { ChallengeCategoryDto } from '../dtos'
+import { ChallengeCategory } from '..'
+
+export class ChallengeCategoriesFaker {
+  static fake(baseDto?: Partial<ChallengeCategoryDto>): ChallengeCategory {
+    return ChallengeCategory.create(ChallengeCategoriesFaker.fakeDto(baseDto))
+  }
+
+  static fakeDto(baseDto?: Partial<ChallengeCategoryDto>): ChallengeCategoryDto {
+    return {
+      id: faker.string.uuid(),
+      name: faker.lorem.word(),
+      ...baseDto,
+    }
+  }
+
+  static fakeManyDto(
+    count?: number,
+    baseDto?: Partial<ChallengeCategoryDto>,
+  ): ChallengeCategoryDto[] {
+    return Array.from({ length: count ?? 10 }).map(() =>
+      ChallengeCategoriesFaker.fakeDto(baseDto),
+    )
+  }
+}

--- a/packages/core/src/challenging/domain/entities/fakers/index.ts
+++ b/packages/core/src/challenging/domain/entities/fakers/index.ts
@@ -1,2 +1,3 @@
 export { ChallengesFaker } from './ChallengesFaker'
 export { SolutionsFaker } from './SolutionsFaker'
+export { ChallengeCategoriesFaker } from './ChallengeCategoriesFaker'


### PR DESCRIPTION
## 🎯 Objetivo
Adicionar uma suíte de testes automatizados para os controllers REST do módulo `challenging`, reforçando a cobertura do fluxo HTTP e padronizando dados de apoio para os cenários de testes.

## 📋 Changelog
- `apps/server/src/constants/env.ts`: ajuste de constantes/variáveis de ambiente usadas pelo server.
- `apps/server/src/rest/controllers/challenging/challenges/tests/*.test.ts`: criação de testes para os controllers de challenges (fetch/list/post/update/delete/vote/kpis).
- `packages/core/src/challenging/domain/entities/fakers/ChallengeCategoriesFaker.ts`: adição de faker para categorias de challenges.
- `packages/core/src/challenging/domain/entities/fakers/index.ts`: export do novo faker.
- `documentation/agents/testing-agent.md`: documentação do agente de testes.

## 🧪 Como testar
1. `npm test:server`
2. Opcional: `npm test` (roda a suíte completa via Turbo)

## 👀 Observações
- Impacto técnico: aumenta a cobertura dos controllers REST e reduz risco de regressões em mudanças futuras no módulo.
- Riscos/efeitos colaterais: testes podem ficar sensíveis a mudanças de contrato/rotas; manter fakers e fixtures alinhados ao domínio.
