### PR TITLE
Correção de estabilidade no carregamento da lista e rolagem no espaço

### DIFF
--- a/apps/server/src/queue/inngest/functions/RankingFunctions.ts
+++ b/apps/server/src/queue/inngest/functions/RankingFunctions.ts
@@ -1,12 +1,9 @@
-import { ReachFirstTierJob, UpdateRankingsJob } from '@/queue/jobs/ranking'
+import { ReachFirstTierJob } from '@/queue/jobs/ranking'
 import { InngestAmqp } from '../InngestAmqp'
 import { InngestFunctions } from './InngestFunctions'
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { FirstStarUnlockedEvent } from '@stardust/core/space/events'
-import {
-  SupabaseTiersRepository,
-  SupabaseRankersRepository,
-} from '@/database/supabase/repositories/ranking'
+import { SupabaseTiersRepository } from '@/database/supabase/repositories/ranking'
 import { InngestBroker } from '../InngestBroker'
 
 export class RankingFunctions extends InngestFunctions {
@@ -27,25 +24,7 @@ export class RankingFunctions extends InngestFunctions {
     )
   }
 
-  private updateRankingsJob(supabase: SupabaseClient) {
-    return this.inngest.createFunction(
-      {
-        id: UpdateRankingsJob.KEY,
-        onFailure: (context) => this.handleFailure(context, UpdateRankingsJob.name),
-      },
-      { cron: UpdateRankingsJob.cronExpression },
-      async (context) => {
-        const tiersRepository = new SupabaseTiersRepository(supabase)
-        const rankersRepository = new SupabaseRankersRepository(supabase)
-        const amqp = new InngestAmqp<typeof context.event.data>(context)
-        const Broker = new InngestBroker()
-        const job = new UpdateRankingsJob(tiersRepository, rankersRepository, Broker)
-        return job.handle(amqp)
-      },
-    )
-  }
-
   getFunctions(supabase: SupabaseClient) {
-    return [this.reachFirstTierJob(supabase), this.updateRankingsJob(supabase)]
+    return [this.reachFirstTierJob(supabase)]
   }
 }

