### PR TITLE
Corrige dados stale no editor e na pagina de desafio

### DIFF
--- a/apps/web/src/rpc/next-safe-action/challengingActions.ts
+++ b/apps/web/src/rpc/next-safe-action/challengingActions.ts
@@ -24,9 +24,7 @@ export const accessAuthenticatedChallengePage = authActionClient
       user: ctx.user,
     })
     const restClient = await NextServerRestClient({
-      isCacheEnabled: true,
-      refetchInterval: 60,
-      cacheKey: 'challenging-actions',
+      isCacheEnabled: false,
     })
     const challengingService = ChallengingService(restClient)
     const spaceService = SpaceService(restClient)
@@ -45,9 +43,7 @@ export const accessChallengePage = actionClient
       request: clientInput,
     })
     const restClient = await NextServerRestClient({
-      isCacheEnabled: true,
-      refetchInterval: 60,
-      cacheKey: 'challenging-actions',
+      isCacheEnabled: false,
     })
     const challengingService = ChallengingService(restClient)
     const spaceService = SpaceService(restClient)
@@ -67,9 +63,7 @@ export const accessChallengeEditorPage = authActionClient
       user: ctx.user,
     })
     const restClient = await NextServerRestClient({
-      isCacheEnabled: true,
-      refetchInterval: 60,
-      cacheKey: 'challenging-actions',
+      isCacheEnabled: false,
     })
     const challengingService = ChallengingService(restClient)
     const action = AccessChallengeEditorPageAction(challengingService)

