### PR TITLE
Correção de toast de autenticação indevido no desafio público

### DIFF
--- a/apps/server/src/ai/challenging/tools/PostChallengeTool.ts
+++ b/apps/server/src/ai/challenging/tools/PostChallengeTool.ts
@@ -56,6 +56,7 @@ export class PostChallengeTool implements Tool<Input, ChallengeDto> {
           id: accountId,
         },
         isPublic: false,
+        isNew: true,
       },
       challengeSourceId: challengeSourceId ?? null,
     })

--- a/apps/web/src/rpc/actions/challenging/AccessChallengePageAction.ts
+++ b/apps/web/src/rpc/actions/challenging/AccessChallengePageAction.ts
@@ -3,10 +3,10 @@ import type { ChallengingService } from '@stardust/core/challenging/interfaces'
 import type { SpaceService } from '@stardust/core/space/interfaces'
 import type { ChallengeDto } from '@stardust/core/challenging/entities/dtos'
 import { Challenge } from '@stardust/core/challenging/entities'
+import { ChallengeVote } from '@stardust/core/challenging/structures'
 import { Star } from '@stardust/core/space/entities'
 import { User } from '@stardust/core/global/entities'
 import { Slug, type Id } from '@stardust/core/global/structures'
-import { ChallengeVote } from '@stardust/core/challenging/structures'
 
 type Dependencies = {
   challengingService: ChallengingService
@@ -69,10 +69,24 @@ export const AccessChallengePageAction = ({
       const challenge = await fetchChallenge(challengeSlug)
       const user = isAuthenticated ? User.create(await call.getUser()) : null
 
+      if (!user) {
+        if (challenge.starId || challenge.isPublic.isFalse) {
+          call.notFound()
+        }
+
+        const challengeNavigation = await fetchChallengeNavigation(challengeSlug)
+
+        return {
+          challengeDto: challenge.dto,
+          userChallengeVote: ChallengeVote.createAsNone().value,
+          previousChallengeSlug: challengeNavigation.previousChallengeSlug,
+          nextChallengeSlug: challengeNavigation.nextChallengeSlug,
+        }
+      }
+
       if (challenge.starId) {
         const star = await fetchChallengeStar(challenge.starId)
         if (star) {
-          if (!user) call.notFound()
           if (user.isGod.notAndNot(user.hasUnlockedStar(star.id)).isTrue) {
             call.notFound()
           }
@@ -83,28 +97,17 @@ export const AccessChallengePageAction = ({
         ? EMPTY_NAVIGATION
         : await fetchChallengeNavigation(challengeSlug)
 
-      if (user) {
-        const isAuthor = challenge.isChallengeAuthor(user.id)
+      const isAuthor = challenge.isChallengeAuthor(user.id)
 
-        if (challenge.isPublic.isFalse && isAuthor.isFalse && user.isGod.isFalse) {
-          call.notFound()
-        }
-
-        const userChallengeVote = await fetchUserChallengeVote(challenge.id)
-
-        return {
-          challengeDto: challenge.dto,
-          userChallengeVote: userChallengeVote.value,
-          previousChallengeSlug: challengeNavigation.previousChallengeSlug,
-          nextChallengeSlug: challengeNavigation.nextChallengeSlug,
-        }
+      if (challenge.isPublic.isFalse && isAuthor.isFalse && user.isGod.isFalse) {
+        call.notFound()
       }
 
-      if (challenge.isPublic.isFalse) call.notFound()
+      const userChallengeVote = await fetchUserChallengeVote(challenge.id)
 
       return {
         challengeDto: challenge.dto,
-        userChallengeVote: ChallengeVote.createAsNone().value,
+        userChallengeVote: userChallengeVote.value,
         previousChallengeSlug: challengeNavigation.previousChallengeSlug,
         nextChallengeSlug: challengeNavigation.nextChallengeSlug,
       }

--- a/apps/web/src/rpc/actions/challenging/tests/AccessChallengeCommentsSlotAction.test.ts
+++ b/apps/web/src/rpc/actions/challenging/tests/AccessChallengeCommentsSlotAction.test.ts
@@ -1,0 +1,49 @@
+import { mock, type Mock } from 'ts-jest-mocker'
+
+import type { ChallengingService } from '@stardust/core/challenging/interfaces'
+import { ChallengesFaker } from '@stardust/core/challenging/entities/fakers'
+import type { Call } from '@stardust/core/global/interfaces'
+import { RestResponse } from '@stardust/core/global/responses'
+import { Slug } from '@stardust/core/global/structures'
+
+import { AccessChallengeCommentsSlotAction } from '../AccessChallengeCommentsSlotAction'
+
+describe('Access Challenge Comments Slot Action', () => {
+  let call: Mock<Call<{ challengeSlug: string }>>
+  let challengingService: Mock<ChallengingService>
+
+  const challengeSlug = 'binary-search'
+
+  beforeEach(() => {
+    call = mock<Call<{ challengeSlug: string }>>()
+    challengingService = mock<ChallengingService>()
+
+    call.getRequest.mockReturnValue({ challengeSlug })
+  })
+
+  it('should return the challenge id when the challenge exists', async () => {
+    const challengeDto = ChallengesFaker.fakeDto({ slug: challengeSlug })
+
+    challengingService.fetchChallengeBySlug.mockResolvedValue(
+      new RestResponse({ body: challengeDto }),
+    )
+
+    const action = AccessChallengeCommentsSlotAction(challengingService)
+    const response = await action.handle(call)
+
+    expect(challengingService.fetchChallengeBySlug).toHaveBeenCalledWith(
+      Slug.create(challengeSlug),
+    )
+    expect(response).toEqual({ challengeId: challengeDto.id })
+  })
+
+  it('should throw when challenge lookup fails', async () => {
+    const action = AccessChallengeCommentsSlotAction(challengingService)
+
+    challengingService.fetchChallengeBySlug.mockResolvedValue(
+      new RestResponse({ statusCode: 404, errorMessage: 'Challenge not found' }),
+    )
+
+    await expect(action.handle(call)).rejects.toThrow('Challenge not found')
+  })
+})

--- a/apps/web/src/rpc/actions/challenging/tests/AccessChallengeEditorPageAction.test.ts
+++ b/apps/web/src/rpc/actions/challenging/tests/AccessChallengeEditorPageAction.test.ts
@@ -1,0 +1,151 @@
+import { mock, type Mock } from 'ts-jest-mocker'
+
+import type { ChallengingService } from '@stardust/core/challenging/interfaces'
+import {
+  ChallengeCategoriesFaker,
+  ChallengesFaker,
+} from '@stardust/core/challenging/entities/fakers'
+import type { Call } from '@stardust/core/global/interfaces'
+import { Slug } from '@stardust/core/global/structures'
+import { RestResponse } from '@stardust/core/global/responses'
+import { UsersFaker } from '@stardust/core/profile/entities/fakers'
+
+import { AccessChallengeEditorPageAction } from '../AccessChallengeEditorPage'
+
+describe('Access Challenge Editor Page Action', () => {
+  let call: Mock<Call<{ challengeSlug: string }>>
+  let challengingService: Mock<ChallengingService>
+
+  const challengeSlug = 'binary-search'
+
+  beforeEach(() => {
+    call = mock<Call<{ challengeSlug: string }>>()
+    challengingService = mock<ChallengingService>()
+
+    call.getRequest.mockReturnValue({ challengeSlug })
+    call.notFound.mockImplementation(() => {
+      throw new Error('Not found')
+    })
+  })
+
+  it('should return challenge and categories for challenge author', async () => {
+    const userDto = UsersFaker.fakeDto()
+    const challengeDto = ChallengesFaker.fakeDto({
+      slug: challengeSlug,
+      author: {
+        id: userDto.id as string,
+        entity: ChallengesFaker.fakeDto().author.entity,
+      },
+    })
+    const categoriesDto = ChallengeCategoriesFaker.fakeManyDto(3)
+
+    call.getUser.mockResolvedValue(userDto)
+    challengingService.fetchChallengeBySlug.mockResolvedValue(
+      new RestResponse({ body: challengeDto }),
+    )
+    challengingService.fetchAllChallengeCategories.mockResolvedValue(
+      new RestResponse({ body: categoriesDto }),
+    )
+
+    const action = AccessChallengeEditorPageAction(challengingService)
+    const response = await action.handle(call)
+
+    expect(challengingService.fetchChallengeBySlug).toHaveBeenCalledWith(
+      Slug.create(challengeSlug),
+    )
+    expect(challengingService.fetchAllChallengeCategories).toHaveBeenCalled()
+    expect(call.notFound).not.toHaveBeenCalled()
+    expect(response).toEqual({
+      challenge: expect.objectContaining({ id: challengeDto.id }),
+      categories: categoriesDto,
+    })
+  })
+
+  it('should allow god user to access editor even when not author', async () => {
+    const userDto = UsersFaker.fakeDto({ insigniaRoles: ['god'] })
+    const challengeDto = ChallengesFaker.fakeDto({ slug: challengeSlug })
+    const categoriesDto = ChallengeCategoriesFaker.fakeManyDto(2)
+
+    call.getUser.mockResolvedValue(userDto)
+    challengingService.fetchChallengeBySlug.mockResolvedValue(
+      new RestResponse({ body: challengeDto }),
+    )
+    challengingService.fetchAllChallengeCategories.mockResolvedValue(
+      new RestResponse({ body: categoriesDto }),
+    )
+
+    const action = AccessChallengeEditorPageAction(challengingService)
+    const response = await action.handle(call)
+
+    expect(call.notFound).not.toHaveBeenCalled()
+    expect(response.categories).toEqual(categoriesDto)
+  })
+
+  it('should call notFound when user is not author and not god', async () => {
+    const userDto = UsersFaker.fakeDto({ insigniaRoles: [] })
+    const challengeDto = ChallengesFaker.fakeDto({ slug: challengeSlug })
+    const categoriesDto = ChallengeCategoriesFaker.fakeManyDto(1)
+
+    call.getUser.mockResolvedValue(userDto)
+    challengingService.fetchChallengeBySlug.mockResolvedValue(
+      new RestResponse({ body: challengeDto }),
+    )
+    challengingService.fetchAllChallengeCategories.mockResolvedValue(
+      new RestResponse({ body: categoriesDto }),
+    )
+
+    const action = AccessChallengeEditorPageAction(challengingService)
+
+    await expect(action.handle(call)).rejects.toThrow('Not found')
+
+    expect(call.notFound).toHaveBeenCalled()
+  })
+
+  it('should call notFound when challenge is not found', async () => {
+    const userDto = UsersFaker.fakeDto()
+
+    call.getUser.mockResolvedValue(userDto)
+    challengingService.fetchChallengeBySlug.mockResolvedValue(
+      new RestResponse({ statusCode: 404, errorMessage: 'Challenge not found' }),
+    )
+
+    const action = AccessChallengeEditorPageAction(challengingService)
+
+    await expect(action.handle(call)).rejects.toThrow('Not found')
+
+    expect(call.notFound).toHaveBeenCalled()
+    expect(challengingService.fetchAllChallengeCategories).not.toHaveBeenCalled()
+  })
+
+  it('should call notFound when challenge service throws', async () => {
+    const userDto = UsersFaker.fakeDto()
+
+    call.getUser.mockResolvedValue(userDto)
+    challengingService.fetchChallengeBySlug.mockRejectedValue(
+      new Error('Unexpected error'),
+    )
+
+    const action = AccessChallengeEditorPageAction(challengingService)
+
+    await expect(action.handle(call)).rejects.toThrow('Not found')
+
+    expect(call.notFound).toHaveBeenCalled()
+  })
+
+  it('should throw when categories lookup fails', async () => {
+    const userDto = UsersFaker.fakeDto({ insigniaRoles: ['god'] })
+    const challengeDto = ChallengesFaker.fakeDto({ slug: challengeSlug })
+
+    call.getUser.mockResolvedValue(userDto)
+    challengingService.fetchChallengeBySlug.mockResolvedValue(
+      new RestResponse({ body: challengeDto }),
+    )
+    challengingService.fetchAllChallengeCategories.mockResolvedValue(
+      new RestResponse({ statusCode: 500, errorMessage: 'Categories failed' }),
+    )
+
+    const action = AccessChallengeEditorPageAction(challengingService)
+
+    await expect(action.handle(call)).rejects.toThrow('Categories failed')
+  })
+})

--- a/apps/web/src/rpc/actions/challenging/tests/AccessChallengePageAction.test.ts
+++ b/apps/web/src/rpc/actions/challenging/tests/AccessChallengePageAction.test.ts
@@ -3,8 +3,8 @@ import { mock, type Mock } from 'ts-jest-mocker'
 import type { ChallengingService } from '@stardust/core/challenging/interfaces'
 import { Challenge } from '@stardust/core/challenging/entities'
 import { ChallengesFaker } from '@stardust/core/challenging/entities/fakers'
-import { ChallengeNavigationFaker } from '@stardust/core/challenging/structures/fakers'
 import { ChallengeVote } from '@stardust/core/challenging/structures'
+import { ChallengeNavigationFaker } from '@stardust/core/challenging/structures/fakers'
 import type { Call } from '@stardust/core/global/interfaces'
 import { RestResponse } from '@stardust/core/global/responses'
 import { Slug } from '@stardust/core/global/structures'
@@ -40,7 +40,7 @@ describe('Access Challenge Page Action', () => {
     })
   })
 
-  it('should return the navigation payload for unauthenticated public access', async () => {
+  it('should return the navigation payload for unauthenticated public access without star', async () => {
     const postedAt = new Date('2026-03-20T00:00:00.000Z')
     const challengeDto = ChallengesFaker.fakeDto({
       slug: challengeSlug,
@@ -75,8 +75,9 @@ describe('Access Challenge Page Action', () => {
       previousChallengeSlug: navigationDto.previousChallengeSlug,
       nextChallengeSlug: navigationDto.nextChallengeSlug,
     })
-    expect(call.getUser).not.toHaveBeenCalled()
+    expect(call.notFound).not.toHaveBeenCalled()
     expect(challengingService.fetchChallengeVote).not.toHaveBeenCalled()
+    expect(call.getUser).not.toHaveBeenCalled()
   })
 
   it('should return the user vote and navigation payload for authenticated access', async () => {
@@ -166,12 +167,29 @@ describe('Access Challenge Page Action', () => {
 
     await expect(makeAction().handle(call)).rejects.toThrow('Not found')
 
-    expect(spaceService.fetchStarById).toHaveBeenCalledWith(
-      expect.objectContaining({ value: starDto.id }),
-    )
+    expect(spaceService.fetchStarById).not.toHaveBeenCalled()
     expect(call.notFound).toHaveBeenCalled()
     expect(challengingService.fetchChallengeNavigation).not.toHaveBeenCalled()
     expect(challengingService.fetchChallengeVote).not.toHaveBeenCalled()
+  })
+
+  it('should call notFound for unauthenticated users on private challenges', async () => {
+    const challengeDto = ChallengesFaker.fakeDto({
+      slug: challengeSlug,
+      isPublic: false,
+      starId: undefined,
+    })
+
+    challengingService.fetchChallengeBySlug.mockResolvedValue(
+      new RestResponse({ body: challengeDto }),
+    )
+
+    await expect(makeAction().handle(call)).rejects.toThrow('Not found')
+
+    expect(call.notFound).toHaveBeenCalled()
+    expect(challengingService.fetchChallengeNavigation).not.toHaveBeenCalled()
+    expect(challengingService.fetchChallengeVote).not.toHaveBeenCalled()
+    expect(call.getUser).not.toHaveBeenCalled()
   })
 
   it('should call notFound when the authenticated user has not unlocked the star', async () => {

--- a/apps/web/src/rpc/actions/challenging/tests/AccessSolutionPageAction.test.ts
+++ b/apps/web/src/rpc/actions/challenging/tests/AccessSolutionPageAction.test.ts
@@ -1,0 +1,140 @@
+import { mock, type Mock } from 'ts-jest-mocker'
+
+import type { ChallengingService } from '@stardust/core/challenging/interfaces'
+import { NotSolutionAuthorError } from '@stardust/core/challenging/errors'
+import {
+  ChallengesFaker,
+  SolutionsFaker,
+} from '@stardust/core/challenging/entities/fakers'
+import type { Call } from '@stardust/core/global/interfaces'
+import { RestResponse } from '@stardust/core/global/responses'
+import { Slug } from '@stardust/core/global/structures'
+import { UsersFaker } from '@stardust/core/profile/entities/fakers'
+
+import { AccessSolutionPageAction } from '../AccessSolutionPageAction'
+
+describe('Access Solution Page Action', () => {
+  let call: Mock<Call<{ challengeSlug: string; solutionSlug?: string }>>
+  let challengingService: Mock<ChallengingService>
+
+  const challengeSlug = 'binary-search'
+  const solutionSlug = 'binary-search-solution'
+
+  beforeEach(() => {
+    call = mock<Call<{ challengeSlug: string; solutionSlug?: string }>>()
+    challengingService = mock<ChallengingService>()
+  })
+
+  it('should return challenge id and null solution when no solution slug is provided', async () => {
+    const userDto = UsersFaker.fakeDto()
+    const challengeDto = ChallengesFaker.fakeDto({ slug: challengeSlug })
+
+    call.getRequest.mockReturnValue({ challengeSlug })
+    call.getUser.mockResolvedValue(userDto)
+    challengingService.fetchChallengeBySlug.mockResolvedValue(
+      new RestResponse({ body: challengeDto }),
+    )
+
+    const action = AccessSolutionPageAction(challengingService)
+    const response = await action.handle(call)
+
+    expect(challengingService.fetchChallengeBySlug).toHaveBeenCalledWith(
+      Slug.create(challengeSlug),
+    )
+    expect(challengingService.fetchSolutionBySlug).not.toHaveBeenCalled()
+    expect(response).toEqual({
+      challengeId: challengeDto.id,
+      solution: null,
+    })
+  })
+
+  it('should return solution when user is the solution author', async () => {
+    const userDto = UsersFaker.fakeDto()
+    const challengeDto = ChallengesFaker.fakeDto({ slug: challengeSlug })
+    const solutionDto = SolutionsFaker.fakeDto({
+      slug: solutionSlug,
+      author: {
+        id: userDto.id as string,
+        entity: SolutionsFaker.fakeDto().author.entity,
+      },
+    })
+
+    call.getRequest.mockReturnValue({ challengeSlug, solutionSlug })
+    call.getUser.mockResolvedValue(userDto)
+    challengingService.fetchChallengeBySlug.mockResolvedValue(
+      new RestResponse({ body: challengeDto }),
+    )
+    challengingService.fetchSolutionBySlug.mockResolvedValue(
+      new RestResponse({ body: solutionDto }),
+    )
+
+    const action = AccessSolutionPageAction(challengingService)
+    const response = await action.handle(call)
+
+    expect(challengingService.fetchSolutionBySlug).toHaveBeenCalledWith(
+      Slug.create(solutionSlug),
+    )
+    expect(response).toEqual({
+      challengeId: challengeDto.id,
+      solution: solutionDto,
+    })
+  })
+
+  it('should throw NotSolutionAuthorError when user is not the solution author', async () => {
+    const userDto = UsersFaker.fakeDto()
+    const challengeDto = ChallengesFaker.fakeDto({ slug: challengeSlug })
+    const solutionDto = SolutionsFaker.fakeDto({
+      slug: solutionSlug,
+      author: {
+        id: UsersFaker.fakeDto().id as string,
+        entity: SolutionsFaker.fakeDto().author.entity,
+      },
+    })
+
+    call.getRequest.mockReturnValue({ challengeSlug, solutionSlug })
+    call.getUser.mockResolvedValue(userDto)
+    challengingService.fetchChallengeBySlug.mockResolvedValue(
+      new RestResponse({ body: challengeDto }),
+    )
+    challengingService.fetchSolutionBySlug.mockResolvedValue(
+      new RestResponse({ body: solutionDto }),
+    )
+
+    const action = AccessSolutionPageAction(challengingService)
+
+    await expect(action.handle(call)).rejects.toBeInstanceOf(NotSolutionAuthorError)
+  })
+
+  it('should throw when challenge lookup fails', async () => {
+    const userDto = UsersFaker.fakeDto()
+
+    call.getRequest.mockReturnValue({ challengeSlug, solutionSlug })
+    call.getUser.mockResolvedValue(userDto)
+    challengingService.fetchChallengeBySlug.mockResolvedValue(
+      new RestResponse({ statusCode: 404, errorMessage: 'Challenge not found' }),
+    )
+
+    const action = AccessSolutionPageAction(challengingService)
+
+    await expect(action.handle(call)).rejects.toThrow('Challenge not found')
+    expect(challengingService.fetchSolutionBySlug).not.toHaveBeenCalled()
+  })
+
+  it('should throw when solution lookup fails', async () => {
+    const userDto = UsersFaker.fakeDto()
+    const challengeDto = ChallengesFaker.fakeDto({ slug: challengeSlug })
+
+    call.getRequest.mockReturnValue({ challengeSlug, solutionSlug })
+    call.getUser.mockResolvedValue(userDto)
+    challengingService.fetchChallengeBySlug.mockResolvedValue(
+      new RestResponse({ body: challengeDto }),
+    )
+    challengingService.fetchSolutionBySlug.mockResolvedValue(
+      new RestResponse({ statusCode: 404, errorMessage: 'Solution not found' }),
+    )
+
+    const action = AccessSolutionPageAction(challengingService)
+
+    await expect(action.handle(call)).rejects.toThrow('Solution not found')
+  })
+})

--- a/apps/web/src/rpc/actions/challenging/tests/ViewSolutionAction.test.ts
+++ b/apps/web/src/rpc/actions/challenging/tests/ViewSolutionAction.test.ts
@@ -1,0 +1,49 @@
+import { mock, type Mock } from 'ts-jest-mocker'
+
+import type { ChallengingService } from '@stardust/core/challenging/interfaces'
+import { SolutionsFaker } from '@stardust/core/challenging/entities/fakers'
+import type { Call } from '@stardust/core/global/interfaces'
+import { RestResponse } from '@stardust/core/global/responses'
+import { Slug } from '@stardust/core/global/structures'
+
+import { ViewSolutionAction } from '../ViewSolutionAction'
+
+describe('View Solution Action', () => {
+  let call: Mock<Call<{ solutionSlug: string }>>
+  let challengingService: Mock<ChallengingService>
+
+  const solutionSlug = 'binary-search-solution'
+
+  beforeEach(() => {
+    call = mock<Call<{ solutionSlug: string }>>()
+    challengingService = mock<ChallengingService>()
+
+    call.getRequest.mockReturnValue({ solutionSlug })
+  })
+
+  it('should return the solution for a valid slug', async () => {
+    const solutionDto = SolutionsFaker.fakeDto({ slug: solutionSlug })
+
+    challengingService.viewSolution.mockResolvedValue(
+      new RestResponse({ body: solutionDto }),
+    )
+
+    const action = ViewSolutionAction(challengingService)
+    const response = await action.handle(call)
+
+    expect(challengingService.viewSolution).toHaveBeenCalledWith(
+      Slug.create(solutionSlug),
+    )
+    expect(response).toEqual({ solution: solutionDto })
+  })
+
+  it('should throw when solution cannot be viewed', async () => {
+    challengingService.viewSolution.mockResolvedValue(
+      new RestResponse({ statusCode: 404, errorMessage: 'Solution not found' }),
+    )
+
+    const action = ViewSolutionAction(challengingService)
+
+    await expect(action.handle(call)).rejects.toThrow('Solution not found')
+  })
+})

--- a/apps/web/src/ui/challenging/widgets/layouts/Challenge/AssistantChatbot/AssistantChatsHistory/index.tsx
+++ b/apps/web/src/ui/challenging/widgets/layouts/Challenge/AssistantChatbot/AssistantChatsHistory/index.tsx
@@ -5,6 +5,7 @@ import type { ChatDto } from '@stardust/core/conversation/entities/dtos'
 import { useRestContext } from '@/ui/global/hooks/useRestContext'
 import { useToastContext } from '@/ui/global/contexts/ToastContext'
 import type { DialogRef } from '@/ui/global/widgets/components/Dialog/types'
+import { useAuthContext } from '@/ui/auth/contexts/AuthContext'
 
 import { AssistantChatsHistoryView } from './AssistantChatsHistoryView'
 import { useAssistantChatsHistory } from './useAssistantChatsHistory'
@@ -25,6 +26,7 @@ export const AssistantChatsHistory = ({
   const dialogRef = useRef<DialogRef | null>(null)
   const { conversationService } = useRestContext()
   const toastProvider = useToastContext()
+  const { isAccountAuthenticated } = useAuthContext()
   const {
     chats,
     isLoading,
@@ -38,6 +40,7 @@ export const AssistantChatsHistory = ({
     service: conversationService,
     toastProvider,
     dialogRef,
+    isAccountAuthenticated,
     onSelectChat,
     onDeleteChat,
     onEditChatName,

--- a/apps/web/src/ui/challenging/widgets/layouts/Challenge/AssistantChatbot/AssistantChatsHistory/tests/useAssistantChatsHistory.test.ts
+++ b/apps/web/src/ui/challenging/widgets/layouts/Challenge/AssistantChatbot/AssistantChatsHistory/tests/useAssistantChatsHistory.test.ts
@@ -40,6 +40,7 @@ describe('useAssistantChatsHistory', () => {
           service,
           toastProvider,
           dialogRef,
+          isAccountAuthenticated: true,
           onSelectChat,
           onDeleteChat,
           onEditChatName,
@@ -79,7 +80,7 @@ describe('useAssistantChatsHistory', () => {
     )
   })
 
-  it('should fetch chats on mount', async () => {
+  it('should fetch chats on mount when account is authenticated', async () => {
     const chat = ChatFaker.fake()
     service.fetchChats.mockResolvedValueOnce(
       createRestResponse({
@@ -97,6 +98,16 @@ describe('useAssistantChatsHistory', () => {
     await waitFor(() => expect(result.current.chats).toHaveLength(1))
 
     expect(result.current.chats[0].dto).toEqual(chat.dto)
+  })
+
+  it('should not fetch chats on mount when account is not authenticated', async () => {
+    Hook({ isAccountAuthenticated: false })
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20))
+    })
+
+    expect(service.fetchChats).not.toHaveBeenCalled()
   })
 
   it('should close dialog and select chat when handleChatSelect is called', async () => {
@@ -233,7 +244,7 @@ describe('useAssistantChatsHistory', () => {
     expect(toastProvider.showSuccess).toHaveBeenCalledWith('Nome do chat atualizado')
   })
 
-  it('should refetch when dialog opens', async () => {
+  it('should refetch when dialog opens with authenticated account', async () => {
     const chat = ChatFaker.fake()
 
     const firstResponse = createRestResponse({
@@ -257,7 +268,7 @@ describe('useAssistantChatsHistory', () => {
       .mockResolvedValueOnce(firstResponse)
       .mockResolvedValueOnce(secondResponse)
 
-    const { result } = Hook()
+    const { result } = Hook({ isAccountAuthenticated: true })
 
     await waitFor(() => expect(result.current.chats).toHaveLength(1))
 
@@ -286,7 +297,7 @@ describe('useAssistantChatsHistory', () => {
 
     service.fetchChats.mockResolvedValueOnce(response)
 
-    const { result } = Hook()
+    const { result } = Hook({ isAccountAuthenticated: true })
 
     await waitFor(() => expect(result.current.chats).toHaveLength(1))
 
@@ -294,6 +305,26 @@ describe('useAssistantChatsHistory', () => {
 
     act(() => {
       result.current.handleOpenChange(false)
+    })
+
+    expect(service.fetchChats).toHaveBeenCalledTimes(initialCalls)
+  })
+
+  it('should not refetch when dialog opens without authenticated account', async () => {
+    const { result } = Hook({ isAccountAuthenticated: false })
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20))
+    })
+
+    const initialCalls = service.fetchChats.mock.calls.length
+
+    act(() => {
+      result.current.handleOpenChange(true)
+    })
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20))
     })
 
     expect(service.fetchChats).toHaveBeenCalledTimes(initialCalls)

--- a/apps/web/src/ui/challenging/widgets/layouts/Challenge/AssistantChatbot/AssistantChatsHistory/useAssistantChatsHistory.ts
+++ b/apps/web/src/ui/challenging/widgets/layouts/Challenge/AssistantChatbot/AssistantChatsHistory/useAssistantChatsHistory.ts
@@ -16,6 +16,7 @@ export type Params = {
   service: ConversationService
   toastProvider: ToastProvider
   dialogRef: RefObject<DialogRef | null>
+  isAccountAuthenticated: boolean
   onSelectChat: (chatDto: ChatDto) => void
   onDeleteChat: (chatId: string) => void
   onEditChatName?: (chatId: string, chatName: string) => void
@@ -25,6 +26,7 @@ export function useAssistantChatsHistory({
   service,
   toastProvider,
   dialogRef,
+  isAccountAuthenticated,
   onSelectChat,
   onDeleteChat,
   onEditChatName,
@@ -45,6 +47,7 @@ export function useAssistantChatsHistory({
       fetcher: fetchChats,
       itemsPerPage: CHATS_PER_PAGE.value,
       isInfinity: true,
+      isEnabled: isAccountAuthenticated,
     },
   )
 
@@ -59,7 +62,7 @@ export function useAssistantChatsHistory({
   }
 
   function handleOpenChange(isOpen: boolean) {
-    if (isOpen) {
+    if (isOpen && isAccountAuthenticated) {
       refetch()
     }
   }

--- a/apps/web/src/ui/global/hooks/usePaginatedCache.ts
+++ b/apps/web/src/ui/global/hooks/usePaginatedCache.ts
@@ -47,6 +47,10 @@ export function usePaginatedCache<CacheItem>({
     : ''
 
   function getKey(pageIndex: number, previousPageData: CacheItem[]) {
+    if (!isEnabled) {
+      return null
+    }
+
     if (isEnabled && previousPageData && !previousPageData.length) {
       return null
     }

--- a/documentation/features/challenging/challenge-layout/prd.md
+++ b/documentation/features/challenging/challenge-layout/prd.md
@@ -1,1 +1,0 @@
-https://github.com/JohnPetros/stardust/milestone/17

--- a/documentation/features/challenging/challenge-layout/reports/unexpected-toast-for-auth-error-bug-report.md
+++ b/documentation/features/challenging/challenge-layout/reports/unexpected-toast-for-auth-error-bug-report.md
@@ -1,0 +1,336 @@
+---
+title: Toast de auth indevido no desafio publico
+prd: https://github.com/JohnPetros/stardust/milestone/17
+issue: https://github.com/JohnPetros/stardust/issues/384
+apps: web
+status: closed
+last_updated_at: 2026-04-24
+---
+
+# Bug Report: Toast de auth indevido no desafio publico
+
+## Problema Identificado
+
+Ao acessar diretamente a pagina de resolucao de desafio (`/challenging/challenges/[slug]/challenge`) sem sessao ativa, um toast vermelho com a mensagem `Error: Conta nao autorizada` era exibido automaticamente durante o carregamento inicial em cenarios de acesso permitido para anonimos. O comportamento correto e: visitantes anonimos podem acessar apenas desafios publicos sem vinculo a estrela (`starId` ausente), sem exibir toast de autenticacao; desafios privados ou vinculados a estrela devem continuar retornando `404`.
+
+## Resolucao Final
+
+- O widget `AssistantChatsHistory` passou a resolver `isAccountAuthenticated` no entry point e repassar essa pre-condicao ao hook, conforme o Widget Pattern da camada UI.
+- O hook `useAssistantChatsHistory` agora desabilita o `usePaginatedCache` para visitantes anonimos e evita `refetch()` ao abrir o historico sem autenticacao.
+- `AccessChallengePageAction` foi consolidada para permitir acesso anonimo apenas a desafios publicos sem `starId`, mantendo `404` para desafios privados ou vinculados a estrela.
+- A causa raiz confirmada permaneceu a mesma do diagnostico inicial: a UI iniciava um fetch protegido durante a montagem do assistente em contexto anonimo.
+
+## Validacao Final
+
+- Testes de regressao adicionados em `apps/web/src/ui/challenging/widgets/layouts/Challenge/AssistantChatbot/AssistantChatsHistory/tests/useAssistantChatsHistory.test.ts` para garantir que visitantes anonimos nao fazem fetch no mount nem ao abrir o dialog.
+- Teste adicional em `apps/web/src/rpc/actions/challenging/tests/AccessChallengePageAction.test.ts` para garantir `404` em visitante anonimo acessando desafio privado.
+- `npm run test` executado com sucesso apos a consolidacao da correcao.
+- Verificacao arquitetural concluida: a mudanca permaneceu na borda `web/ui` e `web/rpc`, sem alterar contratos de `core`, `rest` ou a protecao do backend em `GET /conversation/chats`.
+
+## Causas
+
+- O layout mobile do desafio monta o slide do assistente no carregamento inicial.
+- O historico de conversas do assistente dispara `fetchChats` automaticamente via `usePaginatedCache` com `isEnabled` padrao `true`.
+- `GET /conversation/chats` e uma rota protegida por `verifyAuthentication`, entao visitantes sem sessao recebem `401` com a mensagem `Conta nao autorizada`.
+- `usePaginatedCache` exibe erros do SWR via toast, transformando o erro esperado de rota protegida em notificacao indevida na pagina publica.
+
+## Contexto e Análise
+
+### Camada Core (Use Cases)
+- **Arquivo:** `packages/core/src/conversation/use-cases/ListChatsUseCase.ts`
+- **Diagnóstico:** O use case lista chats por `userId` e assume identidade autenticada. Nao ha evidencia de bug no core; o historico de conversas e um recurso pessoal e deve continuar exigindo usuario autenticado.
+
+### Camada REST (Controllers)
+- **Arquivo:** `apps/server/src/app/hono/routers/conversation/ChatsRouter.ts`
+- **Diagnóstico:** A rota `GET /conversation/chats` registra `this.authMiddleware.verifyAuthentication` antes de `FetchChatsController`, portanto a resposta `401` para visitante anonimo e comportamento esperado do backend.
+- **Arquivo:** `apps/server/src/rest/controllers/conversation/FetchChatsController.ts`
+- **Diagnóstico:** O controller chama `http.getAccountId()` e repassa o valor como `userId` para `ListChatsUseCase`, confirmando que a listagem de chats depende de conta autenticada.
+
+### Camada REST (Services)
+- **Arquivo:** `apps/web/src/rest/services/ConversationService.ts`
+- **Diagnóstico:** `fetchChats(...)` chama `GET /conversation/chats`. O service apenas transporta o contrato REST protegido; o problema esta no momento em que a UI chama esse metodo sem autenticacao.
+
+### Camada RPC (Actions)
+- **Arquivo:** `apps/web/src/rpc/actions/challenging/AccessChallengePageAction.ts`
+- **Diagnóstico:** A action publica da pagina do desafio evita chamadas autenticadas quando `isAuthenticated` e `false`, retornando `ChallengeVote.createAsNone()` para visitante. Isso indica que o carregamento principal da pagina de desafio nao e a origem do toast.
+
+### Camada UI (Widgets)
+- **Arquivo:** `apps/web/src/ui/challenging/widgets/layouts/Challenge/ChallengeSlider/ChallengeSliderView.tsx`
+- **Diagnóstico:** O slider mobile renderiza `AssistantChatbot` no quarto slide durante a montagem do layout. Em mobile, isso torna o assistente parte do carregamento inicial mesmo antes do usuario navegar ate o slide.
+- **Arquivo:** `apps/web/src/ui/challenging/widgets/layouts/Challenge/AssistantChatbot/AssistantChatbotView.tsx`
+- **Diagnóstico:** A view monta `AssistantChatsHistory` junto com os botoes do cabecalho do assistente. Como o componente de historico possui hook de dados proprio, ele pode iniciar fetch mesmo com o dialog fechado.
+- **Arquivo:** `apps/web/src/ui/challenging/widgets/layouts/Challenge/AssistantChatbot/AssistantChatsHistory/useAssistantChatsHistory.ts`
+- **Diagnóstico:** O hook chama `usePaginatedCache` sem `isEnabled`, usando o valor padrao `true`. Isso dispara `fetchChats` assim que o componente monta, inclusive para usuario anonimo.
+- **Arquivo:** `apps/web/src/ui/global/hooks/usePaginatedCache.ts`
+- **Diagnóstico:** O hook exibe erros de fetch com `toast.show(error)` no `onError`. Quando `fetchChats` recebe `401`, o erro de autorizacao sobe como toast automatico.
+
+### Camada UI (Contexts)
+- **Arquivo:** `apps/web/src/ui/global/contexts/RestContext/useRestContextProvider.ts`
+- **Diagnóstico:** Quando nao ha `accessToken`, o contexto configura `Authorization` como string vazia. Isso nao e a causa principal, mas confirma que chamadas client-side protegidas feitas por visitante nao possuem credencial valida e devem ser evitadas pela UI.
+
+### Camada Next.js App (Pages, Layouts)
+- **Arquivo:** `apps/web/src/app/challenging/challenges/[challengeSlug]/challenge/page.tsx`
+- **Diagnóstico:** A page detecta ausencia de cookie de acesso e executa `accessChallengePage`, a action publica. O fluxo server-side da pagina esta alinhado ao requisito de acesso publico; o erro surge depois, na montagem client-side do assistente/historico.
+
+## Plano de Correção
+
+### 1. O que já existe?
+
+Liste recursos existentes da codebase que estao envolvidos no bug, serao reutilizados na correcao ou podem ser impactados indiretamente.
+
+- **core**
+  - `ListChatsUseCase` — Lista chats por usuario autenticado e deve permanecer protegido.
+- **rest**
+  - `ChatsRouter` — Protege `GET /conversation/chats` com `verifyAuthentication`.
+  - `FetchChatsController` — Resolve `accountId` e delega a listagem de chats ao core.
+  - `ConversationService` — Expoe `fetchChats(...)` para a UI via REST.
+- **rpc**
+  - `AccessChallengePageAction` — Carrega a pagina publica sem buscar voto autenticado para visitantes.
+- **ui**
+  - `ChallengeSliderView` — Monta o assistente no slide mobile durante o carregamento do layout.
+  - `AssistantChatsHistory` — Entry point do historico de chats, onde dependencias e contexto de autenticacao devem ser resolvidos.
+  - `useAssistantChatsHistory` — Controla fetch, paginacao e handlers do historico de chats.
+  - `usePaginatedCache` — Executa fetch paginado e exibe erros como toast.
+  - `RestContextProvider` — Fornece `ConversationService` configurado com o token atual quando existe.
+- **web**
+  - `apps/web/src/app/challenging/challenges/[challengeSlug]/challenge/page.tsx` — Mantem a pagina de desafio publica quando nao ha cookie de acesso.
+
+### 2. O que deve ser criado?
+
+Descreva novos recursos necessarios **apenas se estritamente necessarios**.
+
+- **ui**
+  - Nenhum recurso novo e necessario. A correcao pode reutilizar `AuthContext`, `AssistantChatsHistory` e `usePaginatedCache`.
+
+### 3. O que deve ser modificado?
+
+Liste mudancas pontuais em codigo existente, explicando o motivo da alteracao.
+
+- **ui**
+  - `apps/web/src/ui/challenging/widgets/layouts/Challenge/AssistantChatbot/AssistantChatsHistory/index.tsx` — Consumir o estado de autenticacao no entry point e repassar para `useAssistantChatsHistory`, seguindo o Widget Pattern.
+  - `apps/web/src/ui/challenging/widgets/layouts/Challenge/AssistantChatbot/AssistantChatsHistory/useAssistantChatsHistory.ts` — Receber `isAccountAuthenticated` e passar `isEnabled: isAccountAuthenticated` para `usePaginatedCache`, alem de evitar `refetch()` em `handleOpenChange` quando o usuario nao estiver autenticado.
+
+### 4. O que deve ser removido?
+
+Liste codigo redundante, legado ou incorreto que deve ser eliminado como parte da correcao.
+
+- **ui**
+  - `apps/web/src/ui/challenging/widgets/layouts/Challenge/AssistantChatbot/AssistantChatsHistory/useAssistantChatsHistory.ts` — Remover o comportamento implicito de fetch automatico sem checagem de autenticacao para o historico de chats.
+
+# Spec de Correção: Toast de auth indevido no desafio publico
+
+# 1. Objetivo
+
+Corrigir a pagina publica de resolucao de desafio para que visitantes nao autenticados nao recebam toast automatico de `Conta nao autorizada` durante o carregamento inicial. A implementacao deve impedir que o historico de conversas do assistente dispare chamadas protegidas sem conta autenticada, preservando o acesso publico ao desafio e mantendo os contratos protegidos de conversas no backend.
+
+---
+
+# 2. Escopo
+
+## 2.1 In-scope
+
+- Bloquear o fetch automatico de `GET /conversation/chats` quando `AssistantChatsHistory` montar sem usuario autenticado.
+- Manter `/challenging/challenges/[slug]/challenge` acessivel para visitantes anonimos apenas quando o desafio for publico e sem `starId`, sem toast de erro no carregamento.
+- Preservar a rota protegida `GET /conversation/chats` e o contrato de `ListChatsUseCase` como recursos autenticados.
+- Reutilizar `AuthContext` para decidir se o historico de chats pode buscar dados.
+- Preservar `usePaginatedCache` como utilitario generico de fetch paginado.
+
+## 2.2 Out-of-scope
+
+- Tornar o historico de conversas disponivel para usuarios anonimos.
+- Alterar contratos REST, controllers, use cases ou banco de dados do modulo `conversation`.
+- Alterar as regras de autorizacao de desafio privado, desafio com `starId` ou privilegios de `owner/god` em `AccessChallengePageAction`, alem do ajuste necessario para o caso anonimo publico sem `starId`.
+- Implementar novo dialog de exigencia de conta para criar chats ou consultar historico.
+- Modificar a politica de toast global do `usePaginatedCache`.
+
+---
+
+# 3. Requisitos
+
+## 3.1 Funcionais
+
+- Ao acessar `/challenging/challenges/[slug]/challenge` sem sessao ativa para um desafio publico sem `starId`, nenhum toast `Conta nao autorizada` deve aparecer no carregamento inicial.
+- O historico de conversas do assistente so deve buscar chats quando houver conta autenticada.
+- O carregamento sem cookie deve seguir as regras de autorizacao: anonimo acessa apenas desafio publico sem `starId`; desafio privado ou com `starId` retorna `404`.
+- Usuarios autenticados devem continuar conseguindo abrir o historico de chats do assistente.
+- Usuario dono do desafio privado pode acessar normalmente.
+- Usuario `god` pode acessar qualquer tipo de desafio.
+
+## 3.2 Nao funcionais
+
+- Compatibilidade retroativa: nenhum contrato REST, RPC ou core deve ser alterado.
+- Seguranca: rotas de conversa protegidas devem continuar exigindo `verifyAuthentication`.
+- Resiliencia de UI: componentes montados por slides ou paineis ocultos nao devem disparar chamadas protegidas sem pre-condicao de autenticacao.
+- Arquitetura: dependencias de contexto devem ser resolvidas no entry point do widget, mantendo hooks recebendo parametros.
+
+---
+
+# 4. O que ja existe?
+
+## Camada Core (Use Cases)
+
+* **`ListChatsUseCase`** (`packages/core/src/conversation/use-cases/ListChatsUseCase.ts`) - *Lista chats por `userId`, reforcando que historico de conversas e recurso pessoal autenticado.*
+
+## Camada REST (Controllers)
+
+* **`ChatsRouter`** (`apps/server/src/app/hono/routers/conversation/ChatsRouter.ts`) - *Protege `GET /conversation/chats` com `verifyAuthentication` antes de chamar o controller.*
+* **`FetchChatsController`** (`apps/server/src/rest/controllers/conversation/FetchChatsController.ts`) - *Resolve `accountId` e executa a listagem de chats do usuario autenticado.*
+
+## Camada REST (Services)
+
+* **`ConversationService`** (`apps/web/src/rest/services/ConversationService.ts`) - *Expoe `fetchChats(...)`, que chama `GET /conversation/chats`.*
+
+## Camada RPC (Actions)
+
+* **`AccessChallengePageAction`** (`apps/web/src/rpc/actions/challenging/AccessChallengePageAction.ts`) - *Controla acesso anonimo/autenticado, incluindo regra de `starId`, ownership e privilegio `god`.*
+
+## Camada UI (Widgets)
+
+* **`ChallengeSliderView`** (`apps/web/src/ui/challenging/widgets/layouts/Challenge/ChallengeSlider/ChallengeSliderView.tsx`) - *Renderiza `AssistantChatbot` como quarto slide no mobile, causando montagem do assistente no carregamento inicial.*
+* **`AssistantChatbotView`** (`apps/web/src/ui/challenging/widgets/layouts/Challenge/AssistantChatbot/AssistantChatbotView.tsx`) - *Monta `AssistantChatsHistory` junto ao cabecalho do assistente.*
+* **`AssistantChatsHistory`** (`apps/web/src/ui/challenging/widgets/layouts/Challenge/AssistantChatbot/AssistantChatsHistory/index.tsx`) - *Entry point que resolve `conversationService`, `toastProvider` e deve resolver tambem o estado de autenticacao.*
+* **`useAssistantChatsHistory`** (`apps/web/src/ui/challenging/widgets/layouts/Challenge/AssistantChatbot/AssistantChatsHistory/useAssistantChatsHistory.ts`) - *Executa `usePaginatedCache` para carregar chats e hoje nao recebe pre-condicao de autenticacao.*
+* **`usePaginatedCache`** (`apps/web/src/ui/global/hooks/usePaginatedCache.ts`) - *Hook generico que suporta `isEnabled` e mostra erros do fetch via toast.*
+
+## Camada UI (Contexts)
+
+* **`AuthContextProvider`** (`apps/web/src/ui/auth/contexts/AuthContext/index.tsx`) - *Disponibiliza `isAccountAuthenticated` via hook de auth.*
+* **`RestContextProvider`** (`apps/web/src/ui/global/contexts/RestContext/useRestContextProvider.ts`) - *Fornece `ConversationService` client-side com token quando existe.*
+
+## Camada Next.js App (Pages, Layouts)
+
+* **`Page`** (`apps/web/src/app/challenging/challenges/[challengeSlug]/challenge/page.tsx`) - *Escolhe `accessChallengePage` para visitante sem cookie e entrega `ChallengePage` como pagina publica.*
+
+---
+
+# 5. O que deve ser criado?
+
+**Nao aplicavel**.
+
+---
+
+# 6. O que deve ser modificado?
+
+## Camada UI (Widgets)
+
+* **Arquivo:** `apps/web/src/ui/challenging/widgets/layouts/Challenge/AssistantChatbot/AssistantChatsHistory/index.tsx`
+* **Mudanca:** Consumir o hook de autenticacao existente e repassar `isAccountAuthenticated` para `useAssistantChatsHistory`.
+* **Justificativa:** O entry point do widget ja resolve dependencias externas (`conversationService`, `toastProvider`) e e o local correto para fornecer a pre-condicao de auth ao hook, sem acoplar o hook diretamente ao contexto.
+* **Camada:** `ui`
+
+## Camada UI (Widgets)
+
+* **Arquivo:** `apps/web/src/ui/challenging/widgets/layouts/Challenge/AssistantChatbot/AssistantChatsHistory/useAssistantChatsHistory.ts`
+* **Mudanca:** Adicionar `isAccountAuthenticated: boolean` aos parametros do hook e passar `isEnabled: isAccountAuthenticated` para `usePaginatedCache`.
+* **Justificativa:** `usePaginatedCache` ja possui mecanismo para impedir fetch; usa-lo evita chamada protegida quando o usuario e anonimo e elimina o toast automatico de `Conta nao autorizada`.
+* **Camada:** `ui`
+
+## Camada RPC (Actions)
+
+* **Arquivo:** `apps/web/src/rpc/actions/challenging/AccessChallengePageAction.ts`
+* **Mudanca:** Permitir acesso anonimo apenas para desafio publico sem `starId`; manter `404` para anonimo em desafio privado ou com `starId`; manter acesso para autor de desafio privado e para usuario `god`.
+* **Justificativa:** Alinha o comportamento esperado de autorizacao da pagina de desafio com as regras atuais de produto e evita regressao de acesso indevido.
+* **Camada:** `rpc`
+
+## Camada UI (Widgets)
+
+* **Arquivo:** `apps/web/src/ui/challenging/widgets/layouts/Challenge/AssistantChatbot/AssistantChatsHistory/useAssistantChatsHistory.ts`
+* **Mudanca:** Ajustar `handleOpenChange(isOpen: boolean)` para chamar `refetch()` apenas quando `isOpen` e `isAccountAuthenticated` forem verdadeiros.
+* **Justificativa:** Mesmo apos bloquear o fetch inicial, abrir o dialog como visitante nao deve disparar uma chamada protegida que retornaria `401`.
+* **Camada:** `ui`
+
+---
+
+# 7. O que deve ser removido?
+
+**Nao aplicavel**.
+
+---
+
+# 8. Decisoes Tecnicas e Trade-offs
+
+* **Decisao**
+  - Corrigir o bug na borda `web` com duas frentes: pre-condicao de autenticacao no fetch do historico do assistente e consolidacao explicita das regras de autorizacao da pagina em `AccessChallengePageAction`.
+* **Alternativas consideradas**
+  - Alterar `GET /conversation/chats` para aceitar visitantes anonimos.
+  - Silenciar globalmente erros `401` dentro de `usePaginatedCache`.
+  - Remover o `AssistantChatbot` do slide mobile ate o usuario navegar para ele.
+* **Motivo da escolha**
+  - O backend esta correto ao proteger historico de chats pessoais. O problema e a UI chamar um recurso protegido sem autenticacao, portanto a correcao menor e mais segura e condicionar o fetch na origem.
+* **Impactos / trade-offs**
+  - Visitantes anonimos so acessam desafios publicos sem `starId`; em desafios privados ou com `starId`, a pagina retorna `404`.
+  - Visitantes anonimos continuarao vendo o botao de historico apenas nos cenarios de acesso permitido, mas sem fetch automatico. Uma UX explicita de exigencia de conta para historico ou criacao de chat fica fora desta spec.
+
+---
+
+# 9. Diagramas e Referencias
+
+* **Fluxo de Dados:**
+
+```ascii
+Visitante anonimo
+       |
+       v
+AccessChallengePageAction
+       |
+       +-- desafio privado ou com starId? --> sim --> call.notFound() (404)
+       |
+       `-- desafio publico sem starId --> ChallengePage
+                                    |
+                                    v
+                          AssistantChatsHistory
+                                    |
+                                    v
+                          isAccountAuthenticated?
+                                    |
+                                    +-- nao --> usePaginatedCache desabilitado --> sem GET /conversation/chats --> sem toast
+                                    |
+                                    `-- sim --> ConversationService.fetchChats --> GET /conversation/chats
+```
+
+* **Fluxo Cross-app:**
+
+```ascii
+apps/web UI
+  AssistantChatsHistory
+       |
+       | REST somente se usuario autenticado
+       v
+apps/server REST
+  GET /conversation/chats + verifyAuthentication
+       |
+       v
+packages/core
+  ListChatsUseCase(userId)
+```
+
+* **Layout:**
+
+```ascii
+ChallengeLayoutView
+`- ChallengeSliderView (mobile)
+   `- SwiperSlide: Assistente
+      `- AssistantChatbot
+         `- AssistantChatsHistory
+            `- useAssistantChatsHistory(isAccountAuthenticated)
+```
+
+* **Referencias:**
+  - `apps/web/src/ui/challenging/widgets/layouts/Challenge/ChallengeSlider/ChallengeSliderView.tsx`
+  - `apps/web/src/ui/challenging/widgets/layouts/Challenge/AssistantChatbot/AssistantChatbotView.tsx`
+  - `apps/web/src/rpc/actions/challenging/AccessChallengePageAction.ts`
+  - `apps/web/src/ui/challenging/widgets/layouts/Challenge/AssistantChatbot/AssistantChatsHistory/index.tsx`
+  - `apps/web/src/ui/challenging/widgets/layouts/Challenge/AssistantChatbot/AssistantChatsHistory/useAssistantChatsHistory.ts`
+  - `apps/web/src/ui/global/hooks/usePaginatedCache.ts`
+  - `apps/web/src/rest/services/ConversationService.ts`
+  - `apps/server/src/app/hono/routers/conversation/ChatsRouter.ts`
+  - `apps/server/src/rest/controllers/conversation/FetchChatsController.ts`
+  - `packages/core/src/conversation/use-cases/ListChatsUseCase.ts`
+
+---
+
+# 10. Pendencias / Duvidas
+
+**Sem pendencias**.
+
+---

--- a/documentation/plan.md
+++ b/documentation/plan.md
@@ -5,7 +5,7 @@ status: closed
 
 ## Pendencias (quando aplicavel)
 
-- [ ] Nenhuma pendencia bloqueante identificada no bug report de entrada.
+- Sem pendencias identificadas no bug report informado.
 
 ---
 
@@ -13,60 +13,73 @@ status: closed
 
 | Fase | Objetivo | Depende de | Pode rodar em paralelo com |
 | --- | --- | --- | --- |
-| F1 | Consolidar no core os criterios de integridade do update de desafio para servir como contrato da correcao client-side. | - | - |
-| F3 | Corrigir sincronizacao de estado no `web` para sempre refletir o `challengeDto` fresco apos update. | F1 | - |
+| F1 | Consolidar o contrato funcional da correcao no core (sem alterar dominio, use cases ou contratos protegidos) | - | - |
+| F3 | Implementar a correcao na web para impedir fetch protegido sem autenticacao no historico do assistente | F1 | - |
 
-> **Estratégia de paralelismo:** sempre comece pelo core (domínio, structures e use cases). Assim que o core estiver concluído, a fase `web` pode ser executada, pois depende apenas do contrato definido no core.
+> **Estrategia de paralelismo:** sempre comece pelo core (dominio, structures e use cases). Nesta correcao, apos F1 apenas a fase de `web` e necessaria.
 
 ---
 
-## F1 — Core: Domínio, Structures e Use Cases
+## F1 — Core: Dominio, Structures e Use Cases
 
-**Objetivo:** Definir o contrato do domínio — entidades, structures, interfaces de repositório/provider e use cases — sem nenhuma dependência de infraestrutura. Essa fase desbloqueia F3.
+**Objetivo:** Definir o contrato funcional da correcao sem dependencia de infraestrutura, preservando que historico de chats permanece recurso autenticado.
 
 ### Tarefas
 
-- [x] **T1.1** — Cobrir no core o cenario de update sem mudanca de titulo
+- [x] **T1.1** — Validar e congelar o contrato autenticado do historico de chats
   - **Depende de:** -
-  - **Resultado observavel:** os testes de `UpdateChallengeUseCase` passam a garantir explicitamente que alteracoes em `description`, `code`, `testCases`, `categories` e `isPublic` sao persistidas mesmo quando `title`/`slug` nao mudam.
+  - **Resultado observavel:** Fica explicitado que `ListChatsUseCase` continua exigindo `userId` autenticado e que `GET /conversation/chats` permanece protegido, sem alteracoes em core/server.
   - **Camada:** `core`
-  - **Artefatos:** `packages/core/src/challenging/use-cases/tests/UpdateChallengeUseCase.test.ts`
-  - **Concluido em:** 2026-04-22
+  - **Artefatos:** `packages/core/src/conversation/use-cases/ListChatsUseCase.ts`, `apps/server/src/app/hono/routers/conversation/ChatsRouter.ts`, `apps/server/src/rest/controllers/conversation/FetchChatsController.ts`
+  - **Concluido em:** 2026-04-24
 
-- [x] **T1.2** — Formalizar no core o contrato de payload atualizado apos update
+- [x] **T1.2** — Definir pre-condicoes funcionais para o consumo do historico na UI
   - **Depende de:** T1.1
-  - **Resultado observavel:** o resultado consumido pela borda web para leitura de desafio permanece consistente com o estado persistido apos update no mesmo `slug`, sem perda de campos editaveis.
+  - **Resultado observavel:** Fica definido como criterio de implementacao que `fetchChats` e `refetch` do historico so podem executar quando `isAccountAuthenticated` for `true`.
   - **Camada:** `core`
-  - **Artefatos:** `packages/core/src/challenging/use-cases/UpdateChallengeUseCase.ts`, `packages/core/src/challenging/use-cases/tests/UpdateChallengeUseCase.test.ts`
-  - **Concluido em:** 2026-04-22
+  - **Artefatos:** `apps/web/src/ui/challenging/widgets/layouts/Challenge/AssistantChatbot/AssistantChatsHistory/index.tsx`, `apps/web/src/ui/challenging/widgets/layouts/Challenge/AssistantChatbot/AssistantChatsHistory/useAssistantChatsHistory.ts`
+  - **Concluido em:** 2026-04-24
 
 ---
 
-## F3 — Web: UI e Integração
+## F3 — Web: UI e Integracao
 
-> ⚡ Inicia após F1 estar concluída.
+> ⚡ Pode rodar em paralelo com F2 e F4 apos F1 estar concluida.
 
-**Objetivo:** Implementar a interface e integração client-side na aplicação web — widgets, actions e chamadas RPC/REST — consumindo os contratos definidos no core.
+**Objetivo:** Implementar a correcao na aplicacao web para impedir chamadas autenticadas indevidas no carregamento inicial da pagina publica do desafio.
 
 ### Tarefas
 
-- [x] **T3.1** — Ajustar hidratacao do `useChallengePage` para reconciliar props com store
+- [x] **T3.1** — Injetar estado de autenticacao no entry point de `AssistantChatsHistory`
   - **Depende de:** T1.2
-  - **Resultado observavel:** ao abrir a pagina com `challengeDto` diferente do estado atual em store, o hook atualiza o store com o payload novo, inclusive quando a navegacao retorna para a mesma `slug`.
+  - **Resultado observavel:** `apps/web/src/ui/challenging/widgets/layouts/Challenge/AssistantChatbot/AssistantChatsHistory/index.tsx` passa `isAccountAuthenticated` para `useAssistantChatsHistory`, mantendo a resolucao de dependencias no entry point do widget.
   - **Camada:** `ui`
-  - **Artefatos:** `apps/web/src/ui/challenging/widgets/pages/Challenge/useChallengePage.ts`
-  - **Concluido em:** 2026-04-22
+  - **Artefatos:** `apps/web/src/ui/challenging/widgets/layouts/Challenge/AssistantChatbot/AssistantChatsHistory/index.tsx`, `apps/web/src/ui/challenging/widgets/layouts/Challenge/AssistantChatbot/AssistantChatsHistory/useAssistantChatsHistory.ts`
+  - **Concluido em:** 2026-04-24
 
-- [x] **T3.2** — Preservar estado client-side quando nao houver divergencia de payload
+- [x] **T3.2** — Condicionar o fetch inicial do historico a autenticacao
   - **Depende de:** T3.1
-  - **Resultado observavel:** em navegacoes sem alteracao real de dados, o hook nao sobrescreve o estado local desnecessariamente e mantem o comportamento atual da pagina.
+  - **Resultado observavel:** `apps/web/src/ui/challenging/widgets/layouts/Challenge/AssistantChatbot/AssistantChatsHistory/useAssistantChatsHistory.ts` passa `isEnabled: isAccountAuthenticated` para `usePaginatedCache` e visitantes anonimos nao disparam `GET /conversation/chats` na montagem.
   - **Camada:** `ui`
-  - **Artefatos:** `apps/web/src/ui/challenging/widgets/pages/Challenge/useChallengePage.ts`
-  - **Concluido em:** 2026-04-22
+  - **Artefatos:** `apps/web/src/ui/challenging/widgets/layouts/Challenge/AssistantChatbot/AssistantChatsHistory/useAssistantChatsHistory.ts`, `apps/web/src/ui/challenging/widgets/layouts/Challenge/AssistantChatbot/AssistantChatsHistory/tests/useAssistantChatsHistory.test.ts`, `apps/web/src/ui/global/hooks/usePaginatedCache.ts`
+  - **Concluido em:** 2026-04-24
 
-- [x] **T3.3** — Cobrir em testes do widget os cenarios de estado stale e estado estavel
-  - **Depende de:** T3.1, T3.2
-  - **Resultado observavel:** existe teste automatizado validando que (a) dados atualizados apos edicao na mesma `slug` passam a ser exibidos e (b) payload identico nao dispara reidratacao redundante.
+- [x] **T3.3** — Bloquear `refetch` ao abrir historico sem sessao ativa
+  - **Depende de:** T3.2
+  - **Resultado observavel:** `handleOpenChange` chama `refetch()` apenas quando `isOpen` e `isAccountAuthenticated` forem verdadeiros, evitando `401` esperado para visitante anonimo.
+  - **Camada:** `ui`
+  - **Artefatos:** `apps/web/src/ui/challenging/widgets/layouts/Challenge/AssistantChatbot/AssistantChatsHistory/useAssistantChatsHistory.ts`, `apps/web/src/ui/challenging/widgets/layouts/Challenge/AssistantChatbot/AssistantChatsHistory/tests/useAssistantChatsHistory.test.ts`
+  - **Concluido em:** 2026-04-24
+
+- [x] **T3.4** — Validar comportamento final da pagina publica do desafio
+  - **Depende de:** T3.3
+  - **Resultado observavel:** Ao abrir `/challenging/challenges/[challengeSlug]/challenge` sem sessao, nenhum toast `Conta nao autorizada` aparece no carregamento inicial; com sessao ativa, historico do assistente continua carregando normalmente.
   - **Camada:** `web`
-  - **Artefatos:** `apps/web/src/ui/challenging/widgets/pages/Challenge/tests/useChallengePage.test.ts`
-  - **Concluido em:** 2026-04-22
+  - **Artefatos:** `apps/web/src/ui/challenging/widgets/layouts/Challenge/AssistantChatbot/AssistantChatsHistory/tests/useAssistantChatsHistory.test.ts`
+  - **Concluido em:** 2026-04-24
+
+---
+
+## Divergencias em relacao a Spec
+
+- **T3.2:** Foi necessario corrigir a implementacao de `isEnabled` em `apps/web/src/ui/global/hooks/usePaginatedCache.ts` para que a pre-condicao de autenticacao realmente bloqueie o fetch inicial quando desabilitado.

--- a/documentation/prompts/create-bug-report-prompt.md
+++ b/documentation/prompts/create-bug-report-prompt.md
@@ -13,14 +13,15 @@ O bug report deve:
 - Indicar **onde e por que provavelmente está quebrado**
 - Sugerir **como corrigir**, respeitando a arquitetura do projeto
 
-O resultado desta tarefa é **sempre composto por dois artefatos gerados no mesmo fluxo**:
+O resultado desta tarefa é **sempre um único arquivo Markdown** contendo dois artefatos no mesmo documento:
 - o **Bug Report**
 - a **Spec de correção derivada dele**
 
-Após a criação do Bug Report, uma **Spec de correção** deve ser gerada automaticamente com base no plano de correção levantado, seguindo o prompt `documentation/prompts/create-spec-prompt.md`.
+Após a criação do Bug Report, uma **Spec de correção** deve ser gerada automaticamente com base no plano de correção levantado, seguindo o prompt `documentation/prompts/create-spec-prompt.md`, mas deve ser incorporada ao mesmo arquivo `.md` do Bug Report.
 
 > A Spec não é uma etapa opcional, posterior ou separada.
-> Ela faz parte da mesma entrega do Bug Report e deve ser salva na mesma execução.
+> Ela faz parte da mesma entrega do Bug Report e deve ser salva na mesma execução, no mesmo arquivo Markdown.
+> Não crie um segundo arquivo em `specs/` para a Spec derivada de Bug Report.
 
 ---
 
@@ -77,31 +78,29 @@ Após a criação do Bug Report, uma **Spec de correção** deve ser gerada auto
 
 ### 5. Geração da Spec de Correção
 
-Após salvar o Bug Report, gere automaticamente uma Spec de correção seguindo `documentation/prompts/create-spec-prompt.md`, com as seguintes adaptações:
+Após salvar a seção de Bug Report, gere automaticamente uma Spec de correção no mesmo arquivo Markdown, seguindo `documentation/prompts/create-spec-prompt.md`, com as seguintes adaptações:
 
 - A geração da Spec deve acontecer **na mesma tarefa**, imediatamente após salvar o Bug Report, sem depender de nova solicitação do usuário.
-- O trabalho **só pode ser considerado concluído quando os dois arquivos existirem**: o Bug Report e a Spec derivada.
-- A Spec deve ser tratada como **continuação direta do Bug Report**, e não como entregável independente.
+- O trabalho **só pode ser considerado concluído quando o arquivo único contiver** o Bug Report e a Spec derivada.
+- A Spec deve ser tratada como **continuação direta do Bug Report no mesmo `.md`**, e não como entregável independente.
 
 - O **esboço da tarefa** é o próprio Bug Report gerado.
 - O **PRD de referência** é o PRD da feature afetada, encontrado em `documentation/features/<dominio>/`.
-- O **frontmatter** da Spec deve referenciar o Bug Report no campo `issue`.
+- A Spec **não deve ter frontmatter próprio**; o frontmatter único do arquivo deve permanecer no topo do Bug Report.
 - As seções **O que já existe**, **O que deve ser criado**, **O que deve ser modificado** e **O que deve ser removido** devem ser derivadas diretamente do plano de correção do Bug Report, sem retrabalho de pesquisa.
-- Salve a Spec em `documentation/features/{dominio}/specs/{nome-descritivo}-fix-spec.md`.
+- Salve a Spec como seção adicional dentro de `documentation/features/{dominio}/reports/{nome-descritivo}-bug-report.md`.
 
 ---
 
 ## Template de Saída (Estrutura Obrigatória)
 
-Salve o arquivo em `documentation/features/{dominio}/reports/{nome-descritivo}-bug-report.md` seguindo **estritamente** o template abaixo. Não adicione seções extras nem altere os títulos.
+Salve um único arquivo em `documentation/features/{dominio}/reports/{nome-descritivo}-bug-report.md` seguindo **estritamente** o template abaixo. O mesmo arquivo deve conter o Bug Report e, ao final, a seção `# Spec de Correção` derivada dele. Não crie arquivo separado em `specs/`.
 
 ```md
 ---
 title: {Titulo Curto e Descritivo}
-prd: <link para o PRD referente à bug, sendo uma milestone do GitHub>
-issue: <link para o issue referente à bug, servindo como esboço para a bug>
-prd: <link para o PRD referente à spec, sendo uma milestone do GitHub>
-issue: <link para o issue referente à spec, servindo como esboço para a spec>
+prd: <link para o PRD referente ao bug e à spec, sendo uma milestone do GitHub>
+issue: <link para o issue referente ao bug, servindo como esboço para a spec>
 apps: {web|server|studio}
 status: {open|closed}
 last_updated_at: {YYYY-MM-DD}
@@ -228,6 +227,10 @@ Liste código redundante, legado ou incorreto que deve ser eliminado como parte 
 
 - **{Camada}**
   - `{Nome do Recurso}` — {Motivo da remoção}
+
+# Spec de Correção: {Titulo Curto e Descritivo}
+
+<!-- Gerar a spec no mesmo arquivo, seguindo a estrutura de `documentation/prompts/create-spec-prompt.md`, sem frontmatter próprio. -->
 ```
 
 ---
@@ -241,5 +244,6 @@ Liste código redundante, legado ou incorreto que deve ser eliminado como parte 
 - Use apenas as camadas listadas na seção 3. Mapeamento de Camadas — não crie camadas arbitrárias.
 - Omita do template as camadas que não forem aplicáveis ao bug em questão.
 - A Spec de correção deve ser gerada **sempre**, sem necessidade de solicitação explícita.
-- O processo não deve parar após criar apenas o Bug Report; a tarefa permanece incompleta até a Spec ser criada e salva.
+- O processo não deve parar após criar apenas o Bug Report; a tarefa permanece incompleta até a Spec ser criada no mesmo arquivo Markdown.
 - A Spec de correção **não pode contradizer** o Bug Report — ela é uma derivação direta dele.
+- A Spec de correção **não deve ser salva em arquivo separado**; Bug Report e Spec devem coexistir em um único `.md`.


### PR DESCRIPTION
## Objetivo
Este PR corrige o comportamento da página pública de desafio que exibia um toast de autenticação (`Conta nao autorizada`) para visitantes anônimos no carregamento inicial, mesmo em cenários permitidos.

## Issues relacionadas
resolve #384

## Causa do bug
O histórico de conversas do assistente era montado no layout mobile e disparava `fetchChats` automaticamente via `usePaginatedCache` sem pré-condição de autenticação. Como `GET /conversation/chats` é protegido, visitantes recebiam `401`, convertido em toast pela UI.

## Changelog
- `apps/web/src/ui/challenging/widgets/layouts/Challenge/AssistantChatbot/AssistantChatsHistory/index.tsx`
  - passa a resolver `isAccountAuthenticated` no entry point e repassar ao hook.
- `apps/web/src/ui/challenging/widgets/layouts/Challenge/AssistantChatbot/AssistantChatsHistory/useAssistantChatsHistory.ts`
  - adiciona `isAccountAuthenticated` aos parâmetros.
  - condiciona o fetch com `isEnabled: isAccountAuthenticated`.
  - bloqueia `refetch()` ao abrir o diálogo sem autenticação.
- `apps/web/src/ui/global/hooks/usePaginatedCache.ts`
  - passa a retornar `null` no `getKey` quando `isEnabled` for `false`, evitando fetch indevido.
- `apps/web/src/rpc/actions/challenging/AccessChallengePageAction.ts`
  - consolida regra de acesso anônimo: apenas desafios públicos sem `starId`.
  - mantém `404` para desafios privados ou com `starId` para visitante sem sessão.
- `apps/web/src/rpc/actions/challenging/tests/AccessChallengePageAction.test.ts`
  - amplia cobertura de autorização para acesso anônimo e casos de `notFound`.
- `apps/web/src/ui/challenging/widgets/layouts/Challenge/AssistantChatbot/AssistantChatsHistory/tests/useAssistantChatsHistory.test.ts`
  - adiciona regressão para garantir ausência de fetch/refetch para anônimos.
- testes adicionais de ações RPC em `apps/web/src/rpc/actions/challenging/tests/`:
  - `AccessChallengeCommentsSlotAction.test.ts`
  - `AccessChallengeEditorPageAction.test.ts`
  - `AccessSolutionPageAction.test.ts`
  - `ViewSolutionAction.test.ts`
- documentação atualizada:
  - `documentation/features/challenging/challenge-layout/reports/unexpected-toast-for-auth-error-bug-report.md` (status `closed` + validação final)
  - `documentation/plan.md`
  - `documentation/prompts/create-bug-report-prompt.md`
  - remoção de `documentation/features/challenging/challenge-layout/prd.md`

## Como testar
1. Execute `npm run test` na raiz do monorepo e valide que a suíte passa.
2. Acesse `/challenging/challenges/[slug]/challenge` sem sessão:
   - para desafio público sem `starId`, valide que a página abre sem toast de `Conta nao autorizada`.
3. Ainda sem sessão, tente slug de desafio privado ou com `starId` e valide retorno `404`.
4. Com sessão ativa, abra o histórico do assistente e valide que os chats continuam carregando normalmente.

## Observações
- A correção respeita os limites de camada: ajuste na borda `web/ui` e `web/rpc`, sem alterar contratos de `core` e sem afrouxar autenticação de `GET /conversation/chats`.
- O branch também inclui `.tmp/stardust.wiki` como gitlink (repositório embutido), o que pode ser revisado separadamente se não fizer parte do escopo desejado.