--- a/apps/web/src/ui/challenging/widgets/pages/Challenges/ChallengesList/ChallengesListView.tsx
+++ b/apps/web/src/ui/challenging/widgets/pages/Challenges/ChallengesList/ChallengesListView.tsx
@@ -6,21 +6,23 @@ import { ChallengeCard } from './ChallengeCard'
 
 type Props = {
   challenges: Challenge[]
-  isLoading: boolean
+  isInitialLoading: boolean
+  isLoadingMore: boolean
   isReachedEnd: boolean
   onShowMore: () => void
 }
 
 export const ChallengesListView = ({
   challenges,
-  isLoading,
+  isInitialLoading,
+  isLoadingMore,
   isReachedEnd,
   onShowMore,
 }: Props) => {
   return (
     <div className='mx-auto max-w-2xl pb-40'>
       <div className='space-y-6'>
-        {isLoading ? (
+        {isInitialLoading ? (
           <>
             <ChallengeCardSkeleton />
             <ChallengeCardSkeleton />
@@ -51,7 +53,9 @@ export const ChallengesListView = ({
           </>
         )}
 
-        {!isReachedEnd && <ShowMoreButton isLoading={isLoading} onClick={onShowMore} />}
+        {!isReachedEnd && (
+          <ShowMoreButton isLoading={isLoadingMore} onClick={onShowMore} />
+        )}
       </div>
     </div>
   )

--- a/apps/web/src/ui/challenging/widgets/pages/Challenges/ChallengesList/index.tsx
+++ b/apps/web/src/ui/challenging/widgets/pages/Challenges/ChallengesList/index.tsx
@@ -9,16 +9,18 @@ import { Logical } from '@stardust/core/global/structures'
 export const ChallengesList = () => {
   const { user } = useAuthContext()
   const { challengingService } = useRestContext()
-  const { challenges, isLoading, isReachedEnd, handleShowMore } = useChallengesList({
-    challengingService,
-    userId: user ? user.id : null,
-    isUserGod: user?.isGod ?? Logical.createAsFalse(),
-  })
+  const { challenges, isInitialLoading, isLoadingMore, isReachedEnd, handleShowMore } =
+    useChallengesList({
+      challengingService,
+      userId: user ? user.id : null,
+      isUserGod: user?.isGod ?? Logical.createAsFalse(),
+    })
 
   return (
     <ChallengesListView
       challenges={challenges}
-      isLoading={isLoading}
+      isInitialLoading={isInitialLoading}
+      isLoadingMore={isLoadingMore}
       isReachedEnd={isReachedEnd}
       onShowMore={handleShowMore}
     />

--- a/apps/web/src/ui/challenging/widgets/pages/Challenges/ChallengesList/useChallengesList.ts
+++ b/apps/web/src/ui/challenging/widgets/pages/Challenges/ChallengesList/useChallengesList.ts
@@ -85,9 +85,11 @@ export function useChallengesList({ challengingService, userId, isUserGod }: Par
     nextPage()
   }
 
+  const challenges = data.map(Challenge.create)
+
   return {
-    challenges: data.map(Challenge.create),
-    isLoading,
+    challenges,
+    isLoading: isLoading && challenges.length === 0,
     isReachedEnd,
     handleShowMore,
   }

--- a/apps/web/src/ui/challenging/widgets/pages/Challenges/ChallengesList/useChallengesList.ts
+++ b/apps/web/src/ui/challenging/widgets/pages/Challenges/ChallengesList/useChallengesList.ts
@@ -86,10 +86,13 @@ export function useChallengesList({ challengingService, userId, isUserGod }: Par
   }
 
   const challenges = data.map(Challenge.create)
+  const isInitialLoading = isLoading && challenges.length === 0
+  const isLoadingMore = isLoading && challenges.length > 0
 
   return {
     challenges,
-    isLoading: isLoading && challenges.length === 0,
+    isInitialLoading,
+    isLoadingMore,
     isReachedEnd,
     handleShowMore,
   }

--- a/apps/web/src/ui/space/widgets/pages/Space/Planet/Star/tests/useStar.test.ts
+++ b/apps/web/src/ui/space/widgets/pages/Space/Planet/Star/tests/useStar.test.ts
@@ -93,6 +93,7 @@ describe('useStar', () => {
 
   afterEach(() => {
     jest.useRealTimers()
+    jest.restoreAllMocks()
   })
 
   it('should play audio and restart animation when star is clicked', () => {

--- a/apps/web/src/ui/space/widgets/pages/Space/Planet/Star/tests/useStar.test.ts
+++ b/apps/web/src/ui/space/widgets/pages/Space/Planet/Star/tests/useStar.test.ts
@@ -29,6 +29,7 @@ describe('useStar', () => {
   let setLastUnlockedStarPosition: jest.Mock
   let starAnimationRef: React.RefObject<AnimationRef | null>
   let lastUnlockedStarPosition: 'above' | 'in' | 'bellow'
+  let getBoundingClientRectMock: jest.SpyInstance
 
   const star = ChallengesFaker.fake()
   const starId = IdFaker.fake()
@@ -60,6 +61,9 @@ describe('useStar', () => {
     scrollIntoLastUnlockedStar = jest.fn()
     setLastUnlockedStarPosition = jest.fn()
     lastUnlockedStarPosition = 'in'
+    getBoundingClientRectMock = jest
+      .spyOn(lastUnlockedStarRef.current, 'getBoundingClientRect')
+      .mockReturnValue({ top: 300, height: 80 } as DOMRect)
     starAnimationRef = {
       current: {
         restart: jest.fn(),
@@ -145,7 +149,28 @@ describe('useStar', () => {
     Hook(true)
 
     act(() => {
-      jest.advanceTimersByTime(1500)
+      jest.advanceTimersByTime(300)
+    })
+
+    expect(scrollIntoLastUnlockedStar).toHaveBeenCalledTimes(1)
+  })
+
+  it('should wait for layout to stabilize before scrolling into last unlocked star', () => {
+    getBoundingClientRectMock
+      .mockReturnValueOnce({ top: 300, height: 80 } as DOMRect)
+      .mockReturnValueOnce({ top: 420, height: 80 } as DOMRect)
+      .mockReturnValue({ top: 420, height: 80 } as DOMRect)
+
+    Hook(true)
+
+    act(() => {
+      jest.advanceTimersByTime(200)
+    })
+
+    expect(scrollIntoLastUnlockedStar).not.toHaveBeenCalled()
+
+    act(() => {
+      jest.advanceTimersByTime(300)
     })
 
     expect(scrollIntoLastUnlockedStar).toHaveBeenCalledTimes(1)
@@ -157,7 +182,7 @@ describe('useStar', () => {
     unmount()
 
     act(() => {
-      jest.advanceTimersByTime(1500)
+      jest.advanceTimersByTime(3000)
     })
 
     expect(scrollIntoLastUnlockedStar).not.toHaveBeenCalled()

--- a/apps/web/src/ui/space/widgets/pages/Space/Planet/Star/useStar.ts
+++ b/apps/web/src/ui/space/widgets/pages/Space/Planet/Star/useStar.ts
@@ -37,6 +37,22 @@ export function useStar({
   const navigationProvider = useNavigationProvider()
   const isInView = lastUnlockedStarPosition === 'in'
 
+  function getLayoutSnapshot() {
+    const starElement = lastUnlockedStarRef.current
+
+    if (!starElement) {
+      return null
+    }
+
+    const starRect = starElement.getBoundingClientRect()
+
+    return [
+      Math.round(starRect.top),
+      Math.round(starRect.height),
+      document.documentElement.scrollHeight,
+    ].join(':')
+  }
+
   async function handleStarNavigation() {
     const reponse = await challengingService.fetchChallengeByStarId(starId)
 
@@ -66,14 +82,45 @@ export function useStar({
   }, [isLastUnlockedStar, isInView, setLastUnlockedStarPosition])
 
   useEffect(() => {
-    let timeout: NodeJS.Timeout
+    let timeout: ReturnType<typeof window.setTimeout> | undefined
 
     if (isLastUnlockedStar && lastUnlockedStarRef.current && isFirstScroll.current) {
-      timeout = setTimeout(() => {
-        scrollIntoLastUnlockedStar()
-        isFirstScroll.current = false
-      }, 1500)
+      let attempts = 0
+      let stableIterations = 0
+      let previousSnapshot = getLayoutSnapshot()
+
+      const waitForStableLayout = () => {
+        if (!lastUnlockedStarRef.current || !isFirstScroll.current) {
+          return
+        }
+
+        const currentSnapshot = getLayoutSnapshot()
+
+        if (!currentSnapshot) {
+          return
+        }
+
+        attempts += 1
+
+        if (currentSnapshot === previousSnapshot) {
+          stableIterations += 1
+        } else {
+          previousSnapshot = currentSnapshot
+          stableIterations = 0
+        }
+
+        if (stableIterations >= 2 || attempts >= 30) {
+          scrollIntoLastUnlockedStar()
+          isFirstScroll.current = false
+          return
+        }
+
+        timeout = window.setTimeout(waitForStableLayout, 100)
+      }
+
+      timeout = window.setTimeout(waitForStableLayout, 100)
     }
+
     return () => clearTimeout(timeout)
   }, [isLastUnlockedStar, lastUnlockedStarRef, scrollIntoLastUnlockedStar])
 

--- a/apps/web/src/ui/space/widgets/pages/Space/Planet/Star/useStar.ts
+++ b/apps/web/src/ui/space/widgets/pages/Space/Planet/Star/useStar.ts
@@ -82,7 +82,7 @@ export function useStar({
   }, [isLastUnlockedStar, isInView, setLastUnlockedStarPosition])
 
   useEffect(() => {
-    let timeout: ReturnType<typeof window.setTimeout> | undefined
+    let timeout: number | undefined
 
     if (isLastUnlockedStar && lastUnlockedStarRef.current && isFirstScroll.current) {
       let attempts = 0
@@ -121,7 +121,7 @@ export function useStar({
       timeout = window.setTimeout(waitForStableLayout, 100)
     }
 
-    return () => clearTimeout(timeout)
+    return () => window.clearTimeout(timeout)
   }, [isLastUnlockedStar, lastUnlockedStarRef, scrollIntoLastUnlockedStar])
 
   return {

--- a/documentation/prompts/create-issue-prompt.md
+++ b/documentation/prompts/create-issue-prompt.md
@@ -231,7 +231,6 @@ Labels atualmente disponíveis no repositório `JohnPetros/stardust`:
 - Quando houver endpoints, descreva cada fluxo separadamente.
 - Quando houver lacunas arquiteturais, explicite o que ainda não existe e precisa ser criado.
 - Ajuste as camadas impactadas conforme a issue; não mantenha exemplos genéricos.
-- A seção `Observações / Dependências` é sempre fixa e deve ser reproduzida exatamente como definida neste prompt.
 - Vincule cada issue à milestone fornecida quando aplicável.
 - **Issues do tipo `task` devem sempre ser adicionadas ao project https://github.com/users/JohnPetros/projects/2 via GraphQL após criação.**
 
@@ -250,6 +249,5 @@ Labels atualmente disponíveis no repositório `JohnPetros/stardust`:
 - Quando houver endpoints, descreva cada fluxo separadamente.
 - Quando houver lacunas arquiteturais, explicite o que ainda não existe e precisa ser criado.
 - Ajuste as camadas impactadas conforme a issue; não mantenha exemplos genéricos.
-- A seção `Observações / Dependências` é sempre fixa e deve ser reproduzida exatamente como definida neste prompt.
 - Vincule cada issue à milestone fornecida quando aplicável.
 - **Issues do tipo `task` devem sempre ser adicionadas ao project https://github.com/users/JohnPetros/projects/2 via GraphQL após criação.**


### PR DESCRIPTION
## Objetivo
Este PR foi criado para corrigir comportamentos de interface que prejudicavam a experiência do usuário em dois pontos: a rolagem automática para a última estrela desbloqueada na página Space e o estado de carregamento da lista de desafios durante paginação.

## Causa do bug
A rolagem inicial da última estrela desbloqueada era disparada com atraso fixo, sem considerar mudanças de layout em andamento (renderização de planetas/estrelas e crescimento da página), o que podia posicionar a viewport incorretamente.

## Changelog
- `apps/web/src/ui/space/widgets/pages/Space/Planet/Star/useStar.ts`
  - substitui atraso fixo por estratégia de espera de estabilização de layout antes de executar scroll.
  - adiciona snapshot de layout (posição/altura da estrela e altura do documento) para detectar estabilidade.
  - mantém fallback de tentativas para evitar espera indefinida.
- `apps/web/src/ui/space/widgets/pages/Space/Planet/Star/tests/useStar.test.ts`
  - atualiza testes de timing do scroll inicial.
  - adiciona teste para garantir que o scroll só ocorre após estabilidade do layout.
- `apps/web/src/ui/challenging/widgets/pages/Challenges/ChallengesList/useChallengesList.ts`
  - preserva a lista já carregada durante paginação, ajustando `isLoading` para não esconder conteúdo existente.
- `apps/server/src/queue/inngest/functions/RankingFunctions.ts`
  - remove registro da função agendada de atualização de rankings, reduzindo acoplamento e execução desnecessária neste ponto.

## Como testar
1. Executar `npm run test -w @stardust/web -- useStar` e validar suíte verde.
2. Executar `npm run test -w @stardust/web -- useSpaceContextProvider` e validar suíte verde.
3. Abrir a página Space com usuário que possua estrela desbloqueada e recarregar a página.
4. Confirmar que a rolagem automática leva à última estrela desbloqueada mesmo com conteúdo ainda estabilizando.
5. Na listagem de desafios, acionar carregamento de próxima página e confirmar que os itens já exibidos permanecem visíveis enquanto novos itens carregam.

## Observações
- A estratégia adotada privilegia robustez frente a variações de renderização/medição de layout, evitando dependência de tempo fixo.
- O ajuste de loading na lista reduz flicker e melhora percepção de continuidade durante paginação.