--- a/apps/web/src/ui/challenging/widgets/pages/Challenge/tests/useChallengePage.test.ts
+++ b/apps/web/src/ui/challenging/widgets/pages/Challenge/tests/useChallengePage.test.ts
@@ -1,0 +1,156 @@
+import { renderHook, waitFor } from '@testing-library/react'
+
+import { Challenge } from '@stardust/core/challenging/entities'
+import { ChallengesFaker } from '@stardust/core/challenging/entities/fakers'
+import {
+  ChallengeCraftsVisibility,
+  ChallengeVote,
+} from '@stardust/core/challenging/structures'
+
+import { useChallengeStore } from '@/ui/challenging/stores/ChallengeStore'
+import { useChallengeNavigationGuard } from '@/ui/challenging/hooks/useChallengeNavigationGuard'
+import { useLocalStorage } from '@/ui/global/hooks/useLocalStorage'
+import { useNavigationProvider } from '@/ui/global/hooks/useNavigationProvider'
+import { useQueryStringParam } from '@/ui/global/hooks/useQueryStringParam'
+import { useChallengePage } from '../useChallengePage'
+
+jest.mock('@/ui/challenging/stores/ChallengeStore', () => ({
+  useChallengeStore: jest.fn(),
+}))
+jest.mock('@/ui/challenging/hooks/useChallengeNavigationGuard', () => ({
+  useChallengeNavigationGuard: jest.fn(),
+}))
+jest.mock('@/ui/global/hooks/useNavigationProvider', () => ({
+  useNavigationProvider: jest.fn(),
+}))
+jest.mock('@/ui/global/hooks/useQueryStringParam', () => ({
+  useQueryStringParam: jest.fn(),
+}))
+jest.mock('@/ui/global/hooks/useLocalStorage', () => ({
+  useLocalStorage: jest.fn(),
+}))
+
+type Params = Parameters<typeof useChallengePage>[0]
+
+describe('useChallengePage', () => {
+  const setChallenge = jest.fn()
+  const setPanelsLayout = jest.fn()
+  const setActiveContent = jest.fn()
+  const setCraftsVislibility = jest.fn()
+  const resetStore = jest.fn()
+  const goTo = jest.fn()
+  const requestNavigation = jest.fn()
+  const confirmNavigation = jest.fn()
+  const cancelNavigation = jest.fn()
+  const removeLocalStorageItem = jest.fn()
+
+  const craftsVislibility = ChallengeCraftsVisibility.create({
+    canShowComments: true,
+    canShowSolutions: false,
+  })
+
+  const challengeDto = ChallengesFaker.fakeDto({
+    id: 'c07445ed-ee93-48dc-a84f-7d4f5e2f6f4d',
+    title: 'Find Sum',
+    slug: 'find-sum',
+    description: 'Current challenge description',
+    code: 'function sum(a, b) { return a + b }',
+    difficultyLevel: 'easy',
+    categories: [],
+  })
+
+  const Hook = (params?: Partial<Params>) =>
+    renderHook(() =>
+      useChallengePage({
+        challengeDto,
+        userChallengeVote: 'upvote',
+        previousChallengeSlug: null,
+        nextChallengeSlug: null,
+        user: null,
+        isAccountAuthenticated: false,
+        ...params,
+      }),
+    )
+
+  function setupStore(challenge: Challenge | null) {
+    jest.mocked(useChallengeStore).mockReturnValue({
+      getChallengeSlice: () => ({
+        challenge,
+        setChallenge,
+      }),
+      getCraftsVisibilitySlice: () => ({
+        craftsVislibility,
+        setCraftsVislibility,
+      }),
+      getActiveContentSlice: () => ({
+        activeContent: 'description',
+        setActiveContent,
+      }),
+      getPanelsLayoutSlice: () => ({
+        panelsLayout: 'tabs-left;code_editor-right',
+        setPanelsLayout,
+      }),
+      resetStore,
+    } as unknown as ReturnType<typeof useChallengeStore>)
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    setupStore(null)
+
+    jest.mocked(useNavigationProvider).mockReturnValue({
+      goTo,
+      goBack: jest.fn(),
+      refresh: jest.fn(),
+      openExternal: jest.fn(),
+      currentRoute: '/challenging/challenges/find-sum',
+    } as ReturnType<typeof useNavigationProvider>)
+
+    jest.mocked(useQueryStringParam).mockReturnValue(['', jest.fn()])
+
+    jest.mocked(useLocalStorage).mockReturnValue({
+      get: jest.fn(),
+      set: jest.fn(),
+      has: jest.fn(),
+      remove: removeLocalStorageItem,
+    } as ReturnType<typeof useLocalStorage>)
+
+    jest.mocked(useChallengeNavigationGuard).mockReturnValue({
+      requestNavigation,
+      confirmNavigation,
+      cancelNavigation,
+      isDirty: jest.fn().mockReturnValue(false),
+    })
+  })
+
+  it('should rehydrate challenge store when payload is stale, including same slug updates', async () => {
+    const staleChallenge = Challenge.create({
+      ...challengeDto,
+      description: 'Stale description',
+      code: 'function sum() { return 0 }',
+    })
+    staleChallenge.userVote = ChallengeVote.create('none')
+    setupStore(staleChallenge)
+
+    Hook()
+
+    await waitFor(() => expect(setChallenge).toHaveBeenCalledTimes(1))
+
+    const hydratedChallenge = setChallenge.mock.calls[0][0] as Challenge
+
+    expect(hydratedChallenge.description.value).toBe(challengeDto.description)
+    expect(hydratedChallenge.code).toBe(challengeDto.code)
+    expect(hydratedChallenge.userVote.value).toBe('upvote')
+  })
+
+  it('should preserve client-side challenge state when payload is stable', () => {
+    const stableChallenge = Challenge.create(challengeDto)
+    stableChallenge.userVote = ChallengeVote.create('upvote')
+    setupStore(stableChallenge)
+
+    Hook()
+
+    expect(setChallenge).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/ui/challenging/widgets/pages/Challenge/useChallengePage.ts
+++ b/apps/web/src/ui/challenging/widgets/pages/Challenge/useChallengePage.ts
@@ -29,6 +29,60 @@ type Params = {
   isAccountAuthenticated: boolean
 }
 
+type HydrationComparablePayload = {
+  id: string | null
+  title: string
+  code: string
+  difficultyLevel: string
+  description: string
+  starId: string | null
+  isPublic: boolean
+  downvotesCount: number
+  upvotesCount: number
+  completionCount: number
+  categories: ChallengeDto['categories']
+  testCases: ChallengeDto['testCases']
+  userChallengeVote: string
+}
+
+function toHydrationComparablePayload(
+  challengeDto: ChallengeDto,
+  userChallengeVote: string,
+): HydrationComparablePayload {
+  return {
+    id: challengeDto.id ?? null,
+    title: challengeDto.title,
+    code: challengeDto.code,
+    difficultyLevel: challengeDto.difficultyLevel,
+    description: challengeDto.description,
+    starId: challengeDto.starId ? challengeDto.starId : null,
+    isPublic: challengeDto.isPublic ?? false,
+    downvotesCount: challengeDto.downvotesCount ?? 0,
+    upvotesCount: challengeDto.upvotesCount ?? 0,
+    completionCount: challengeDto.completionCount ?? 0,
+    categories: challengeDto.categories,
+    testCases: challengeDto.testCases,
+    userChallengeVote,
+  }
+}
+
+function shouldHydrateChallenge(
+  challengeDto: ChallengeDto,
+  userChallengeVote: string,
+  currentChallenge: Challenge | null,
+) {
+  if (!currentChallenge) return true
+
+  const incomingPayload = JSON.stringify(
+    toHydrationComparablePayload(challengeDto, userChallengeVote),
+  )
+  const currentPayload = JSON.stringify(
+    toHydrationComparablePayload(currentChallenge.dto, currentChallenge.userVote.value),
+  )
+
+  return incomingPayload !== currentPayload
+}
+
 export function useChallengePage({
   challengeDto,
   userChallengeVote,
@@ -98,7 +152,7 @@ export function useChallengePage({
   }
 
   useEffect(() => {
-    if (!challenge) {
+    if (shouldHydrateChallenge(challengeDto, userChallengeVote, challenge)) {
       const challenge = Challenge.create(challengeDto)
       challenge.userVote = ChallengeVote.create(userChallengeVote)
       setChallenge(challenge)

--- a/documentation/architecture.md
+++ b/documentation/architecture.md
@@ -14,10 +14,6 @@ O StarDust usa uma arquitetura **Hexagonal (Ports and Adapters)** onde o pacote 
 - **Email (`packages/email/`)**: Templates de e-mail construidos com React Email para envio de e-mails.
 - **LSP (`packages/lsp/`)**: Implementação da Linguagem de Programação Delegua para análise e execução de código.
 
-## Injeção de Dependências
-
-O `@stardust/core` define interfaces (Repositories, Gateways, Jobs). As apps implementam e injetam essas interfaces em runtime — nunca o Core conhece as implementações.
-
 ## Fluxo de Dados (resumo)
 
 **RPC**: Route/Controller → Action.execute(call) → Use Case → call.redirect() ou call.json()
@@ -44,14 +40,6 @@ O `@stardust/core` define interfaces (Repositories, Gateways, Jobs). As apps imp
 - TurboRepo garante compartilhamento de código e orquestração de scripts entre as apps.
 - TypeScript estrito em todo o projeto para máxima segurança de tipos.
 
-## Armadilhas a Evitar
-
-1. Importar código de Apps dentro do Core.
-2. Chamar banco de dados ou APIs diretamente em Use Cases (use interfaces/gateways).
-3. Lógica de negócio fora do `core/`.
-4. Usar `new Class()` diretamente — prefira Factory Functions.
-5. Dependências circulares entre pacotes do monorepo.
-
 ## Stack Tecnológica
 
 | Tecnologia | Pacote/Ferramenta | Finalidade |
@@ -68,7 +56,7 @@ O `@stardust/core` define interfaces (Repositories, Gateways, Jobs). As apps imp
 | **Linter/Formatter** | Biome | Qualidade e padronização de código |
 | **Testes** | Jest | Testes unitários e de integração |
 
-## Estrutura de Diretórios
+## Estrutura de Diretórios Geral
 
 ```
 stardust/

--- a/documentation/features/challenging/challenge-editor/reports/challenge-editor-stale-data-after-update-bug-report.md
+++ b/documentation/features/challenging/challenge-editor/reports/challenge-editor-stale-data-after-update-bug-report.md
@@ -1,0 +1,125 @@
+---
+title: Challenge Editor stale data after update
+apps: web
+status: closed
+last_updated_at: 2026-04-22
+---
+
+# Bug Report: Challenge Editor stale data after update
+
+## Problema Identificado
+
+Ao editar um desafio existente, a atualizacao e persistida com sucesso, mas a pagina final do desafio continua exibindo os dados antigos quando o titulo permanece inalterado. Na pratica, mudancas em descricao, codigo, casos de teste, categorias e visibilidade nao aparecem apos o redirecionamento, embora o fluxo de submit conclua sem erro.
+
+## Causas
+
+- Estado stale na camada client: a pagina do desafio reutiliza um `challenge` salvo em store compartilhada e nao o substitui quando recebe um `challengeDto` mais recente.
+- Hidratacao condicional no hook da pagina do desafio: `setChallenge(...)` so ocorre quando o estado atual esta vazio.
+- O redirecionamento pos-update volta para a mesma rota quando a `slug` nao muda, o que aumenta a chance de reaproveitamento do estado antigo sem reinicializacao.
+- Cache de leitura na camada RPC/Next: as actions server-side de acesso a pagina de desafio e de acesso ao editor usavam `NextServerRestClient` com `isCacheEnabled: true`, `refetchInterval: 60` e `cacheKey: 'challenging-actions'`, permitindo retorno de snapshot stale por ate 60s apos update.
+
+## Contexto e Analise
+
+### Camada Core (Use Cases)
+- **Arquivo:** `packages/core/src/challenging/use-cases/UpdateChallengeUseCase.ts`
+- **Diagnostico:** O caso de uso reconstrui a entidade completa, valida duplicidade apenas quando o titulo muda e delega `replace(challenge)` ao repositorio. Nao ha evidencia de regra que descarte alteracoes em campos diferentes de `title`, o que indica que a origem do bug nao esta no core.
+
+### Camada REST (Controllers)
+- **Arquivo:** `apps/server/src/rest/controllers/challenging/challenges/UpdateChallengeController.ts`
+- **Diagnostico:** O controller sobrescreve `challengeDto.id` com o parametro de rota e delega integralmente ao `UpdateChallengeUseCase`. Nao existe filtro condicional por `title`, reforcando que o backend nao aparenta ser o ponto de falha.
+
+### Camada REST (Services)
+- **Arquivo:** `apps/web/src/rest/services/ChallengingService.ts`
+- **Diagnostico:** O service envia `PUT /challenging/challenges/:challengeId` com `challenge.dto` completo. O contrato de transporte ja contempla todos os campos editaveis e nao introduz nenhuma restricao ligada ao titulo.
+
+### Camada Banco de Dados (Repositories)
+- **Arquivo:** `apps/server/src/database/supabase/repositories/challenging/SupabaseChallengesRepository.ts`
+- **Diagnostico:** `replace(challenge)` atualiza `title`, `code`, `description`, `difficulty_level`, `user_id`, `star_id`, `is_public`, `is_new`, `slug` e `test_cases`, alem de recriar o vinculo em `challenges_categories`. A persistencia cobre os campos afetados pelo bug, entao a inconsistencia observada tende a ocorrer depois do banco.
+
+### Camada RPC (Actions)
+- **Arquivo:** `apps/web/src/rpc/actions/challenging/AccessChallengePageAction.ts`
+- **Diagnostico:** A action busca novamente o desafio por `slug` e retorna `challengeDto` para a pagina. Isso delimita que existe uma fonte fresca de dados chegando na borda do `web`, e que a divergencia aparece na fase client-side de hidratacao/estado.
+
+### Camada RPC (Next Safe Action)
+- **Arquivo:** `apps/web/src/rpc/next-safe-action/challengingActions.ts`
+- **Diagnostico:** Apesar de `AccessChallengePageAction` buscar dados no backend, as actions `accessChallengePage`, `accessAuthenticatedChallengePage` e `accessChallengeEditorPage` estavam configuradas com cache server-side (`refetchInterval: 60`). Isso introduzia stale data no retorno para a pagina do desafio e para a pagina de edicao logo apos update.
+
+### Camada UI (Widgets)
+- **Arquivo:** `apps/web/src/ui/challenging/widgets/pages/ChallengeEditor/useChallengeEditorPage.ts`
+- **Diagnostico:** Apos `updateChallenge(...)`, o hook redireciona para `ROUTES.challenging.challenges.challenge(challengeSlug)`. Quando o titulo nao muda, a `slug` permanece igual e o retorno acontece para a mesma rota logica, sem nenhum passo adicional de invalidacao do estado exibido.
+- **Arquivo:** `apps/web/src/ui/challenging/widgets/pages/Challenge/useChallengePage.ts`
+- **Diagnostico:** O hook da pagina do desafio so chama `setChallenge(...)` quando `challenge` ainda e nulo. Se a store ja contem um desafio da navegacao anterior, o `challengeDto` novo nao substitui o estado antigo, mesmo tendo vindo atualizado da action RPC.
+
+### Camada UI (Stores)
+- **Arquivo:** `apps/web/src/ui/challenging/stores/ChallengeStore/index.ts`
+- **Diagnostico:** A store expoe `getChallengeSlice()` e `resetStore()`, mas nao possui nenhum mecanismo de sincronizacao automatica com props novas vindas da pagina.
+- **Arquivo:** `apps/web/src/ui/challenging/stores/zustand/useZustandChallengeStore.ts`
+- **Diagnostico:** O estado global guarda `challenge` entre navegacoes do modulo e oferece `setChallenge(challenge)` sem logica de invalidacao por mudanca de payload. O comportamento atual depende totalmente do widget consumidor decidir quando reidratar o store.
+
+### Camada Next.js App (Pages, Layouts)
+- **Arquivo:** `apps/web/src/app/challenging/challenges/[challengeSlug]/challenge/page.tsx`
+- **Diagnostico:** A page server-side carrega `challengeDto` atualizado via action e o repassa para `ChallengePage`. Isso reforca que o dado fresco chega corretamente ao app Next.js; o problema surge depois, na sincronizacao client-side com a store compartilhada.
+
+## Plano de Correcao (Spec)
+
+### 1. O que ja existe?
+
+Liste recursos existentes da codebase que estao envolvidos no bug, serao reutilizados na correcao ou podem ser impactados indiretamente.
+
+- **web**
+  - `apps/web/src/app/challenging/challenges/[challengeSlug]/challenge/page.tsx` - carrega o `challengeDto` atualizado e entrega o snapshot server-side para o widget client.
+  - `apps/web/src/rpc/actions/challenging/AccessChallengePageAction.ts` - refaz a leitura do desafio por `slug` e entrega o payload fresco para a pagina.
+  - `apps/web/src/ui/challenging/widgets/pages/Challenge/useChallengePage.ts` - concentra a hidratacao inicial do desafio, o uso da store e o ponto exato onde o estado stale persiste.
+  - `apps/web/src/ui/challenging/widgets/pages/ChallengeEditor/useChallengeEditorPage.ts` - executa o update e faz o redirecionamento para a pagina do desafio.
+  - `apps/web/src/ui/challenging/stores/ChallengeStore/index.ts` - fornece acesso ao estado compartilhado e ao `setChallenge`/`resetStore` usados pelo widget.
+  - `apps/web/src/ui/challenging/stores/zustand/useZustandChallengeStore.ts` - implementa a persistencia client-side do `challenge` no ciclo de navegacao.
+- **rest**
+  - `apps/web/src/rest/services/ChallengingService.ts` - envia o payload completo de update para o backend.
+  - `apps/server/src/rest/controllers/challenging/challenges/UpdateChallengeController.ts` - recebe o update e o encaminha ao core.
+- **core**
+  - `packages/core/src/challenging/use-cases/UpdateChallengeUseCase.ts` - aplica a regra de update sem depender da alteracao de campos alem de `title` para persistir a entidade.
+- **database**
+  - `apps/server/src/database/supabase/repositories/challenging/SupabaseChallengesRepository.ts` - persiste todos os campos editaveis e confirma que o problema nao esta na escrita em banco.
+
+### 2. O que deve ser criado?
+
+Descreva novos recursos necessarios **apenas se estritamente necessarios**.
+
+- **web**
+  - Nenhum recurso novo e necessario. A correcao pode reutilizar o fluxo existente de fetch server-side e a store atual.
+
+### 3. O que deve ser modificado?
+
+Liste mudancas pontuais em codigo existente, explicando o motivo da alteracao.
+
+- **web**
+  - `apps/web/src/ui/challenging/widgets/pages/Challenge/useChallengePage.ts` - ajustar a logica de hidratacao para sincronizar a store com o `challengeDto` recebido quando o snapshot server-side divergir do `challenge` atual, inclusive ao retornar para a mesma `slug` apos editar o desafio.
+  - `apps/web/src/ui/challenging/widgets/pages/Challenge/useChallengePage.ts` - preservar o comportamento atual para navegacao normal e estados interativos locais quando nao houver divergencia entre props e store, evitando sobrescrever estado client-side sem necessidade.
+  - `apps/web/src/rpc/next-safe-action/challengingActions.ts` - desabilitar cache nas actions de acesso a pagina de desafio (autenticada e publica) e na action de acesso ao editor, garantindo leitura fresca apos atualizacao.
+
+### 4. O que deve ser removido?
+
+Liste codigo redundante, legado ou incorreto que deve ser eliminado como parte da correcao.
+
+- **web**
+  - A condicao implicita de hidratacao "so inicializa quando `challenge` e nulo" em `apps/web/src/ui/challenging/widgets/pages/Challenge/useChallengePage.ts` deve deixar de ser a unica regra de sincronizacao, pois e ela que permite manter estado stale apos o update.
+
+## Correcao Aplicada
+
+- **Core**
+  - `packages/core/src/challenging/use-cases/UpdateChallengeUseCase.ts` - retorno padronizado para payload persistido apos `replace(...)` com nova leitura por `id`.
+  - `packages/core/src/challenging/use-cases/tests/UpdateChallengeUseCase.test.ts` - cobertura para update sem mudanca de titulo e para contrato de retorno com snapshot persistido.
+- **Web (UI)**
+  - `apps/web/src/ui/challenging/widgets/pages/Challenge/useChallengePage.ts` - reconciliacao entre `challengeDto` e store atual via comparacao de payload; reidratacao apenas quando houver divergencia real.
+  - `apps/web/src/ui/challenging/widgets/pages/Challenge/tests/useChallengePage.test.ts` - testes de estado stale e estado estavel.
+- **Web (RPC/Next)**
+  - `apps/web/src/rpc/next-safe-action/challengingActions.ts` - `isCacheEnabled: false` em `accessChallengePage`, `accessAuthenticatedChallengePage` e `accessChallengeEditorPage`.
+
+## Validacao
+
+- `npm run codecheck -w @stardust/web` ✅
+- `npm run typecheck -w @stardust/web` ✅
+- `npm run test -w @stardust/web` ✅
+- `npm run codecheck -w @stardust/core` ✅
+- `npm run typecheck -w @stardust/core` ✅
+- `npm run test -w @stardust/core` ✅

--- a/documentation/features/challenging/challenge-editor/reports/challenge-editor-stale-data-after-update-bug-report.md
+++ b/documentation/features/challenging/challenge-editor/reports/challenge-editor-stale-data-after-update-bug-report.md
@@ -1,6 +1,8 @@
 ---
 title: Challenge Editor stale data after update
 apps: web
+prd: https://github.com/JohnPetros/stardust/milestone/4
+issue: https://github.com/JohnPetros/stardust/issues/392
 status: closed
 last_updated_at: 2026-04-22
 ---

--- a/documentation/features/challenging/challenge-editor/specs/challenge-editor-stale-data-after-update-fix-spec.md
+++ b/documentation/features/challenging/challenge-editor/specs/challenge-editor-stale-data-after-update-fix-spec.md
@@ -4,12 +4,12 @@ prd: documentation/features/challenging/challenge-editor/prd.md
 issue: documentation/features/challenging/challenge-editor/reports/challenge-editor-stale-data-after-update-bug-report.md
 apps: web
 status: open
-last_updated_at: 2026-04-22
+last_updated_at: 2026-04-24
 ---
 
 # 1. Objetivo
 
-Corrigir o fluxo de retorno do Challenge Editor para que a pagina do desafio sempre exiba o snapshot mais recente recebido da action RPC apos um update bem-sucedido, mesmo quando o titulo nao muda e a navegacao retorna para a mesma `slug`. A implementacao deve permanecer restrita ao `web`, reutilizando o fetch server-side e a store Zustand ja existentes, sem alterar contratos de `rest`, `core` ou `database`.
+Corrigir o fluxo de retorno do Challenge Editor para que a pagina do desafio sempre exiba o snapshot mais recente apos um update bem-sucedido, mesmo quando o titulo nao muda e a navegacao retorna para a mesma `slug`. A implementacao deve alinhar `core` e `web`: no `core`, garantir que o payload retornado pelo update reflita o estado persistido mais recente; no `web`, sincronizar hidratacao client-side e desabilitar cache nas actions de acesso afetadas para evitar stale data.
 
 ---
 
@@ -19,11 +19,13 @@ Corrigir o fluxo de retorno do Challenge Editor para que a pagina do desafio sem
 
 - Sincronizar a store client-side do desafio com o `challengeDto` recebido pela pagina do desafio quando houver divergencia entre o snapshot server-side e o estado atual.
 - Garantir que alteracoes persistidas em descricao, codigo, casos de teste, categorias e visibilidade aparecam apos salvar no Challenge Editor, independentemente de mudanca de `title`/`slug`.
+- Garantir no `core` que `UpdateChallengeUseCase` retorne o estado persistido apos `replace(...)`, evitando retornar snapshot potencialmente defasado do pre-update.
+- Desabilitar cache de leitura nas actions de acesso da pagina de desafio (publica/autenticada) e no acesso ao editor para reduzir risco de stale data no retorno imediato apos update.
 - Manter o fluxo atual de acesso via `AccessChallengePageAction` e a estrutura da pagina `apps/web/src/app/challenging/challenges/[challengeSlug]/challenge/page.tsx`.
 
 ## 2.2 Out-of-scope
 
-- Alteracoes em contratos REST, controllers, use cases ou repositories do modulo `challenging`.
+- Alteracoes em contratos REST, controllers, repositories ou banco de dados do modulo `challenging`.
 - Mudancas no fluxo de criacao de desafios.
 - Mudancas na navegacao do editor para usar hard reload, refresh global da pagina ou invalidacao manual fora do widget da pagina do desafio.
 
@@ -94,6 +96,20 @@ Corrigir o fluxo de retorno do Challenge Editor para que a pagina do desafio sem
 * **Justificativa:** A correcao precisa atacar apenas a divergencia de snapshot sem degradar o comportamento existente de votacao, navegacao e estados locais do widget.
 * **Camada:** `ui`
 
+## Camada RPC (Actions)
+
+* **Arquivo:** `apps/web/src/rpc/next-safe-action/challengingActions.ts`
+* **Mudanca:** Desabilitar cache de leitura nas actions `accessChallengePage`, `accessAuthenticatedChallengePage` e `accessChallengeEditorPage` para forcar leitura fresca apos update.
+* **Justificativa:** Mesmo com sincronizacao correta no client, respostas cacheadas na borda web podem reintroduzir stale data imediatamente apos salvar no editor.
+* **Camada:** `rpc`
+
+## Camada Core (Use Cases)
+
+* **Arquivo:** `packages/core/src/challenging/use-cases/UpdateChallengeUseCase.ts`
+* **Mudanca:** Apos persistir com `replace(...)`, reler o desafio por id e retornar o snapshot persistido no payload final do update.
+* **Justificativa:** O fluxo de retorno para o `web` deve refletir exatamente o estado que ficou no repositorio, inclusive quando a `slug` permanece igual e apenas campos editaveis sao alterados.
+* **Camada:** `core`
+
 ---
 
 # 7. O que deve ser removido?
@@ -105,25 +121,16 @@ Corrigir o fluxo de retorno do Challenge Editor para que a pagina do desafio sem
 # 8. Decisoes Tecnicas e Trade-offs
 
 * **Decisao**
-  - Corrigir o bug na camada `ui`, em `useChallengePage`, sincronizando a store com o `challengeDto` recebido pela pagina.
+  - Corrigir o bug com ajuste combinado de `core` + `web`: retorno consistente no `UpdateChallengeUseCase`, cache desabilitado nas actions de acesso e sincronizacao da store em `useChallengePage`.
 * **Alternativas consideradas**
   - Forcar `window.location.reload()` apos update.
   - Resetar a store no editor antes do redirecionamento.
   - Alterar contratos de backend para devolver algum mecanismo extra de invalidacao.
 * **Motivo da escolha**
-  - O dado fresco ja esta disponivel no `web` via `AccessChallengePageAction` e `page.tsx`. O problema esta na hidratacao client-side, entao a correcao mais consistente e menor e alinhar a sincronizacao no ponto em que o snapshot entra no widget.
+  - O dado precisa estar fresco em toda a cadeia de retorno. Apenas ajustar hidratacao client-side nao cobre cenarios em que o payload de update ou a leitura server-side imediata estejam defasados por cache/snapshot anterior.
 * **Impactos / trade-offs**
   - A logica de comparacao entre props e store precisa ser cuidadosa para nao sobrescrever estados client-side legitimos quando nao houver divergencia real.
-
-* **Decisao**
-  - Nao alterar `core`, `rest` ou `database` nesta correcao.
-* **Alternativas consideradas**
-  - Reabrir o fluxo completo de update do backend.
-  - Introduzir novo contrato no service para invalidacao explicita.
-* **Motivo da escolha**
-  - As evidencias atuais mostram que controller, use case e repository ja persistem corretamente os campos editados. Alterar essas camadas aumentaria o escopo sem atacar a causa real.
-* **Impactos / trade-offs**
-  - A spec assume que a origem do bug esta restrita ao reaproveitamento indevido do estado no `web`, o que esta alinhado com o codigo analisado.
+  - A leitura sem cache nas actions prioriza consistencia pos-update em detrimento de possivel reducao marginal de hit de cache nessas rotas.
 
 ---
 

--- a/documentation/features/challenging/challenge-editor/specs/challenge-editor-stale-data-after-update-fix-spec.md
+++ b/documentation/features/challenging/challenge-editor/specs/challenge-editor-stale-data-after-update-fix-spec.md
@@ -1,0 +1,213 @@
+---
+title: Correcao de stale data na pagina do desafio apos update
+prd: documentation/features/challenging/challenge-editor/prd.md
+issue: documentation/features/challenging/challenge-editor/reports/challenge-editor-stale-data-after-update-bug-report.md
+apps: web
+status: open
+last_updated_at: 2026-04-22
+---
+
+# 1. Objetivo
+
+Corrigir o fluxo de retorno do Challenge Editor para que a pagina do desafio sempre exiba o snapshot mais recente recebido da action RPC apos um update bem-sucedido, mesmo quando o titulo nao muda e a navegacao retorna para a mesma `slug`. A implementacao deve permanecer restrita ao `web`, reutilizando o fetch server-side e a store Zustand ja existentes, sem alterar contratos de `rest`, `core` ou `database`.
+
+---
+
+# 2. Escopo
+
+## 2.1 In-scope
+
+- Sincronizar a store client-side do desafio com o `challengeDto` recebido pela pagina do desafio quando houver divergencia entre o snapshot server-side e o estado atual.
+- Garantir que alteracoes persistidas em descricao, codigo, casos de teste, categorias e visibilidade aparecam apos salvar no Challenge Editor, independentemente de mudanca de `title`/`slug`.
+- Manter o fluxo atual de acesso via `AccessChallengePageAction` e a estrutura da pagina `apps/web/src/app/challenging/challenges/[challengeSlug]/challenge/page.tsx`.
+
+## 2.2 Out-of-scope
+
+- Alteracoes em contratos REST, controllers, use cases ou repositories do modulo `challenging`.
+- Mudancas no fluxo de criacao de desafios.
+- Mudancas na navegacao do editor para usar hard reload, refresh global da pagina ou invalidacao manual fora do widget da pagina do desafio.
+
+---
+
+# 3. Requisitos
+
+## 3.1 Funcionais
+
+- A pagina do desafio deve refletir o conteudo persistido mais recente apos um update realizado no Challenge Editor.
+- A correcao deve funcionar quando o usuario altera apenas campos diferentes de `title`.
+- O comportamento de acesso e fetch atual da pagina do desafio deve ser preservado.
+
+## 3.2 Nao funcionais
+
+- Compatibilidade retroativa: a correcao nao deve alterar os contratos existentes entre `web`, `rest`, `core` e `database`.
+- Resiliencia de estado: a store compartilhada nao deve permanecer com snapshot stale quando a pagina receber um `challengeDto` mais recente para o mesmo desafio.
+- Performance: a sincronizacao deve ocorrer apenas quando houver divergencia real entre props e store, evitando reidratar o desafio sem necessidade a cada render.
+
+---
+
+# 4. O que ja existe?
+
+## Camada REST (Services)
+
+* **`ChallengingService`** (`apps/web/src/rest/services/ChallengingService.ts`) - *Ja envia `updateChallenge(challenge)` com o `challenge.dto` completo para o backend.*
+
+## Camada RPC (Actions)
+
+* **`AccessChallengePageAction`** (`apps/web/src/rpc/actions/challenging/AccessChallengePageAction.ts`) - *Busca o desafio por `slug` e retorna um `challengeDto` fresco para a pagina de desafio.*
+
+## Camada UI (Widgets)
+
+* **`useChallengeEditorPage`** (`apps/web/src/ui/challenging/widgets/pages/ChallengeEditor/useChallengeEditorPage.ts`) - *Executa o update e redireciona para a rota do desafio apos sucesso.*
+* **`ChallengePage`** (`apps/web/src/ui/challenging/widgets/pages/Challenge/index.tsx`) - *Recebe `challengeDto` via props e delega a hidratacao para `useChallengePage`.*
+* **`useChallengePage`** (`apps/web/src/ui/challenging/widgets/pages/Challenge/useChallengePage.ts`) - *Concentra a hidratacao do desafio, o uso da store e a logica que hoje so inicializa o estado quando `challenge` e nulo.*
+
+## Camada UI (Stores)
+
+* **`ChallengeStore`** (`apps/web/src/ui/challenging/stores/ChallengeStore/index.ts`) - *Exibe o slice do desafio e disponibiliza `setChallenge` e `resetStore`.*
+* **`useZustandChallengeStore`** (`apps/web/src/ui/challenging/stores/zustand/useZustandChallengeStore.ts`) - *Implementa a store compartilhada com `state.challenge` persistido no ciclo de navegacao do modulo.*
+
+## Camada Next.js App (Pages, Layouts)
+
+* **`Page`** (`apps/web/src/app/challenging/challenges/[challengeSlug]/challenge/page.tsx`) - *Carrega `challengeDto` atualizado via action server-side e o repassa ao widget client `ChallengePage`.*
+
+---
+
+# 5. O que deve ser criado?
+
+**Nao aplicavel**.
+
+---
+
+# 6. O que deve ser modificado?
+
+## Camada UI (Widgets)
+
+* **Arquivo:** `apps/web/src/ui/challenging/widgets/pages/Challenge/useChallengePage.ts`
+* **Mudanca:** Substituir a hidratacao baseada apenas em `!challenge` por uma sincronizacao que compare o `challengeDto` recebido com o `challenge` atual da store e reidrate o estado quando o snapshot server-side estiver mais novo ou divergente.
+* **Justificativa:** O `challengeDto` atualizado ja chega na borda do `web`, mas hoje e ignorado se a store ja contem um desafio anterior, o que produz stale data apos editar e voltar para a mesma `slug`.
+* **Camada:** `ui`
+
+## Camada UI (Widgets)
+
+* **Arquivo:** `apps/web/src/ui/challenging/widgets/pages/Challenge/useChallengePage.ts`
+* **Mudanca:** Manter a inicializacao de `userVote`, `craftsVisibility` e demais estados derivados compativeis com o desafio sincronizado, sem resetar indevidamente estados client-side quando props e store representarem o mesmo snapshot.
+* **Justificativa:** A correcao precisa atacar apenas a divergencia de snapshot sem degradar o comportamento existente de votacao, navegacao e estados locais do widget.
+* **Camada:** `ui`
+
+---
+
+# 7. O que deve ser removido?
+
+**Nao aplicavel**.
+
+---
+
+# 8. Decisoes Tecnicas e Trade-offs
+
+* **Decisao**
+  - Corrigir o bug na camada `ui`, em `useChallengePage`, sincronizando a store com o `challengeDto` recebido pela pagina.
+* **Alternativas consideradas**
+  - Forcar `window.location.reload()` apos update.
+  - Resetar a store no editor antes do redirecionamento.
+  - Alterar contratos de backend para devolver algum mecanismo extra de invalidacao.
+* **Motivo da escolha**
+  - O dado fresco ja esta disponivel no `web` via `AccessChallengePageAction` e `page.tsx`. O problema esta na hidratacao client-side, entao a correcao mais consistente e menor e alinhar a sincronizacao no ponto em que o snapshot entra no widget.
+* **Impactos / trade-offs**
+  - A logica de comparacao entre props e store precisa ser cuidadosa para nao sobrescrever estados client-side legitimos quando nao houver divergencia real.
+
+* **Decisao**
+  - Nao alterar `core`, `rest` ou `database` nesta correcao.
+* **Alternativas consideradas**
+  - Reabrir o fluxo completo de update do backend.
+  - Introduzir novo contrato no service para invalidacao explicita.
+* **Motivo da escolha**
+  - As evidencias atuais mostram que controller, use case e repository ja persistem corretamente os campos editados. Alterar essas camadas aumentaria o escopo sem atacar a causa real.
+* **Impactos / trade-offs**
+  - A spec assume que a origem do bug esta restrita ao reaproveitamento indevido do estado no `web`, o que esta alinhado com o codigo analisado.
+
+---
+
+# 9. Diagramas e Referencias
+
+* **Fluxo de Dados:**
+
+```ascii
+[Challenge Editor]
+        |
+        v
+[useChallengeEditorPage.handleSubmit]
+        |
+        v
+[ChallengingService.updateChallenge]
+        |
+        v
+[UpdateChallengeController]
+        |
+        v
+[UpdateChallengeUseCase]
+        |
+        v
+[SupabaseChallengesRepository.replace]
+        |
+        v
+      [DB]
+        |
+        v
+[Next.js challenge page]
+        |
+        v
+[AccessChallengePageAction -> challengeDto fresco]
+        |
+        v
+[ChallengePage/useChallengePage]
+        |
+        +--> estado atual == snapshot recebido ? manter store atual
+        |
+        `--> estado atual diverge do snapshot recebido ? setChallenge(Challenge.create(challengeDto))
+```
+
+* **Fluxo Cross-app (se aplicavel):**
+
+**Nao aplicavel**.
+
+* **Layout (se aplicavel):**
+
+```ascii
+apps/web/src/app/challenging/challenges/[challengeSlug]/challenge/page.tsx
+`- ChallengePage
+   `- useChallengePage
+      |- recebe challengeDto da page server-side
+      |- le challenge atual da ChallengeStore
+      `- sincroniza store quando snapshot divergir
+```
+
+* **Referencias:**
+  - `apps/web/src/ui/challenging/widgets/pages/Challenge/useChallengePage.ts`
+  - `apps/web/src/ui/challenging/widgets/pages/ChallengeEditor/useChallengeEditorPage.ts`
+  - `apps/web/src/rpc/actions/challenging/AccessChallengePageAction.ts`
+  - `apps/web/src/app/challenging/challenges/[challengeSlug]/challenge/page.tsx`
+  - `apps/web/src/ui/challenging/stores/ChallengeStore/index.ts`
+  - `apps/web/src/ui/challenging/stores/zustand/useZustandChallengeStore.ts`
+  - `apps/server/src/database/supabase/repositories/challenging/SupabaseChallengesRepository.ts`
+  - `packages/core/src/challenging/use-cases/UpdateChallengeUseCase.ts`
+
+---
+
+# 10. Pendencias / Duvidas
+
+**Sem pendencias**.
+
+---
+
+## Restricoes
+
+* **Nao inclua testes automatizados na spec.**
+* Todos os caminhos citados devem existir no projeto **ou** estar explicitamente marcados como **novo arquivo**.
+* **Nao invente** arquivos, metodos, contratos, schemas ou integracoes sem evidencia no PRD/codebase.
+* **Nao proponha acoplamento cross-domain no `core` sem evidencia explicita na codebase.** Se a necessidade for autenticacao, autorizacao, ownership, montagem de contexto ou adaptacao de transporte, prefira manter isso na borda da app quando esse ja for o padrao encontrado.
+* **Nao use o `core` para resolver conveniencias da app.** Se uma responsabilidade pertence a `middleware`, `controller`, `toolset`, `router` ou adapter local, a spec nao deve empurra-la para `use case` apenas para “centralizar”.
+* **Nao exponha em schemas de entrada campos controlados pelo servidor** quando o fluxo do PRD exigir que esses valores sejam definidos internamente.
+* Quando faltar informacao suficiente, registrar em **Pendencias / Duvidas** e usar a tool `question` se necessario.
+* Toda referencia a codigo existente deve incluir caminho relativo real.
+* Se uma secao nao se aplicar, preencher explicitamente com **Nao aplicavel**.
+* A spec deve ser consistente com os padroes ja existentes na codebase (nomenclatura, organizacao de pastas, contratos e convencoes por camada).

--- a/documentation/plan.md
+++ b/documentation/plan.md
@@ -5,12 +5,7 @@ status: closed
 
 ## Pendencias (quando aplicavel)
 
-Sem pendencias bloqueantes identificadas na spec de entrada.
-
-## Divergencias
-
-- **2026-04-21 — Mastra MCP runtime:** a API instalada nao expoe uma implementacao concreta publica de `MCPServer` em `@mastra/core` para instanciacao direta no server app. Foi adotada uma implementacao compativel via `@modelcontextprotocol/sdk` encapsulada em `ChallengeManagementMcpServer`, mantendo contrato funcional de singleton MCP HTTP e uso das tools do `ChallengingToolset`.
-- **2026-04-21 — Compatibilidade de testes Jest:** importacao estatica do runtime MCP causava erro ESM durante bootstrap dos testes (`@sindresorhus/slugify` transitivo de `@mastra/core/mcp`). O `McpRouter` passou a carregar o server MCP por `dynamic import` no handler da rota `/mcp`, preservando comportamento em runtime e estabilidade da suite de testes.
+- [ ] Nenhuma pendencia bloqueante identificada no bug report de entrada.
 
 ---
 
@@ -18,8 +13,8 @@ Sem pendencias bloqueantes identificadas na spec de entrada.
 
 | Fase | Objetivo | Depende de | Pode rodar em paralelo com |
 | --- | --- | --- | --- |
-| F1 | Definir contratos de autenticacao por API key e contexto MCP no core (interfaces e use case). | - | - |
-| F2 | Implementar endpoint `/mcp` autenticado, server MCP e tools de gerenciamento de desafios no `apps/server`. | F1 | - |
+| F1 | Consolidar no core os criterios de integridade do update de desafio para servir como contrato da correcao client-side. | - | - |
+| F3 | Corrigir sincronizacao de estado no `web` para sempre refletir o `challengeDto` fresco apos update. | F1 | - |
 
 > **Estratégia de paralelismo:** sempre comece pelo core (domínio, structures e use cases). Assim que o core estiver concluído, as fases de `server`, `web` e `studio` podem ser executadas em paralelo, pois todas dependem apenas do contrato definido no core.
 
@@ -27,140 +22,51 @@ Sem pendencias bloqueantes identificadas na spec de entrada.
 
 ## F1 — Core: Domínio, Structures e Use Cases
 
-**Objetivo:** Definir o contrato do domínio — entidades, structures, interfaces de repositório/provider e use cases — sem nenhuma dependência de infraestrutura. Essa fase desbloqueia F2.
+**Objetivo:** Definir o contrato do domínio — entidades, structures, interfaces de repositório/provider e use cases — sem nenhuma dependência de infraestrutura. Essa fase desbloqueia F3.
 
 ### Tarefas
 
-- [x] **T1.1** — Expandir contrato `Mcp` com identidade autenticada
+- [x] **T1.1** — Cobrir no core o cenario de update sem mudanca de titulo
   - **Depende de:** -
-  - **Resultado observavel:** `packages/core/src/global/interfaces/ai/Mcp.ts` passa a exigir `getAccountId(): string` junto de `getInput()`, estabelecendo contrato unico para tools MCP consumirem a conta autenticada.
+  - **Resultado observavel:** os testes de `UpdateChallengeUseCase` passam a garantir explicitamente que alteracoes em `description`, `code`, `testCases`, `categories` e `isPublic` sao persistidas mesmo quando `title`/`slug` nao mudam.
   - **Camada:** `core`
-  - **Artefatos:** `packages/core/src/global/interfaces/ai/Mcp.ts`
-  - **Data:** 2026-04-21
+  - **Artefatos:** `packages/core/src/challenging/use-cases/tests/UpdateChallengeUseCase.test.ts`
+  - **Concluido em:** 2026-04-22
 
-- [x] **T1.2** — Adicionar lookup de API key por hash no contrato de repositorio
-  - **Depende de:** -
-  - **Resultado observavel:** `packages/core/src/auth/interfaces/ApiKeysRepository.ts` passa a declarar `findByHash(keyHash: Text): Promise<ApiKey | null>` para autenticar sem trafegar segredo em texto claro.
+- [x] **T1.2** — Formalizar no core o contrato de payload atualizado apos update
+  - **Depende de:** T1.1
+  - **Resultado observavel:** o resultado consumido pela borda web para leitura de desafio permanece consistente com o estado persistido apos update no mesmo `slug`, sem perda de campos editaveis.
   - **Camada:** `core`
-  - **Artefatos:** `packages/core/src/auth/interfaces/ApiKeysRepository.ts`
-  - **Data:** 2026-04-21
-
-- [x] **T1.3** — Criar `AuthenticateApiKeyUseCase`
-  - **Depende de:** T1.2
-  - **Resultado observavel:** novo arquivo `packages/core/src/auth/use-cases/AuthenticateApiKeyUseCase.ts` autentica `apiKey` via `ApiKeySecretProvider.hash`, busca por `findByHash`, rejeita key revogada e retorna `{ userId }` da key valida.
-  - **Camada:** `core`
-  - **Artefatos:** `packages/core/src/auth/use-cases/AuthenticateApiKeyUseCase.ts`, `packages/core/src/auth/use-cases/tests/AuthenticateApiKeyUseCase.test.ts`
-  - **Data:** 2026-04-21
-
-- [x] **T1.4** — Exportar use case de autenticacao no barrel de auth
-  - **Depende de:** T1.3
-  - **Resultado observavel:** `packages/core/src/auth/use-cases/index.ts` exporta `AuthenticateApiKeyUseCase`, permitindo injecao no boundary do server sem importacao por caminho interno.
-  - **Camada:** `core`
-  - **Artefatos:** `packages/core/src/auth/use-cases/index.ts`
-  - **Data:** 2026-04-21
+  - **Artefatos:** `packages/core/src/challenging/use-cases/UpdateChallengeUseCase.ts`, `packages/core/src/challenging/use-cases/tests/UpdateChallengeUseCase.test.ts`
+  - **Concluido em:** 2026-04-22
 
 ---
 
-## F2 — Server: Infra, Repositórios e Handlers
+## F3 — Web: UI e Integração
 
-**Objetivo:** Implementar a camada de infraestrutura e exposição — repositórios, providers e handlers HTTP/MCP — consumindo os contratos definidos no core.
+> ⚡ Pode rodar em paralelo com F2 e F4 após F1 estar concluída.
+
+**Objetivo:** Implementar a interface e integração client-side na aplicação web — widgets, actions e chamadas RPC/REST — consumindo os contratos definidos no core.
 
 ### Tarefas
 
-- [x] **T2.1** — Implementar `findByHash` no repositório Supabase de API keys
+- [x] **T3.1** — Ajustar hidratacao do `useChallengePage` para reconciliar props com store
   - **Depende de:** T1.2
-  - **Resultado observavel:** `apps/server/src/database/supabase/repositories/auth/SupabaseApiKeysRepository.ts` consulta `key_hash` por `keyHash.value` e retorna `ApiKey` mapeada (ou `null`) via `SupabaseApiKeyMapper`.
-  - **Camada:** `database`
-  - **Artefatos:** `apps/server/src/database/supabase/repositories/auth/SupabaseApiKeysRepository.ts`
-  - **Data:** 2026-04-21
+  - **Resultado observavel:** ao abrir a pagina com `challengeDto` diferente do estado atual em store, o hook atualiza o store com o payload novo, inclusive quando a navegacao retorna para a mesma `slug`.
+  - **Camada:** `ui`
+  - **Artefatos:** `apps/web/src/ui/challenging/widgets/pages/Challenge/useChallengePage.ts`
+  - **Concluido em:** 2026-04-22
 
-- [x] **T2.2** — Adicionar middleware de autenticacao por `X-Api-Key`
-  - **Depende de:** T1.3, T1.4, T2.1
-  - **Resultado observavel:** `apps/server/src/app/hono/middlewares/AuthMiddleware.ts` passa a ter `verifyApiKeyAuthentication`, que extrai `X-Api-Key`, autentica com `AuthenticateApiKeyUseCase` e preenche `context.account.id` com o `userId` autenticado.
-  - **Camada:** `rest`
-  - **Artefatos:** `apps/server/src/app/hono/middlewares/AuthMiddleware.ts`
-  - **Data:** 2026-04-21
+- [x] **T3.2** — Preservar estado client-side quando nao houver divergencia de payload
+  - **Depende de:** T3.1
+  - **Resultado observavel:** em navegacoes sem alteracao real de dados, o hook nao sobrescreve o estado local desnecessariamente e mantem o comportamento atual da pagina.
+  - **Camada:** `ui`
+  - **Artefatos:** `apps/web/src/ui/challenging/widgets/pages/Challenge/useChallengePage.ts`
+  - **Concluido em:** 2026-04-22
 
-- [x] **T2.3** — Criar constante de instrucoes oficiais de criacao de desafios
-  - **Depende de:** T1.1
-  - **Resultado observavel:** novo arquivo `apps/server/src/ai/challenging/constants/challenge-creation-instructions.ts` define `CHALLENGE_CREATION_INSTRUCTIONS` com campos obrigatorios, formato de `testCases`, minimo de 3 casos e regra de controle server-side de `author`/`isPublic`.
-  - **Camada:** `ai`
-  - **Artefatos:** `apps/server/src/ai/challenging/constants/challenge-creation-instructions.ts`
-  - **Data:** 2026-04-21
-
-- [x] **T2.4** — Publicar constante no barrel de constantes de challenging
-  - **Depende de:** T2.3
-  - **Resultado observavel:** `apps/server/src/ai/challenging/constants/index.ts` exporta `CHALLENGE_CREATION_INSTRUCTIONS` para consumo do toolset.
-  - **Camada:** `ai`
-  - **Artefatos:** `apps/server/src/ai/challenging/constants/index.ts`
-  - **Data:** 2026-04-21
-
-- [x] **T2.5** — Criar tool de instrucoes de criacao
-  - **Depende de:** T1.1, T2.3
-  - **Resultado observavel:** novo arquivo `apps/server/src/ai/challenging/tools/GetChallengeCreationInstructionsTool.ts` retorna `{ instructions }` sem acesso a banco, usando somente a constante oficial.
-  - **Camada:** `ai`
-  - **Artefatos:** `apps/server/src/ai/challenging/tools/GetChallengeCreationInstructionsTool.ts`
-  - **Data:** 2026-04-21
-
-- [x] **T2.7** — Criar tool MCP de atualizacao preservando `isPublic`
-  - **Depende de:** T1.1
-  - **Resultado observavel:** novo arquivo `apps/server/src/ai/challenging/tools/UpdateChallengeTool.ts` valida autoria via `mcp.getAccountId()`, reutiliza `author`/`isPublic` persistidos e delega para `UpdateChallengeUseCase`.
-  - **Camada:** `ai`
-  - **Artefatos:** `apps/server/src/ai/challenging/tools/UpdateChallengeTool.ts`
-  - **Data:** 2026-04-21
-
-- [x] **T2.8** — Ajustar `PostChallengeTool` para autoria autenticada e rascunho forçado
-  - **Depende de:** T1.1
-  - **Resultado observavel:** `apps/server/src/ai/challenging/tools/PostChallengeTool.ts` remove autor hardcoded, usa `mcp.getAccountId()` para `author.id` e sempre envia `isPublic = false` ao `PostChallengeUseCase`.
-  - **Camada:** `ai`
-  - **Artefatos:** `apps/server/src/ai/challenging/tools/PostChallengeTool.ts`, `apps/server/src/ai/challenging/tools/tests/PostChallengeTool.test.ts`
-  - **Data:** 2026-04-21
-
-- [x] **T2.9** — Atualizar descricoes e barrel das tools de challenging
-  - **Depende de:** T2.5, T2.7, T2.8
-  - **Resultado observavel:** `apps/server/src/ai/challenging/constants/tools-descriptions.ts` descreve as novas tools MCP e `apps/server/src/ai/challenging/tools/index.ts` exporta as novas classes para composicao no toolset.
-  - **Camada:** `ai`
-  - **Artefatos:** `apps/server/src/ai/challenging/constants/tools-descriptions.ts`, `apps/server/src/ai/challenging/tools/index.ts`
-  - **Data:** 2026-04-21
-
-- [x] **T2.10** — Expandir adapter `MastraMcp` com `getAccountId()`
-  - **Depende de:** T1.1
-  - **Resultado observavel:** `apps/server/src/ai/mastra/MastraMcp.ts` implementa `getInput()` + `getAccountId()` e passa a resolver a conta autenticada a partir do contexto do runtime MCP server.
-  - **Camada:** `ai`
-  - **Artefatos:** `apps/server/src/ai/mastra/MastraMcp.ts`
-  - **Data:** 2026-04-21
-
-- [x] **T2.11** — Atualizar `ChallengingToolset` com schemas MCP e composicao das tools de gerenciamento
-  - **Depende de:** T2.4, T2.5, T2.6, T2.7, T2.8, T2.9, T2.10
-  - **Resultado observavel:** `apps/server/src/ai/mastra/toolsets/ChallengingToolset.ts` registra tools de instrucoes/criacao/consulta/atualizacao com `inputSchema` e `outputSchema` explicitos, derivando entradas de `challengeSchema`/`idSchema` sem `author` e `isPublic`.
-  - **Camada:** `ai`
-  - **Artefatos:** `apps/server/src/ai/mastra/toolsets/ChallengingToolset.ts`
-  - **Data:** 2026-04-21
-
-- [x] **T2.12** — Criar servidor MCP unico de gerenciamento de desafios
-  - **Depende de:** T2.11
-  - **Resultado observavel:** novo arquivo `apps/server/src/ai/mastra/mcp/ChallengeManagementMcpServer.ts` expoe `getServer()` com singleton de MCP HTTP runtime e toolset restrito ao dominio `challenging`.
-  - **Camada:** `ai`
-  - **Artefatos:** `apps/server/src/ai/mastra/mcp/ChallengeManagementMcpServer.ts`
-  - **Data:** 2026-04-21
-
-- [x] **T2.13** — Criar `McpRouter` com autenticacao por API key e validacao de insignia
-  - **Depende de:** T2.2, T2.12
-  - **Resultado observavel:** novo arquivo `apps/server/src/app/hono/routers/mcp/McpRouter.ts` registra `/mcp`, aplica `verifyApiKeyAuthentication`, valida insignia de Engenheiro e delega ao transporte HTTP do MCP server.
-  - **Camada:** `rest`
-  - **Artefatos:** `apps/server/src/app/hono/routers/mcp/McpRouter.ts`
-  - **Data:** 2026-04-21
-
-- [x] **T2.14** — Exportar router MCP nos barrels de roteamento
-  - **Depende de:** T2.13
-  - **Resultado observavel:** `apps/server/src/app/hono/routers/mcp/index.ts` e `apps/server/src/app/hono/routers/index.ts` passam a exportar `McpRouter` para composicao do app.
-  - **Camada:** `rest`
-  - **Artefatos:** `apps/server/src/app/hono/routers/mcp/index.ts`, `apps/server/src/app/hono/routers/index.ts`
-  - **Data:** 2026-04-21
-
-- [x] **T2.15** — Integrar `McpRouter` no `HonoApp` e isolar fluxo `/mcp` do decode JWT
-  - **Depende de:** T2.14
-  - **Resultado observavel:** `apps/server/src/app/hono/HonoApp.ts` registra `McpRouter` e `createSupabaseClient()` deixa de aplicar `jwtDecode` ao bearer de requests `/mcp`, preservando o comportamento atual das demais rotas.
-  - **Camada:** `rest`
-  - **Artefatos:** `apps/server/src/app/hono/HonoApp.ts`
-  - **Data:** 2026-04-21
+- [x] **T3.3** — Cobrir em testes do widget os cenarios de estado stale e estado estavel
+  - **Depende de:** T3.1, T3.2
+  - **Resultado observavel:** existe teste automatizado validando que (a) dados atualizados apos edicao na mesma `slug` passam a ser exibidos e (b) payload identico nao dispara reidratacao redundante.
+  - **Camada:** `web`
+  - **Artefatos:** `apps/web/src/ui/challenging/widgets/pages/Challenge/tests/useChallengePage.test.ts`
+  - **Concluido em:** 2026-04-22

--- a/documentation/plan.md
+++ b/documentation/plan.md
@@ -16,7 +16,7 @@ status: closed
 | F1 | Consolidar no core os criterios de integridade do update de desafio para servir como contrato da correcao client-side. | - | - |
 | F3 | Corrigir sincronizacao de estado no `web` para sempre refletir o `challengeDto` fresco apos update. | F1 | - |
 
-> **Estratégia de paralelismo:** sempre comece pelo core (domínio, structures e use cases). Assim que o core estiver concluído, as fases de `server`, `web` e `studio` podem ser executadas em paralelo, pois todas dependem apenas do contrato definido no core.
+> **Estratégia de paralelismo:** sempre comece pelo core (domínio, structures e use cases). Assim que o core estiver concluído, a fase `web` pode ser executada, pois depende apenas do contrato definido no core.
 
 ---
 
@@ -44,7 +44,7 @@ status: closed
 
 ## F3 — Web: UI e Integração
 
-> ⚡ Pode rodar em paralelo com F2 e F4 após F1 estar concluída.
+> ⚡ Inicia após F1 estar concluída.
 
 **Objetivo:** Implementar a interface e integração client-side na aplicação web — widgets, actions e chamadas RPC/REST — consumindo os contratos definidos no core.
 

--- a/documentation/prompts/create-bug-report-prompt.md
+++ b/documentation/prompts/create-bug-report-prompt.md
@@ -13,7 +13,14 @@ O bug report deve:
 - Indicar **onde e por que provavelmente está quebrado**
 - Sugerir **como corrigir**, respeitando a arquitetura do projeto
 
-Após a criação do Bug Report, uma **Spec de correção** deve ser gerada automaticamente com base no plano de correção levantado, seguindo o prompt `documentation/prompts/create-spec-prompt.md`.
+O resultado desta tarefa e' **sempre composto por dois artefatos gerados no mesmo fluxo**:
+- o **Bug Report**
+- a **Spec de correcao derivada dele**
+
+Apos a criacao do Bug Report, uma **Spec de correcao** deve ser gerada automaticamente com base no plano de correcao levantado, seguindo o prompt `documentation/prompts/create-spec-prompt.md`.
+
+> A Spec nao e' uma etapa opcional, posterior ou separada.
+> Ela faz parte da mesma entrega do Bug Report e deve ser salva na mesma execucao.
 
 ---
 
@@ -72,6 +79,10 @@ Após a criação do Bug Report, uma **Spec de correção** deve ser gerada auto
 
 Após salvar o Bug Report, gere automaticamente uma Spec de correção seguindo `documentation/prompts/create-spec-prompt.md`, com as seguintes adaptações:
 
+- A geracao da Spec deve acontecer **na mesma tarefa**, imediatamente apos salvar o Bug Report, sem depender de nova solicitacao do usuario.
+- O trabalho **so pode ser considerado concluido quando os dois arquivos existirem**: o Bug Report e a Spec derivada.
+- A Spec deve ser tratada como **continuação direta do Bug Report**, e nao como entregavel independente.
+
 - O **esboço da tarefa** é o próprio Bug Report gerado.
 - O **PRD de referência** é o PRD da feature afetada, encontrado em `documentation/features/<dominio>/`.
 - O **frontmatter** da Spec deve referenciar o Bug Report no campo `issue`.
@@ -87,7 +98,8 @@ Salve o arquivo em `documentation/features/{dominio}/reports/{nome-descritivo}-b
 ```md
 ---
 title: {Titulo Curto e Descritivo}
-apps: {web|server|studio}
+prd: <link para o PRD referente à spec, sendo uma milestone do GitHub>
+issue: <link para o issue referente à spec, servindo como esboço para a spec>
 status: {open|closed}
 last_updated_at: {YYYY-MM-DD}
 ---
@@ -226,4 +238,5 @@ Liste código redundante, legado ou incorreto que deve ser eliminado como parte 
 - Use apenas as camadas listadas na seção 3. Mapeamento de Camadas — não crie camadas arbitrárias.
 - Omita do template as camadas que não forem aplicáveis ao bug em questão.
 - A Spec de correção deve ser gerada **sempre**, sem necessidade de solicitação explícita.
+- O processo nao deve parar apos criar apenas o Bug Report; a tarefa permanece incompleta ate a Spec ser criada e salva.
 - A Spec de correção **não pode contradizer** o Bug Report — ela é uma derivação direta dele.

--- a/documentation/prompts/create-bug-report-prompt.md
+++ b/documentation/prompts/create-bug-report-prompt.md
@@ -1,5 +1,5 @@
 ---
-description: Prompt para transformar relatos informais em bug reports tecnicos claros, acionaveis e orientados a correcao.
+description: Prompt para transformar relatos informais em bug reports técnicos claros, acionáveis e orientados a correção.
 ---
 
 # Prompt: Criar Bug Report
@@ -13,14 +13,14 @@ O bug report deve:
 - Indicar **onde e por que provavelmente está quebrado**
 - Sugerir **como corrigir**, respeitando a arquitetura do projeto
 
-O resultado desta tarefa e' **sempre composto por dois artefatos gerados no mesmo fluxo**:
+O resultado desta tarefa é **sempre composto por dois artefatos gerados no mesmo fluxo**:
 - o **Bug Report**
-- a **Spec de correcao derivada dele**
+- a **Spec de correção derivada dele**
 
-Apos a criacao do Bug Report, uma **Spec de correcao** deve ser gerada automaticamente com base no plano de correcao levantado, seguindo o prompt `documentation/prompts/create-spec-prompt.md`.
+Após a criação do Bug Report, uma **Spec de correção** deve ser gerada automaticamente com base no plano de correção levantado, seguindo o prompt `documentation/prompts/create-spec-prompt.md`.
 
-> A Spec nao e' uma etapa opcional, posterior ou separada.
-> Ela faz parte da mesma entrega do Bug Report e deve ser salva na mesma execucao.
+> A Spec não é uma etapa opcional, posterior ou separada.
+> Ela faz parte da mesma entrega do Bug Report e deve ser salva na mesma execução.
 
 ---
 
@@ -79,9 +79,9 @@ Apos a criacao do Bug Report, uma **Spec de correcao** deve ser gerada automatic
 
 Após salvar o Bug Report, gere automaticamente uma Spec de correção seguindo `documentation/prompts/create-spec-prompt.md`, com as seguintes adaptações:
 
-- A geracao da Spec deve acontecer **na mesma tarefa**, imediatamente apos salvar o Bug Report, sem depender de nova solicitacao do usuario.
-- O trabalho **so pode ser considerado concluido quando os dois arquivos existirem**: o Bug Report e a Spec derivada.
-- A Spec deve ser tratada como **continuação direta do Bug Report**, e nao como entregavel independente.
+- A geração da Spec deve acontecer **na mesma tarefa**, imediatamente após salvar o Bug Report, sem depender de nova solicitação do usuário.
+- O trabalho **só pode ser considerado concluído quando os dois arquivos existirem**: o Bug Report e a Spec derivada.
+- A Spec deve ser tratada como **continuação direta do Bug Report**, e não como entregável independente.
 
 - O **esboço da tarefa** é o próprio Bug Report gerado.
 - O **PRD de referência** é o PRD da feature afetada, encontrado em `documentation/features/<dominio>/`.
@@ -100,6 +100,7 @@ Salve o arquivo em `documentation/features/{dominio}/reports/{nome-descritivo}-b
 title: {Titulo Curto e Descritivo}
 prd: <link para o PRD referente à spec, sendo uma milestone do GitHub>
 issue: <link para o issue referente à spec, servindo como esboço para a spec>
+apps: {web|server|studio}
 status: {open|closed}
 last_updated_at: {YYYY-MM-DD}
 ---
@@ -238,5 +239,5 @@ Liste código redundante, legado ou incorreto que deve ser eliminado como parte 
 - Use apenas as camadas listadas na seção 3. Mapeamento de Camadas — não crie camadas arbitrárias.
 - Omita do template as camadas que não forem aplicáveis ao bug em questão.
 - A Spec de correção deve ser gerada **sempre**, sem necessidade de solicitação explícita.
-- O processo nao deve parar apos criar apenas o Bug Report; a tarefa permanece incompleta ate a Spec ser criada e salva.
+- O processo não deve parar após criar apenas o Bug Report; a tarefa permanece incompleta até a Spec ser criada e salva.
 - A Spec de correção **não pode contradizer** o Bug Report — ela é uma derivação direta dele.

--- a/packages/core/src/challenging/use-cases/UpdateChallengeUseCase.ts
+++ b/packages/core/src/challenging/use-cases/UpdateChallengeUseCase.ts
@@ -23,7 +23,8 @@ export class UpdateChallengeUseCase implements UseCase<Request, Response> {
     }
 
     await this.repository.replace(challenge)
-    return challenge.dto
+    const updatedChallenge = await this.findChallenge(challenge.id)
+    return updatedChallenge.dto
   }
 
   private async findChallenge(challengeId: Id) {

--- a/packages/core/src/challenging/use-cases/tests/UpdateChallengeUseCase.test.ts
+++ b/packages/core/src/challenging/use-cases/tests/UpdateChallengeUseCase.test.ts
@@ -4,6 +4,7 @@ import { ChallengesFaker } from '#challenging/domain/entities/fakers/ChallengesF
 import { ChallengeNotFoundError } from '#challenging/domain/errors/ChallengeNotFoundError'
 import { ChallengeAlreadyExistsError } from '#challenging/domain/errors/ChallengeAlreadyExistsError'
 import type { ChallengesRepository } from '#challenging/interfaces/ChallengesRepository'
+import type { ChallengeDto } from '../../domain/entities/dtos'
 import { UpdateChallengeUseCase } from '../UpdateChallengeUseCase'
 
 describe('Update Challenge Use Case', () => {
@@ -52,5 +53,76 @@ describe('Update Challenge Use Case', () => {
     })
 
     expect(repository.replace).toHaveBeenCalledWith(challenge)
+  })
+
+  it('should replace editable fields when title does not change', async () => {
+    const currentChallenge = ChallengesFaker.fake()
+    const updatedDto = ChallengesFaker.fakeDto({
+      id: currentChallenge.id.value,
+      title: currentChallenge.title.value,
+      description: 'updated description',
+      code: 'print("updated")',
+      isPublic: !currentChallenge.isPublic.value,
+      categories: ChallengesFaker.fakeDto().categories,
+      testCases: ChallengesFaker.fakeDto().testCases,
+      author: currentChallenge.author.dto,
+      difficultyLevel: currentChallenge.difficulty.level,
+      postedAt: currentChallenge.postedAt,
+    })
+    const updatedChallenge = ChallengesFaker.fake(updatedDto)
+
+    repository.findById
+      .mockResolvedValueOnce(currentChallenge)
+      .mockResolvedValueOnce(updatedChallenge)
+
+    const response = await useCase.execute({
+      challengeDto: updatedDto,
+    })
+
+    expect(repository.findBySlug).not.toHaveBeenCalled()
+    expect(repository.replace).toHaveBeenCalledWith(updatedChallenge)
+    expect(response).toEqual(updatedChallenge.dto)
+  })
+
+  it('should return the persisted challenge payload after update', async () => {
+    const currentChallenge = ChallengesFaker.fake({
+      upvotesCount: 9,
+      downvotesCount: 3,
+      completionCount: 12,
+      isNew: true,
+    })
+    const updateRequest: ChallengeDto = {
+      id: currentChallenge.id.value,
+      title: currentChallenge.title.value,
+      description: 'updated challenge description',
+      code: 'console.log("updated")',
+      difficultyLevel: currentChallenge.difficulty.level,
+      author: currentChallenge.author.dto,
+      testCases: ChallengesFaker.fakeDto().testCases,
+      categories: ChallengesFaker.fakeDto().categories,
+      isPublic: currentChallenge.isPublic.value,
+      postedAt: currentChallenge.postedAt,
+    }
+    const updatedChallenge = ChallengesFaker.fake(updateRequest)
+    const persistedChallenge = ChallengesFaker.fake({
+      ...currentChallenge.dto,
+      ...updateRequest,
+      upvotesCount: currentChallenge.upvotesCount.value,
+      downvotesCount: currentChallenge.downvotesCount.value,
+      completionCount: currentChallenge.completionCount.value,
+      isNew: currentChallenge.isNew.value,
+      postedAt: currentChallenge.postedAt,
+    })
+
+    repository.findById
+      .mockResolvedValueOnce(currentChallenge)
+      .mockResolvedValueOnce(persistedChallenge)
+
+    const response = await useCase.execute({
+      challengeDto: updateRequest,
+    })
+
+    expect(response).toEqual(persistedChallenge.dto)
+    expect(repository.replace).toHaveBeenCalledWith(updatedChallenge)
   })
 })


### PR DESCRIPTION
## Objetivo
Garantir que, apos atualizar um desafio, tanto a pagina de desafio quanto a pagina de edicao exibam sempre o snapshot mais recente, eliminando stale data causada por hidratacao condicional no client e cache na camada RPC/Next.

## Issues relacionadas
resolve #392

## Causa do bug
A causa raiz era combinada:
- no client, `useChallengePage` so hidratava a store quando `challenge` era nulo, mantendo estado antigo ao voltar para a mesma `slug`;
- no server web, as actions `accessChallengePage`, `accessAuthenticatedChallengePage` e `accessChallengeEditorPage` usavam `NextServerRestClient` com cache ativo (`revalidate: 60`), podendo retornar snapshot defasado apos update.

## Changelog
- Core:
  - atualiza `UpdateChallengeUseCase` para retornar o payload persistido apos `replace(...)` com nova leitura por id;
  - amplia testes de `UpdateChallengeUseCase` cobrindo update sem mudanca de titulo e retorno consistente com estado persistido.
- UI Web:
  - ajusta `useChallengePage` para reconciliar `challengeDto` recebido com estado atual da store e reidratar apenas quando houver divergencia real;
  - adiciona testes de hook para cenarios de estado stale e estado estavel.
- RPC Web:
  - desabilita cache de leitura nas actions de acesso da pagina de desafio (publica/autenticada) e de acesso ao editor.
- Documentacao:
  - registra plano e execucao em `documentation/plan.md`;
  - adiciona bug report e spec de correcao do incidente;
  - atualiza prompt de bug report para exigir geracao de spec no mesmo fluxo.

## Como testar
1. Abrir um desafio existente no editor.
2. Alterar apenas campos diferentes de titulo (ex.: descricao, codigo, casos de teste, categorias ou visibilidade) e salvar.
3. Confirmar que a pagina de desafio, ao redirecionar para a mesma `slug`, exibe os dados atualizados imediatamente.
4. Abrir novamente a pagina de edicao do mesmo desafio e validar que os campos refletem os dados mais recentes.
5. Rodar checks locais:
   - `npm run codecheck -w @stardust/core`
   - `npm run typecheck -w @stardust/core`
   - `npm run test -w @stardust/core`
   - `npm run codecheck -w @stardust/web`
   - `npm run typecheck -w @stardust/web`
   - `npm run test -w @stardust/web`

## Observacoes
- A correcao foi mantida no escopo de `web` e `core`, sem alteracoes em contratos de `rest`/`database` no server.
- O ajuste de cache foi focado nas actions de acesso afetadas para reduzir risco de stale data pos-update.