### PR TITLE
Correção do redirecionamento após sign in no Studio

### DIFF
--- a/apps/studio/src/app/middlewares/AuthMiddleware.ts
+++ b/apps/studio/src/app/middlewares/AuthMiddleware.ts
@@ -12,12 +12,18 @@ export const AuthMiddleware = async ({
 }) => {
   const accessToken = sessionStorage.getItem(SESSION_STORAGE_KEYS.accessToken)
   const isSignInRoute = request.url.endsWith(ROUTES.index)
+  const normalizedAccessToken = accessToken?.replaceAll('"', '').trim() ?? ''
+  const hasSession = Boolean(normalizedAccessToken)
 
-  if (!accessToken && !isSignInRoute) {
+  if (!hasSession && !isSignInRoute) {
     throw redirect(ROUTES.index)
   }
 
+  if (hasSession && isSignInRoute) {
+    throw redirect(ROUTES.dashboard)
+  }
+
   context.set(authContext, {
-    accessToken,
+    accessToken: normalizedAccessToken,
   })
 }

--- a/apps/studio/src/app/middlewares/AuthMiddleware.ts
+++ b/apps/studio/src/app/middlewares/AuthMiddleware.ts
@@ -11,7 +11,8 @@ export const AuthMiddleware = async ({
   context: any
 }) => {
   const accessToken = sessionStorage.getItem(SESSION_STORAGE_KEYS.accessToken)
-  const isSignInRoute = request.url.endsWith(ROUTES.index)
+  const requestPathname = new URL(request.url).pathname
+  const isSignInRoute = requestPathname === ROUTES.index
   const normalizedAccessToken = accessToken?.replaceAll('"', '').trim() ?? ''
   const hasSession = Boolean(normalizedAccessToken)
 

--- a/apps/studio/src/app/middlewares/RestMiddleware.ts
+++ b/apps/studio/src/app/middlewares/RestMiddleware.ts
@@ -74,6 +74,8 @@ export const RestMiddleware = async ({ context }: Route.ActionArgs) => {
   }
 
   if (accountResponse.isFailure) {
+    sessionStorage.removeItem(SESSION_STORAGE_KEYS.accessToken)
+    sessionStorage.removeItem(SESSION_STORAGE_KEYS.refreshToken)
     throw redirect(ROUTES.index)
   }
 

--- a/apps/studio/src/app/middlewares/RestMiddleware.ts
+++ b/apps/studio/src/app/middlewares/RestMiddleware.ts
@@ -1,7 +1,9 @@
 import type { Route } from '../+types/root'
 import { HTTP_HEADERS } from '@stardust/core/global/constants'
+import { HTTP_STATUS_CODE } from '@stardust/core/global/constants'
+import { Text } from '@stardust/core/global/structures'
 
-import { ENV, ROUTES } from '@/constants'
+import { ENV, ROUTES, SESSION_STORAGE_KEYS } from '@/constants'
 import { AxiosRestClient } from '@/rest/axios/AxiosRestClient'
 import {
   AuthService,
@@ -20,19 +22,58 @@ import { redirect } from 'react-router'
 
 export const RestMiddleware = async ({ context }: Route.ActionArgs) => {
   const { accessToken } = context.get(authContext)
+  const refreshToken = sessionStorage.getItem(SESSION_STORAGE_KEYS.refreshToken)
+
+  const normalizedAccessToken = accessToken.replaceAll('"', '').trim()
+  const normalizedRefreshToken = refreshToken?.replaceAll('"', '').trim() ?? ''
   const restClient = AxiosRestClient()
   restClient.setBaseUrl(ENV.stardustServerUrl)
 
-  restClient.setHeader(
-    HTTP_HEADERS.authorization,
-    `Bearer ${accessToken.replaceAll('"', '')}`,
-  )
+  restClient.setHeader(HTTP_HEADERS.authorization, `Bearer ${normalizedAccessToken}`)
 
   const authService = AuthService(restClient)
-  const response = await authService.fetchAccount()
-  const hasSession = response.isSuccessful
+  let accountResponse = await authService.fetchAccount()
 
-  if (!hasSession) {
+  const shouldTryRefresh =
+    accountResponse.statusCode === HTTP_STATUS_CODE.unauthorized &&
+    Boolean(normalizedRefreshToken)
+
+  if (shouldTryRefresh) {
+    const refreshResponse = await authService.refreshSession(
+      Text.create(normalizedRefreshToken),
+    )
+
+    if (refreshResponse.isSuccessful) {
+      sessionStorage.setItem(
+        SESSION_STORAGE_KEYS.accessToken,
+        JSON.stringify(refreshResponse.body.accessToken),
+      )
+      sessionStorage.setItem(
+        SESSION_STORAGE_KEYS.refreshToken,
+        JSON.stringify(refreshResponse.body.refreshToken),
+      )
+
+      restClient.setHeader(
+        HTTP_HEADERS.authorization,
+        `Bearer ${refreshResponse.body.accessToken}`,
+      )
+
+      context.set(authContext, {
+        accessToken: refreshResponse.body.accessToken,
+      })
+
+      accountResponse = await authService.fetchAccount()
+    }
+  }
+
+  if (
+    accountResponse.isFailure &&
+    accountResponse.statusCode !== HTTP_STATUS_CODE.unauthorized
+  ) {
+    accountResponse.throwError()
+  }
+
+  if (accountResponse.isFailure) {
     throw redirect(ROUTES.index)
   }
 

--- a/apps/studio/src/constants/session-storage-keys.ts
+++ b/apps/studio/src/constants/session-storage-keys.ts
@@ -1,3 +1,4 @@
 export const SESSION_STORAGE_KEYS = {
   accessToken: '@stardust/studio/access-token',
+  refreshToken: '@stardust/studio/refresh-token',
 }

--- a/apps/studio/src/ui/auth/widgets/pages/SignIn/SignInForm/tests/useSignInForm.test.ts
+++ b/apps/studio/src/ui/auth/widgets/pages/SignIn/SignInForm/tests/useSignInForm.test.ts
@@ -1,0 +1,118 @@
+import { act, renderHook } from '@testing-library/react'
+import { mock, type Mock } from 'ts-jest-mocker'
+import { useSessionStorage } from 'usehooks-ts'
+
+import type { AuthService } from '@stardust/core/auth/interfaces'
+import type { NavigationProvider, ToastProvider } from '@stardust/core/global/interfaces'
+import { RestResponse } from '@stardust/core/global/responses'
+import { SessionFaker } from '@stardust/core/auth/structures/fakers'
+
+import { ROUTES, SESSION_STORAGE_KEYS } from '@/constants'
+
+import { useSignInForm } from '../useSignInForm'
+
+jest.mock('usehooks-ts', () => ({
+  useSessionStorage: jest.fn(),
+}))
+
+describe('useSignInForm', () => {
+  let authService: Mock<AuthService>
+  let toastProvider: Mock<ToastProvider>
+  let navigationProvider: Mock<NavigationProvider>
+  let setAccessToken: jest.Mock
+  let setRefreshToken: jest.Mock
+
+  const Hook = () =>
+    renderHook(() =>
+      useSignInForm({
+        authService,
+        toastProvider,
+        navigationProvider,
+      }),
+    )
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    authService = mock<AuthService>()
+    toastProvider = mock<ToastProvider>()
+    navigationProvider = mock<NavigationProvider>()
+
+    toastProvider.showSuccess = jest.fn()
+    toastProvider.showError = jest.fn()
+    navigationProvider.goTo = jest.fn()
+
+    setAccessToken = jest.fn()
+    setRefreshToken = jest.fn()
+
+    jest.mocked(useSessionStorage).mockImplementation(((key: string) => {
+      if (key === SESSION_STORAGE_KEYS.accessToken) return ['', setAccessToken, jest.fn()]
+      if (key === SESSION_STORAGE_KEYS.refreshToken)
+        return ['', setRefreshToken, jest.fn()]
+
+      return ['', jest.fn(), jest.fn()]
+    }) as unknown as typeof useSessionStorage)
+  })
+
+  it('should persist tokens, show success toast and navigate to dashboard on successful sign in', async () => {
+    const session = SessionFaker.fakeDto()
+
+    authService.signInGodAccount.mockResolvedValue(
+      new RestResponse({
+        statusCode: 200,
+        body: {
+          ...session,
+          accessToken: 'access-token',
+          refreshToken: 'refresh-token',
+        },
+      }),
+    )
+
+    const { result } = Hook()
+
+    act(() => {
+      result.current.form.setValue('email', 'admin@stardust.dev')
+      result.current.form.setValue('password', '123456')
+    })
+
+    await act(async () => {
+      await result.current.handleSubmit()
+    })
+
+    expect(authService.signInGodAccount).toHaveBeenCalledWith(
+      expect.objectContaining({ value: 'admin@stardust.dev' }),
+      expect.objectContaining({ value: '123456' }),
+    )
+    expect(toastProvider.showSuccess).toHaveBeenCalledWith('Login realizado com sucesso')
+    expect(setAccessToken).toHaveBeenCalledWith('access-token')
+    expect(setRefreshToken).toHaveBeenCalledWith('refresh-token')
+    expect(navigationProvider.goTo).toHaveBeenCalledWith(ROUTES.dashboard)
+    expect(toastProvider.showError).not.toHaveBeenCalled()
+  })
+
+  it('should show error toast when sign in fails', async () => {
+    authService.signInGodAccount.mockResolvedValue(
+      new RestResponse({
+        statusCode: 401,
+        errorMessage: 'Credenciais inválidas',
+      }),
+    )
+
+    const { result } = Hook()
+
+    act(() => {
+      result.current.form.setValue('email', 'admin@stardust.dev')
+      result.current.form.setValue('password', '123456')
+    })
+
+    await act(async () => {
+      await result.current.handleSubmit()
+    })
+
+    expect(toastProvider.showError).toHaveBeenCalledWith('Credenciais inválidas')
+    expect(setAccessToken).not.toHaveBeenCalled()
+    expect(setRefreshToken).not.toHaveBeenCalled()
+    expect(navigationProvider.goTo).not.toHaveBeenCalled()
+    expect(toastProvider.showSuccess).not.toHaveBeenCalled()
+  })
+})

--- a/apps/studio/src/ui/auth/widgets/pages/SignIn/SignInForm/useSignInForm.ts
+++ b/apps/studio/src/ui/auth/widgets/pages/SignIn/SignInForm/useSignInForm.ts
@@ -33,7 +33,8 @@ export function useSignInForm({
     resolver: zodResolver(formSchema),
     mode: 'onSubmit',
   })
-  const [_, setAccessToken] = useSessionStorage(SESSION_STORAGE_KEYS.accessToken, '')
+  const [, setAccessToken] = useSessionStorage(SESSION_STORAGE_KEYS.accessToken, '')
+  const [, setRefreshToken] = useSessionStorage(SESSION_STORAGE_KEYS.refreshToken, '')
 
   async function handleSubmit(data: SignInFormData) {
     const response = await authService.signInGodAccount(
@@ -44,6 +45,7 @@ export function useSignInForm({
     if (response.isSuccessful) {
       toastProvider.showSuccess('Login realizado com sucesso')
       setAccessToken(response.body.accessToken)
+      setRefreshToken(response.body.refreshToken)
       navigationProvider.goTo(ROUTES.dashboard)
     }
 

--- a/apps/studio/src/ui/global/widgets/layouts/App/Header/SignOutButton/index.tsx
+++ b/apps/studio/src/ui/global/widgets/layouts/App/Header/SignOutButton/index.tsx
@@ -8,11 +8,15 @@ import { useSessionStorage } from 'usehooks-ts'
 export const SignOutButton = () => {
   const { authService } = useRestContext()
   const navigationProvider = useNavigationProvider()
-  const [_, setAccessToken] = useSessionStorage(SESSION_STORAGE_KEYS.accessToken, '')
+  const [, setAccessToken] = useSessionStorage(SESSION_STORAGE_KEYS.accessToken, '')
+  const [, setRefreshToken] = useSessionStorage(SESSION_STORAGE_KEYS.refreshToken, '')
   const { handleClick } = useSignOutButton({
     authService,
     navigationProvider,
-    onSignOut: () => setAccessToken(''),
+    onSignOut: () => {
+      setAccessToken('')
+      setRefreshToken('')
+    },
   })
 
   return <SignOutButtonView onClick={handleClick} />

--- a/apps/studio/src/ui/global/widgets/layouts/App/Header/SignOutButton/tests/SignOutButtonView.test.tsx
+++ b/apps/studio/src/ui/global/widgets/layouts/App/Header/SignOutButton/tests/SignOutButtonView.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { SignOutButtonView } from '../SignOutButtonView'
+
+jest.mock('@/ui/global/widgets/components/Icon', () => ({
+  Icon: () => <span data-testid='sign-out-icon' />,
+}))
+
+jest.mock('@/ui/shadcn/components/dropdown-menu', () => ({
+  DropdownMenuItem: ({
+    children,
+    onClick,
+  }: {
+    children: React.ReactNode
+    onClick: () => void
+  }) => (
+    <button onClick={onClick} type='button'>
+      {children}
+    </button>
+  ),
+}))
+
+describe('SignOutButtonView', () => {
+  it('should render label and call onClick when clicked', async () => {
+    const user = userEvent.setup()
+    const onClick = jest.fn()
+
+    render(<SignOutButtonView onClick={onClick} />)
+
+    expect(screen.getByText('Sign out')).toBeInTheDocument()
+    expect(screen.getByTestId('sign-out-icon')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Sign out' }))
+
+    expect(onClick).toHaveBeenCalled()
+  })
+})

--- a/apps/studio/src/ui/global/widgets/layouts/App/Header/SignOutButton/tests/useSignOutButton.test.ts
+++ b/apps/studio/src/ui/global/widgets/layouts/App/Header/SignOutButton/tests/useSignOutButton.test.ts
@@ -1,0 +1,48 @@
+import { act, renderHook } from '@testing-library/react'
+import { mock, type Mock } from 'ts-jest-mocker'
+
+import type { AuthService } from '@stardust/core/auth/interfaces'
+import type { NavigationProvider } from '@stardust/core/global/interfaces'
+import { RestResponse } from '@stardust/core/global/responses'
+
+import { ROUTES } from '@/constants'
+
+import { useSignOutButton } from '../useSignOutButton'
+
+describe('useSignOutButton', () => {
+  let authService: Mock<AuthService>
+  let navigationProvider: Mock<NavigationProvider>
+  let onSignOut: jest.Mock
+
+  const Hook = () =>
+    renderHook(() =>
+      useSignOutButton({
+        authService,
+        navigationProvider,
+        onSignOut,
+      }),
+    )
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    authService = mock<AuthService>()
+    navigationProvider = mock<NavigationProvider>()
+    onSignOut = jest.fn()
+
+    authService.signOut.mockResolvedValue(new RestResponse({ statusCode: 200 }))
+    navigationProvider.goTo = jest.fn()
+  })
+
+  it('should sign out, clear local session and navigate to index', async () => {
+    const { result } = Hook()
+
+    await act(async () => {
+      await result.current.handleClick()
+    })
+
+    expect(authService.signOut).toHaveBeenCalled()
+    expect(onSignOut).toHaveBeenCalled()
+    expect(navigationProvider.goTo).toHaveBeenCalledWith(ROUTES.index)
+  })
+})

--- a/documentation/features/auth/sign-in/prd.md
+++ b/documentation/features/auth/sign-in/prd.md
@@ -1,1 +1,42 @@
-https://github.com/JohnPetros/stardust/milestone/20
+# PRD - Sign In
+
+## Contexto
+Garantir que o fluxo de entrada no StarDust Studio seja confiavel desde a autenticacao ate a abertura do dashboard, evitando retorno indevido para a tela inicial logo apos um login bem-sucedido.
+
+Referencia de produto: https://github.com/JohnPetros/stardust/milestone/20
+
+## Objetivos
+- Reduzir falhas perceptiveis no primeiro acesso autenticado ao Studio.
+- Reaproveitar a sessao criada no sign in sem exigir uma nova tentativa do usuario.
+- Tornar a navegacao entre rota publica e rota privada consistente quando ja existir sessao ativa.
+- Melhorar a recuperacao de sessao no bootstrap autenticado do Studio usando o contrato ja disponivel no backend.
+
+## Escopo entregue
+- Studio UI: o login agora persiste `accessToken` e `refreshToken`, permitindo recuperacao de sessao no carregamento do dashboard.
+- Studio App: a rota `/` redireciona usuarios ja autenticados para `/dashboard`, evitando permanencia indevida na tela de sign in.
+- Studio App: a validacao inicial de sessao no dashboard tenta recuperar a autenticacao com `refreshToken` antes de encerrar a sessao e voltar para `/`.
+- Studio App: o sign out passou a limpar tambem o `refreshToken`, encerrando a sessao local de forma completa.
+
+## Checklist de requisitos
+- [x] Persistir `refreshToken` junto com o `accessToken` no sucesso do sign in do Studio.
+- [x] Redirecionar para o dashboard quando um usuario autenticado acessar a rota `/`.
+- [x] Tentar refresh de sessao quando a validacao inicial de `/auth/account` falhar com erro de autenticacao e houver `refreshToken` disponivel.
+- [x] Atualizar a sessao local com os tokens retornados pelo refresh antes de repetir a validacao da conta.
+- [x] Redirecionar para `/` apenas quando a autenticacao falhar de forma definitiva.
+- [x] Limpar `accessToken` e `refreshToken` no sign out do Studio.
+
+## Decisoes finais de implementacao
+- O Studio reutiliza o contrato existente de `refreshSession`, sem introduzir novo endpoint ou novo service.
+- A recuperacao de sessao fica concentrada no bootstrap autenticado do Studio, preservando a UI de login simples.
+- O fluxo de logout foi ajustado para limpar os dois tokens locais e evitar sobras de sessao entre navegacoes.
+
+## Validacao final
+- [x] `npm run codecheck` na raiz.
+- [x] `npm run typecheck` na raiz.
+- [x] `npm run test` na raiz.
+
+## Status
+**Concluido**
+
+## Ultima atualizacao
+2026-04-06

--- a/documentation/features/auth/sign-in/reports/after-sign-in-error-bug-report.md
+++ b/documentation/features/auth/sign-in/reports/after-sign-in-error-bug-report.md
@@ -1,7 +1,7 @@
 ---
 title: After sign in error bug report
 status: closed
-prd: documentation/features/auth/sign-in/prd.md
+prd: https://github.com/JohnPetros/stardust/milestone/20
 last_updated: 06/02/2026
 ---
 

--- a/documentation/features/auth/sign-in/reports/sign-in-redirection-failed-bug-report.md
+++ b/documentation/features/auth/sign-in/reports/sign-in-redirection-failed-bug-report.md
@@ -1,0 +1,87 @@
+---
+title: Falha no redirecionamento apos sign in no Studio
+apps: studio
+status: closed
+last_updated_at: 2026-04-06
+---
+
+# Bug Report: Falha no redirecionamento apos sign in no Studio
+
+## Problema Identificado
+
+Após um sign in bem-sucedido no Studio, o usuário recebe feedback de sucesso, mas em parte das tentativas não permanece na navegação para a home autenticada. Em vez de concluir a entrada em `/dashboard`, a aplicação volta para `/`, fazendo a tela de sign in parecer ter sido recarregada.
+
+## Causas
+
+- O fluxo de sucesso em `apps/studio/src/ui/auth/widgets/pages/SignIn/SignInForm/useSignInForm.ts` considera o login concluído assim que recebe `accessToken`, grava esse valor em `sessionStorage` e navega imediatamente para `ROUTES.dashboard`.
+- A rota de destino depende de uma segunda validação obrigatória em `apps/studio/src/app/middlewares/RestMiddleware.ts`, que chama `/auth/account` e redireciona para `/` em qualquer falha, sem retry, sem refresh de sessão e sem expor o motivo ao usuário.
+- O Studio já possui contrato para `refreshSession` em `apps/studio/src/rest/services/AuthService.ts`, mas não persiste nem reutiliza `refreshToken` em nenhum ponto do fluxo de autenticação.
+- Hipótese principal: a intermitência ocorre quando a validação imediata de `/auth/account` falha logo após o sign in por estado transitório de autenticação ou erro temporário de rede/API; como o middleware trata toda falha como logout, a navegação retorna para a tela inicial.
+
+## Contexto e Análise
+
+### Camada UI
+
+- **Arquivo:** `apps/studio/src/app/routes/SignInRoute.tsx`
+- **Diagnóstico:** Este é o ponto de entrada da feature. A rota pública renderiza a página de sign in, mas não possui lógica para redirecionar um usuário já autenticado para a home do Studio.
+
+- **Arquivo:** `apps/studio/src/ui/auth/widgets/pages/SignIn/SignInForm/useSignInForm.ts`
+- **Diagnóstico:** O hook grava apenas `response.body.accessToken` em `sessionStorage`, exibe toast de sucesso e chama `navigationProvider.goTo(ROUTES.dashboard)`. O fluxo ignora `response.body.refreshToken`, embora o contrato de `SessionDto` o forneça.
+
+- **Arquivo:** `apps/studio/src/ui/global/hooks/useNavigationProvider.ts`
+- **Diagnóstico:** A navegação pós-login é client-side via `navigate(route)`, portanto o sucesso percebido pelo usuário depende integralmente dos middlewares da rota de destino aceitarem a sessão recém-criada.
+
+### Camada Aplicação Studio
+
+- **Arquivo:** `apps/studio/src/app/routes/DashboardRoute.tsx`
+- **Diagnóstico:** `/dashboard` é a primeira rota privada após o sign in e sempre executa `AuthMiddleware` e `RestMiddleware`, o que transforma a abertura da home em uma segunda etapa obrigatória de validação da sessão.
+
+- **Arquivo:** `apps/studio/src/app/middlewares/AuthMiddleware.ts`
+- **Diagnóstico:** O middleware lê o token bruto de `sessionStorage` e apenas verifica sua presença para liberar a rota privada. Ele não diferencia token recém-criado, token expirado ou token inválido, e também não redireciona usuários autenticados quando a rota atual é `/`.
+
+- **Arquivo:** `apps/studio/src/app/middlewares/RestMiddleware.ts`
+- **Diagnóstico:** O middleware monta o `RestClient`, injeta o header `Authorization`, chama `authService.fetchAccount()` e executa `throw redirect(ROUTES.index)` em qualquer resposta malsucedida. Esse ponto concentra a falha percebida pelo usuário, porque converte toda indisponibilidade temporária ou falha de autenticação em retorno silencioso para a tela de sign in.
+
+- **Arquivo:** `apps/studio/src/rest/services/AuthService.ts`
+- **Diagnóstico:** A camada REST já expõe `signInGodAccount`, `fetchAccount` e `refreshSession`, mas a aplicação Studio usa apenas a primeira chamada no bootstrap do login e descarta o mecanismo de recuperação já previsto no contrato.
+
+### Camada Server/Auth
+
+- **Arquivo:** `apps/server/src/app/hono/HonoApp.ts`
+- **Diagnóstico:** O servidor cria o client do Supabase a partir do header `Authorization` e deriva `account` do JWT recebido. Isso confirma que o ponto de verdade da sessão autenticada no Studio depende do token enviado pelo cliente para a API.
+
+- **Arquivo:** `apps/server/src/rest/services/SupabaseAuthService.ts`
+- **Diagnóstico:** `fetchAccount()` usa `supabase.auth.getUser()` e responde `401` para cenários como `no_authorization`, `bad_jwt` e `session_expired`. O comportamento do Studio hoje colapsa todos esses casos em um único redirecionamento para `/`, sem tentativa de recuperação.
+
+- **Arquivo:** `packages/core/src/auth/domain/structures/dtos/SessionDto.ts`
+- **Diagnóstico:** O contrato de sessão inclui `accessToken` e `refreshToken`. O Studio consome apenas parte do DTO, ficando inconsistente com a capacidade de refresh já suportada pela arquitetura.
+
+## Plano de Correção (Spec)
+
+### 1. O que já existe?
+
+- **Camada UI:** `useSignInForm` — Executa o sign in, persiste o token atual e dispara a navegação para `/dashboard`.
+- **Camada Aplicação Studio:** `AuthMiddleware` — Faz o gate inicial da rota privada usando `sessionStorage`.
+- **Camada Aplicação Studio:** `RestMiddleware` — Valida a sessão com `/auth/account` antes de popular `restContext`.
+- **Camada REST Studio:** `AuthService.refreshSession` — Contrato já disponível para recuperar sessão sem acoplar a UI ao servidor.
+- **Camada Server/Auth:** `SupabaseAuthService.fetchAccount` — Ponto de verdade da sessão autenticada consumido pelo Studio.
+- **Camada Core:** `SessionDto` — Contrato que já entrega `refreshToken` junto com `accessToken`.
+
+### 2. O que deve ser criado?
+
+- **Camada Aplicação Studio:** `SESSION_STORAGE_KEYS.refreshToken` — Chave explícita para persistir o `refreshToken` recebido no sign in.
+
+### 3. O que deve ser modificado?
+
+Liste mudanças pontuais em código existente, explicando o motivo da alteração.
+
+- **Camada UI:** `apps/studio/src/ui/auth/widgets/pages/SignIn/SignInForm/useSignInForm.ts` — Persistir também `response.body.refreshToken` e alinhar o fluxo de sucesso com o contrato completo de `SessionDto`.
+- **Camada Aplicação Studio:** `apps/studio/src/app/middlewares/RestMiddleware.ts` — Trocar o redirecionamento imediato por uma tentativa de recuperação de sessão via `authService.refreshSession(...)` quando `fetchAccount()` falhar por autenticação, atualizando o contexto apenas após a recuperação ou redirecionando somente na falha definitiva.
+- **Camada Aplicação Studio:** `apps/studio/src/app/middlewares/AuthMiddleware.ts` — Redirecionar usuários já autenticados para `ROUTES.dashboard` ao acessar `/`, evitando que um usuário com sessão válida permaneça na tela de sign in.
+- **Camada REST Studio:** `apps/studio/src/rest/services/AuthService.ts` — Reutilizar o método `refreshSession` no bootstrap de autenticação do Studio, sem criar um novo contrato REST.
+
+### 4. O que deve ser removido?
+
+Liste código redundante, legado ou incorreto que deve ser eliminado como parte da correção.
+
+- **Camada Aplicação Studio:** `apps/studio/src/app/middlewares/RestMiddleware.ts` — Remover o comportamento de tratar qualquer falha de `fetchAccount()` como redirecionamento imediato para `/`, porque ele mascara erros transitórios e quebra o fluxo de entrada mesmo após autenticação bem-sucedida.

--- a/documentation/features/auth/sign-in/specs/retry-user-creation-spec.md
+++ b/documentation/features/auth/sign-in/specs/retry-user-creation-spec.md
@@ -1,6 +1,6 @@
 ---
 title: Retry de Criacao de Usuario na Confirmacao de Conta
-prd: ../prd.md
+prd: https://github.com/JohnPetros/stardust/milestone/20
 apps: web,server
 status: closed
 last_updated_at: 2026-03-14

--- a/documentation/prompts/create-bug-report-prompt.md
+++ b/documentation/prompts/create-bug-report-prompt.md
@@ -13,6 +13,8 @@ O bug report deve:
 - Indicar **onde e por que provavelmente está quebrado**
 - Sugerir **como corrigir**, respeitando a arquitetura do projeto
 
+Após a criação do Bug Report, uma **Spec de correção** deve ser gerada automaticamente com base no plano de correção levantado, seguindo o prompt `documentation/prompts/create-spec-prompt.md`.
+
 ---
 
 ## Entrada
@@ -49,17 +51,38 @@ O bug report deve:
 
 - Determine quais camadas estão envolvidas direta ou indiretamente.
 - Sempre que possível, associe o problema a **arquivos reais** da codebase.
+- Use exclusivamente as camadas definidas abaixo:
+  - `core` — Use Cases
+  - `rest` — Controllers e Services HTTP
+  - `database` — Repositories, Mappers e Types
+  - `provision` — Providers e integrações externas
+  - `rpc` — Actions
+  - `ui` — Widgets, Stores e Contexts
+  - `ai` — Workflows e Tools
+  - `queue` — Inngest Functions
+  - `web` — Pages e Layouts Next.js
+  - `studio` — Pages e Layouts React Router
 
 ### 4. Plano de Correção
 
 - Proponha uma solução técnica **incremental e segura**, separada por camadas.
 - O plano deve ser claro o suficiente para servir como base de implementação.
 
+### 5. Geração da Spec de Correção
+
+Após salvar o Bug Report, gere automaticamente uma Spec de correção seguindo `documentation/prompts/create-spec-prompt.md`, com as seguintes adaptações:
+
+- O **esboço da tarefa** é o próprio Bug Report gerado.
+- O **PRD de referência** é o PRD da feature afetada, encontrado em `documentation/features/<dominio>/`.
+- O **frontmatter** da Spec deve referenciar o Bug Report no campo `issue`.
+- As seções **O que já existe**, **O que deve ser criado**, **O que deve ser modificado** e **O que deve ser removido** devem ser derivadas diretamente do plano de correção do Bug Report, sem retrabalho de pesquisa.
+- Salve a Spec em `documentation/features/{dominio}/specs/{nome-descritivo}-fix-spec.md`.
+
 ---
 
 ## Template de Saída (Estrutura Obrigatória)
 
-Salve o arquivo em `documentation/features/{dominio}/bug-reports/{nome-descritivo}-bug-report.md` seguindo **estritamente** o template abaixo. Não adicione seções extras nem altere os títulos.
+Salve o arquivo em `documentation/features/{dominio}/reports/{nome-descritivo}-bug-report.md` seguindo **estritamente** o template abaixo. Não adicione seções extras nem altere os títulos.
 
 ```md
 ---
@@ -81,11 +104,85 @@ last_updated_at: {YYYY-MM-DD}
 
 ## Contexto e Análise
 
-### {Nome da Camada} (ex: Camada UI, Camada Core, Camada REST, Camada Banco de Dados)
-
-<!-- Repita o bloco abaixo para cada camada afetada -->
+### Camada Core (Use Cases)
+<!-- Incluir apenas se aplicável -->
 - **Arquivo:** `{caminho/relativo/do/arquivo}`
-- **Diagnóstico:** {Explique o que está errado neste ponto, incluindo falhas de responsabilidade, fluxo, estado ou contrato.}
+- **Diagnóstico:** {Explique o que está errado neste ponto.}
+
+### Camada REST (Controllers)
+<!-- Incluir apenas se aplicável -->
+- **Arquivo:** `{caminho/relativo/do/arquivo}`
+- **Diagnóstico:** {Explique o que está errado neste ponto.}
+
+### Camada REST (Services)
+<!-- Incluir apenas se aplicável -->
+- **Arquivo:** `{caminho/relativo/do/arquivo}`
+- **Diagnóstico:** {Explique o que está errado neste ponto.}
+
+### Camada Banco de Dados (Repositories)
+<!-- Incluir apenas se aplicável -->
+- **Arquivo:** `{caminho/relativo/do/arquivo}`
+- **Diagnóstico:** {Explique o que está errado neste ponto.}
+
+### Camada Banco de Dados (Mappers)
+<!-- Incluir apenas se aplicável -->
+- **Arquivo:** `{caminho/relativo/do/arquivo}`
+- **Diagnóstico:** {Explique o que está errado neste ponto.}
+
+### Camada Banco de Dados (Types)
+<!-- Incluir apenas se aplicável -->
+- **Arquivo:** `{caminho/relativo/do/arquivo}`
+- **Diagnóstico:** {Explique o que está errado neste ponto.}
+
+### Camada Provision (Providers)
+<!-- Incluir apenas se aplicável -->
+- **Arquivo:** `{caminho/relativo/do/arquivo}`
+- **Diagnóstico:** {Explique o que está errado neste ponto.}
+
+### Camada RPC (Actions)
+<!-- Incluir apenas se aplicável -->
+- **Arquivo:** `{caminho/relativo/do/arquivo}`
+- **Diagnóstico:** {Explique o que está errado neste ponto.}
+
+### Camada UI (Widgets)
+<!-- Incluir apenas se aplicável -->
+- **Arquivo:** `{caminho/relativo/do/arquivo}`
+- **Diagnóstico:** {Explique o que está errado neste ponto.}
+
+### Camada UI (Stores)
+<!-- Incluir apenas se aplicável -->
+- **Arquivo:** `{caminho/relativo/do/arquivo}`
+- **Diagnóstico:** {Explique o que está errado neste ponto.}
+
+### Camada UI (Contexts)
+<!-- Incluir apenas se aplicável -->
+- **Arquivo:** `{caminho/relativo/do/arquivo}`
+- **Diagnóstico:** {Explique o que está errado neste ponto.}
+
+### Camada AI (Workflows)
+<!-- Incluir apenas se aplicável -->
+- **Arquivo:** `{caminho/relativo/do/arquivo}`
+- **Diagnóstico:** {Explique o que está errado neste ponto.}
+
+### Camada AI (Tools)
+<!-- Incluir apenas se aplicável -->
+- **Arquivo:** `{caminho/relativo/do/arquivo}`
+- **Diagnóstico:** {Explique o que está errado neste ponto.}
+
+### Camada Inngest App (Functions)
+<!-- Incluir apenas se aplicável -->
+- **Arquivo:** `{caminho/relativo/do/arquivo}`
+- **Diagnóstico:** {Explique o que está errado neste ponto.}
+
+### Camada Next.js App (Pages, Layouts)
+<!-- Incluir apenas se aplicável -->
+- **Arquivo:** `{caminho/relativo/do/arquivo}`
+- **Diagnóstico:** {Explique o que está errado neste ponto.}
+
+### Camada React Router App (Pages, Layouts)
+<!-- Incluir apenas se aplicável -->
+- **Arquivo:** `{caminho/relativo/do/arquivo}`
+- **Diagnóstico:** {Explique o que está errado neste ponto.}
 
 ## Plano de Correção
 
@@ -126,3 +223,7 @@ Liste código redundante, legado ou incorreto que deve ser eliminado como parte 
 - Cite sempre o arquivo do problema — sem diagnósticos genéricos sem localização.
 - Separe fato (evidência encontrada no código) de hipótese (suspeita sem confirmação).
 - Não proponha correções que violem os contratos entre camadas definidos em `documentation/rules/`.
+- Use apenas as camadas listadas na seção 3. Mapeamento de Camadas — não crie camadas arbitrárias.
+- Omita do template as camadas que não forem aplicáveis ao bug em questão.
+- A Spec de correção deve ser gerada **sempre**, sem necessidade de solicitação explícita.
+- A Spec de correção **não pode contradizer** o Bug Report — ela é uma derivação direta dele.

--- a/documentation/prompts/create-plan-prompt.md
+++ b/documentation/prompts/create-plan-prompt.md
@@ -1,4 +1,62 @@
 ---
+description: Criar um plano de implementacao estruturado em fases e tarefas a partir de uma spec tecnica ou bug report.
+---
+
+# Prompt: Criar Plano
+
+**Objetivo:** Transformar uma Spec técnica ou Bug Report em um **plano de implementação estruturado**, dividido em fases e tarefas atômicas, com dependências explícitas e resultados observáveis por tarefa. O plano deve ser diretamente acionável por um desenvolvedor ou agente de implementação.
+
+---
+
+## Entrada
+
+Exatamente um dos seguintes documentos deve ser fornecido:
+
+- **Spec técnica** (`documentation/features/{dominio}/specs/{nome}-spec.md`) — para features, refatorações ou correções com spec prévia.
+- **Bug Report** (`documentation/features/{dominio}/reports/{nome}-bug-report.md`) — para correções onde a spec foi derivada diretamente do bug report.
+
+> Se nenhum dos dois for fornecido, ou se o documento estiver incompleto, não inicie o plano. Registre a lacuna em **Pendências** e solicite o documento correto.
+
+---
+
+## Diretrizes de Execução
+
+### 1. Leitura do Documento de Entrada
+
+- Leia integralmente a Spec ou o Bug Report fornecido.
+- Identifique:
+  - Quais apps serão tocados (`server`, `web`, `studio`)
+  - Quais camadas serão envolvidas por app
+  - Dependências entre os artefatos a serem criados, modificados ou removidos
+  - Pendências ou ambiguidades que impediriam a implementação
+
+### 2. Definição de Fases
+
+- Sempre inicie pelo **core** (F1): domínio, structures e use cases.
+- Crie uma fase por app tocado (F2 para `server`, F3 para `web`, F4 para `studio`).
+- Omita fases de apps que não forem impactados pelo documento de entrada.
+- Fases de app (F2, F3, F4) só podem iniciar após F1 estar concluída e podem rodar em paralelo entre si.
+
+### 3. Definição de Tarefas
+
+- Cada tarefa deve ser **atômica** — uma única responsabilidade, um único artefato.
+- O **resultado observável** deve ser verificável sem ambiguidade (ex: "rota retorna 200 com payload X", "widget renderiza estado de erro quando Y").
+- A **camada** deve usar exclusivamente os valores: `core`, `database`, `rest`, `provision`, `rpc`, `ui`, `ai`, `queue`, `web`, `studio`.
+- As dependências entre tarefas devem refletir a ordem real de implementação.
+
+### 4. Pendências
+
+- Registre qualquer ambiguidade, informação ausente ou decisão não resolvida que possa bloquear a implementação.
+- Cada pendência deve descrever o impacto e a ação necessária para resolvê-la.
+
+---
+
+## Template de Saída (Estrutura Obrigatória)
+
+Salve o arquivo em `documentation/features/{dominio}/plans/{nome-descritivo}-plan.md` seguindo **estritamente** o template abaixo.
+
+```md
+---
 description: Criar um plano de implementacao estruturado em fases e tarefas a partir de uma spec tecnica.
 ---
 
@@ -50,7 +108,7 @@ description: Criar um plano de implementacao estruturado em fases e tarefas a pa
 - [ ] **T2.1** — <nome da tarefa>
   - **Depende de:** T1.2
   - **Resultado observavel:** <o que deve ser verdadeiro ao concluir>
-  - **Camada:** `core` | `database` | `rpc` | `rest` | `queue` | `ui`
+  - **Camada:** `core` | `database` | `rpc` | `rest` | `queue` | `provision`
 
 ---
 
@@ -65,7 +123,7 @@ description: Criar um plano de implementacao estruturado em fases e tarefas a pa
 - [ ] **T3.1** — <nome da tarefa>
   - **Depende de:** T1.2
   - **Resultado observavel:** <o que deve ser verdadeiro ao concluir>
-  - **Camada:** `core` | `database` | `rpc` | `rest` | `queue` | `ui`
+  - **Camada:** `ui` | `rpc` | `rest` | `web`
 
 ---
 
@@ -80,4 +138,16 @@ description: Criar um plano de implementacao estruturado em fases e tarefas a pa
 - [ ] **T4.1** — <nome da tarefa>
   - **Depende de:** T1.2
   - **Resultado observavel:** <o que deve ser verdadeiro ao concluir>
-  - **Camada:** `core` | `database` | `rpc` | `rest` | `queue` | `ui`
+  - **Camada:** `ui` | `rpc` | `rest` | `studio`
+```
+
+---
+
+## Restrições
+
+- O plano deve ser derivado exclusivamente do documento de entrada — não invente tarefas sem evidência na Spec ou no Bug Report.
+- Omita fases de apps que não forem mencionados no documento de entrada.
+- Use apenas as camadas definidas na seção 3. Definição de Tarefas — não crie camadas arbitrárias.
+- Cada tarefa deve ter exatamente um resultado observável verificável.
+- Não inclua tarefas de teste automatizado no plano.
+- Se o documento de entrada for um Bug Report, as tarefas devem derivar do **Plano de Correção** do bug report, não do relato do problema.


### PR DESCRIPTION
## 🎯 Objetivo
Corrigir a falha de redirecionamento após sign in no Studio, tornando a recuperação de sessão mais resiliente e evitando retorno indevido para a rota pública mesmo após autenticação bem-sucedida.

## 🐛 Causa do bug
O fluxo de login persistia apenas `accessToken` e dependia de uma validação imediata de sessão no bootstrap da rota privada. Qualquer falha nessa validação resultava em redirecionamento direto para `/`, sem tentativa de refresh usando `refreshToken`.

## #️⃣ Issues relacionadas
resolve #378 

## 📋 Changelog
- Ajustado `AuthMiddleware` para normalizar token e redirecionar usuário autenticado em `/` para `/dashboard`.
- Ajustado `RestMiddleware` para:
  - tentar `refreshSession` em `401` quando houver `refreshToken`;
  - atualizar `accessToken` e `refreshToken` em `sessionStorage` após refresh bem-sucedido;
  - revalidar conta antes de decidir redirecionamento.
- Adicionada chave `SESSION_STORAGE_KEYS.refreshToken` no Studio.
- Atualizado `useSignInForm` para persistir `refreshToken` no sucesso do login.
- Atualizado `SignOutButton` para limpar `accessToken` e `refreshToken` no logout.
- Adicionados testes de UI:
  - `useSignInForm.test.ts` (fluxo de sucesso e erro do login);
  - `useSignOutButton.test.ts` (logout + navegação);
  - `SignOutButtonView.test.tsx` (render e ação de clique).
- Atualizada documentação da feature de sign-in:
  - PRD da feature;
  - fechamento do bug report de redirecionamento;
  - consolidação de reports.
- Atualizados prompts de documentação:
  - `create-bug-report-prompt.md`;
  - `create-plan-prompt.md`.

## 🧪 Como testar
1. Executar `npm run test` na raiz e validar que todas as suítes passam.
2. Executar `npm run codecheck` na raiz e validar ausência de erros/warnings.
3. Executar `npm run typecheck` na raiz e validar zero erros de tipagem.
4. No Studio, realizar sign in com conta válida e confirmar navegação para `/dashboard`.
5. Simular sessão expirada com `refreshToken` válido e confirmar recuperação automática da sessão.
6. Executar sign out e confirmar limpeza de `accessToken` e `refreshToken` no `sessionStorage`.

## 👀 Observações
- O comportamento de recuperação foi centralizado nos middlewares de bootstrap do Studio para reaproveitar o contrato já existente de autenticação, sem introduzir novo endpoint.
- Este PR também inclui ajustes de documentação operacional (prompts) já presentes na branch.
