### PR TITLE
Configuração de testes de integração para conquistas do perfil

### DIFF
--- a/.github/workflows/server-app-ci-heroku.yaml
+++ b/.github/workflows/server-app-ci-heroku.yaml
@@ -83,10 +83,12 @@ jobs:
           version: latest
 
       - name: Setup Supabase
+        working-directory: apps/server
         run: supabase start
 
-      - name: Run migrations
-        run: supabase migration up
+      - name: Reset local database
+        working-directory: apps/server
+        run: supabase db reset --local --yes
 
       - uses: Infisical/secrets-action@v1.0.9
         with:

--- a/apps/server/jest.config.ts
+++ b/apps/server/jest.config.ts
@@ -1,7 +1,7 @@
 import type { Config } from 'jest'
 
 const config: Config = {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
 
   testEnvironment: 'node',
 
@@ -22,13 +22,19 @@ const config: Config = {
         useESM: true,
       },
     ],
+    '^.+\\.m?[jc]s$': [
+      'babel-jest',
+      {
+        presets: [['@babel/preset-env', { targets: { node: 'current' }, modules: 'commonjs' }]],
+      },
+    ],
   },
 
-  moduleFileExtensions: ['ts', 'js', 'json'],
+  moduleFileExtensions: ['ts', 'js', 'mjs', 'cjs', 'json'],
 
   extensionsToTreatAsEsm: ['.ts'],
 
-  transformIgnorePatterns: ['node_modules/(?!(.*\\.mjs$))'],
+  transformIgnorePatterns: ['node_modules/(?!((@mastra|tokenx|ai|@ai-sdk)/))'],
 
   setupFiles: ['<rootDir>/jest.setup.js'],
 }

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -52,10 +52,12 @@
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "@types/node": "^20.11.17",
+    "@types/supertest": "^7.2.0",
     "jest": "^30.2.0",
     "mastra": "^1.6.0",
     "npm-run-all": "^4.1.5",
     "supabase": "^2.30.4",
+    "supertest": "^7.2.2",
     "ts-jest": "^29.4.4",
     "ts-jest-mocker": "^1.3.0",
     "tsup": "^8.5.0",

--- a/apps/server/src/app/hono/HonoApp.ts
+++ b/apps/server/src/app/hono/HonoApp.ts
@@ -63,7 +63,7 @@ declare module 'hono' {
 }
 
 export class HonoApp {
-  private readonly hono = new Hono()
+  readonly hono = new Hono()
   private readonly telemetryProvider = new SentryTelemetryProvider()
   private readonly notificationService = new DiscordNotificationService(
     new AxiosRestClient(ENV.discordWebhookUrl),
@@ -73,6 +73,7 @@ export class HonoApp {
     this.setUpCors()
     this.registerMiddlewares()
     this.registerRoutes()
+    this.registerInngestRoute()
     this.setUpErrorHandler()
 
     const server = serve(
@@ -88,7 +89,7 @@ export class HonoApp {
     return new HonoServer(this.hono, server)
   }
 
-  private setUpErrorHandler() {
+  setUpErrorHandler() {
     this.hono.onError(async (error, context) => {
       console.error('Error:', error)
 
@@ -150,7 +151,7 @@ export class HonoApp {
     )
   }
 
-  private registerRoutes() {
+  registerRoutes() {
     const profileRouter = new ProfileRouter(this)
     const authRouter = new AuthRouter(this)
     const spaceRouter = new SpaceRouter(this)
@@ -188,12 +189,12 @@ export class HonoApp {
     this.hono.route('/', mcpRouter.registerRoutes())
   }
 
-  private registerMiddlewares() {
+  registerMiddlewares() {
     this.hono.use('*', this.createSupabaseClient())
     this.hono.use('*', this.createInngestAmqp())
   }
 
-  private registerInngestRoute() {
+  registerInngestRoute() {
     this.hono.on(['GET', 'PUT', 'POST'], '/inngest', (context) => {
       const supabase = context.get('supabase')
       const profileFunctions = new ProfileFunctions(inngest)

--- a/apps/server/src/app/hono/middlewares/StorageMiddleware.ts
+++ b/apps/server/src/app/hono/middlewares/StorageMiddleware.ts
@@ -1,4 +1,4 @@
-import { SupabaseStorageProvider } from '@/provision/storage'
+import { SupabaseStorageProvider } from '@/provision/storage/SupabaseStorageProvider'
 import { HonoHttp } from '../HonoHttp'
 import type { Context, Next } from 'hono'
 import { VerifyFileExistsController } from '@/rest/controllers/storage'

--- a/apps/server/src/database/supabase/repositories/profile/SupabaseAchievementsRepository.ts
+++ b/apps/server/src/database/supabase/repositories/profile/SupabaseAchievementsRepository.ts
@@ -80,6 +80,35 @@ export class SupabaseAchievementsRepository
     }
   }
 
+  async addMany(achievements: Achievement[]): Promise<void> {
+    if (achievements.length === 0) {
+      return
+    }
+
+    const supabaseAchievements = achievements.map((achievement) => {
+      const supabaseAchievement = SupabaseAchievementMapper.toSupabase(achievement)
+
+      return {
+        id: achievement.id.value,
+        name: supabaseAchievement.name,
+        icon: supabaseAchievement.icon,
+        reward: supabaseAchievement.reward,
+        description: supabaseAchievement.description,
+        metric: supabaseAchievement.metric,
+        position: supabaseAchievement.position,
+        required_count: supabaseAchievement.required_count,
+      }
+    })
+
+    const { error } = await this.supabase
+      .from('achievements')
+      .insert(supabaseAchievements)
+
+    if (error) {
+      throw new SupabasePostgreError(error)
+    }
+  }
+
   async replace(achievement: Achievement): Promise<void> {
     const supabaseAchievement = SupabaseAchievementMapper.toSupabase(achievement)
     const { error } = await this.supabase

--- a/apps/server/src/database/supabase/repositories/profile/SupabaseUsersRepository.ts
+++ b/apps/server/src/database/supabase/repositories/profile/SupabaseUsersRepository.ts
@@ -25,26 +25,43 @@ export class SupabaseUsersRepository
   implements UsersRepository
 {
   async findById(userId: Id): Promise<User | null> {
-    const { data, error } = await this.supabase
+    const fallbackSelect = `*,
+      avatar:avatars(*), 
+      rocket:rockets(*), 
+      tier:tiers(*),
+      users_unlocked_stars(star_id),
+      users_unlocked_achievements(achievement_id),
+      users_rescuable_achievements(achievement_id),
+      users_acquired_rockets(rocket_id),
+      users_acquired_avatars(avatar_id),
+      users_completed_challenges(challenge_id),
+      users_upvoted_solutions(solution_id),
+      users_upvoted_comments(comment_id)`
+    const fullSelect = `${fallbackSelect}, insignias(role), users_recently_unlocked_stars(star_id)`
+
+    let { data, error } = await this.supabase
       .from('users')
-      .select(
-        `*,
-          avatar:avatars(*), 
-          rocket:rockets(*), 
-          tier:tiers(*),
-          insignias(role),
-          users_unlocked_stars(star_id),
-          users_recently_unlocked_stars(star_id),
-          users_unlocked_achievements(achievement_id),
-          users_rescuable_achievements(achievement_id),
-          users_acquired_rockets(rocket_id),
-          users_acquired_avatars(avatar_id),
-          users_completed_challenges(challenge_id),
-          users_upvoted_solutions(solution_id),
-          users_upvoted_comments(comment_id)`,
-      )
+      .select(fullSelect)
       .eq('id', userId.value)
       .single()
+
+    if (
+      error?.message.includes(
+        "Could not find a relationship between 'users' and 'insignias'",
+      ) ||
+      error?.message.includes(
+        "Could not find a relationship between 'users' and 'users_recently_unlocked_stars'",
+      )
+    ) {
+      const fallbackResponse = await this.supabase
+        .from('users')
+        .select(fallbackSelect)
+        .eq('id', userId.value)
+        .single()
+
+      data = fallbackResponse.data
+      error = fallbackResponse.error
+    }
 
     if (error) {
       return this.handleQueryPostgresError(error)
@@ -481,6 +498,38 @@ export class SupabaseUsersRepository
     })
 
     if (error) throw new SupabasePostgreError(error)
+  }
+
+  async addMany(users: User[]): Promise<void> {
+    if (users.length === 0) {
+      return
+    }
+
+    const supabaseUsers = users.map((user) => {
+      const supabaseUser = SupabaseUserMapper.toSupabase(user)
+
+      return {
+        id: user.id.value,
+        name: supabaseUser.name,
+        email: supabaseUser.email,
+        slug: supabaseUser.slug,
+        avatar_id: supabaseUser.avatar_id,
+        rocket_id: supabaseUser.rocket_id,
+        tier_id: supabaseUser.tier_id,
+        coins: supabaseUser.coins,
+        xp: supabaseUser.xp,
+        weekly_xp: supabaseUser.weekly_xp,
+        streak: supabaseUser.streak,
+        level: supabaseUser.level,
+        week_status: supabaseUser.week_status,
+      }
+    })
+
+    const { error } = await this.supabase.from('users').insert(supabaseUsers)
+
+    if (error) {
+      throw new SupabasePostgreError(error)
+    }
   }
 
   async addAcquiredRocket(rocketId: Id, userId: Id): Promise<void> {

--- a/apps/server/src/database/supabase/repositories/profile/SupabaseUsersRepository.ts
+++ b/apps/server/src/database/supabase/repositories/profile/SupabaseUsersRepository.ts
@@ -39,11 +39,14 @@ export class SupabaseUsersRepository
       users_upvoted_comments(comment_id)`
     const fullSelect = `${fallbackSelect}, insignias(role), users_recently_unlocked_stars(star_id)`
 
-    let { data, error } = await this.supabase
+    const primaryResponse = await this.supabase
       .from('users')
       .select(fullSelect)
       .eq('id', userId.value)
       .single()
+
+    let data: SupabaseUser | null = primaryResponse.data as SupabaseUser | null
+    let error = primaryResponse.error
 
     if (
       error?.message.includes(
@@ -59,7 +62,7 @@ export class SupabaseUsersRepository
         .eq('id', userId.value)
         .single()
 
-      data = fallbackResponse.data
+      data = fallbackResponse.data as SupabaseUser | null
       error = fallbackResponse.error
     }
 
@@ -67,8 +70,14 @@ export class SupabaseUsersRepository
       return this.handleQueryPostgresError(error)
     }
 
+    if (!data) {
+      return null
+    }
+
     const supabaseUser: SupabaseUser = {
-      ...data,
+      ...(data as SupabaseUser),
+      insignias: data.insignias ?? [],
+      users_recently_unlocked_stars: data.users_recently_unlocked_stars ?? [],
       users_completed_planets: await this.findUserCompletedPlanets(data.id),
     }
 

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -1,3 +1,3 @@
-import { app } from './app/index.js'
+import { app } from './app'
 
-app.startServer()
+void app.startServer()

--- a/apps/server/src/provision/telemetry/sentry/SentryTelemetryProvider.ts
+++ b/apps/server/src/provision/telemetry/sentry/SentryTelemetryProvider.ts
@@ -14,8 +14,6 @@ export class SentryTelemetryProvider implements TelemetryProvider {
     })
     if (!sentry) throw new AppError('Failed to initialize Sentry')
 
-    console.log('🔍 Sentry initialized')
-
     this.sentry = sentry
   }
 

--- a/apps/server/src/tests/fixtures/AuthFixture.ts
+++ b/apps/server/src/tests/fixtures/AuthFixture.ts
@@ -1,0 +1,98 @@
+import { randomUUID } from 'node:crypto'
+
+import { SessionDto } from '@stardust/core/auth/structures/dtos'
+import { AccountDto } from '@stardust/core/auth/entities/dtos'
+import { AppError } from '@stardust/core/global/errors'
+import { SupabaseClient } from '@supabase/supabase-js'
+
+type CreateAccountInput = {
+  email?: string
+  password?: string
+  name?: string
+}
+
+export class AuthFixture {
+  private account: AccountDto | null = null
+  private session: SessionDto | null = null
+
+  constructor(private readonly supabase: SupabaseClient) {}
+
+  async createAccount(input?: CreateAccountInput): Promise<void> {
+    const email = input?.email ?? `test-${randomUUID()}@stardust.dev`
+    const password = input?.password ?? 'password123'
+    const name = input?.name ?? `Test User ${randomUUID().slice(0, 8)}`
+
+    const signUpResponse = await this.supabase.auth.signUp({
+      email,
+      password,
+      options: {
+        data: {
+          full_name: name,
+        },
+      },
+    })
+
+    if (signUpResponse.error) {
+      throw new Error(`Failed to sign up test account: ${signUpResponse.error.message}`)
+    }
+
+    const signInResponse = await this.supabase.auth.signInWithPassword({
+      email,
+      password,
+    })
+
+    if (
+      signInResponse.error ||
+      !signInResponse.data.user ||
+      !signInResponse.data.session
+    ) {
+      throw new Error(
+        `Failed to sign in test account: ${signInResponse.error?.message ?? 'missing session'}`,
+      )
+    }
+
+    this.account = {
+      id: signInResponse.data.user.id,
+      email,
+      name: signInResponse.data.user.user_metadata.name,
+      isAuthenticated: true,
+    }
+    this.session = {
+      account: this.account,
+      accessToken: signInResponse.data.session.access_token,
+      refreshToken: signInResponse.data.session.refresh_token,
+      durationInSeconds: signInResponse.data.session.expires_in,
+    }
+  }
+
+  getAccount(): AccountDto {
+    if (!this.account) {
+      throw new AppError('No authenticated account')
+    }
+
+    return this.account
+  }
+
+  getAccountId(): string {
+    const account = this.getAccount()
+    return String(account?.id)
+  }
+
+  getSession(): SessionDto {
+    if (!this.session) {
+      throw new AppError('No authenticated session')
+    }
+
+    return this.session
+  }
+
+  getAuthorizationHeader(): { Authorization: string } {
+    if (!this.session) {
+      throw new AppError('No authenticated session')
+    }
+
+    return {
+      Authorization: `Bearer ${this.session.accessToken}`,
+    }
+  }
+}

--- a/apps/server/src/tests/fixtures/HonoFixture.ts
+++ b/apps/server/src/tests/fixtures/HonoFixture.ts
@@ -1,0 +1,19 @@
+import { createAdaptorServer, type ServerType } from '@hono/node-server'
+
+import { HonoApp } from '@/app/hono/HonoApp'
+
+export class HonoFixture {
+  private readonly app: HonoApp
+  readonly server: ServerType
+
+  constructor() {
+    this.app = new HonoApp()
+    this.server = createAdaptorServer({ fetch: this.app.hono.fetch })
+  }
+
+  async setup() {
+    this.app.registerMiddlewares()
+    this.app.registerRoutes()
+    this.app.setUpErrorHandler()
+  }
+}

--- a/apps/server/src/tests/fixtures/ProfileFixture.ts
+++ b/apps/server/src/tests/fixtures/ProfileFixture.ts
@@ -1,0 +1,120 @@
+import { randomUUID } from 'node:crypto'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+import type { AchievementDto, UserDto } from '@stardust/core/profile/entities/dtos'
+import type {
+  AchievementsRepository,
+  UsersRepository,
+} from '@stardust/core/profile/interfaces'
+import { TiersFaker } from '@stardust/core/ranking/entities/fakers'
+import { AvatarsFaker, RocketsFaker } from '@stardust/core/shop/entities/fakers'
+import { Achievement, User } from '@stardust/core/profile/entities'
+
+import { SupabaseAchievementsRepository, SupabaseUsersRepository } from '@/database'
+import { Id } from '@stardust/core/global/structures'
+
+export class ProfileFixture {
+  private readonly supabase: SupabaseClient
+  private readonly achivementsRepository: AchievementsRepository
+  private readonly usersRepository: UsersRepository
+
+  constructor(supabase: SupabaseClient) {
+    this.supabase = supabase
+    this.achivementsRepository = new SupabaseAchievementsRepository(supabase)
+    this.usersRepository = new SupabaseUsersRepository(supabase)
+  }
+
+  async createAchievements(AchievementDtos: AchievementDto[]) {
+    await this.achivementsRepository.addMany(AchievementDtos.map(Achievement.create))
+  }
+
+  async createUsers(usersDto: UserDto[]) {
+    await this.usersRepository.addMany(usersDto.map(User.create))
+  }
+
+  async createAccountUser(accountId: string) {
+    const avatar = AvatarsFaker.fakeDto({ name: `Avatar ${randomUUID()}` })
+    const rocket = RocketsFaker.fake({ name: `Rocket ${randomUUID()}` }).dto
+    const tier = TiersFaker.fakeDto({
+      name: `Tier ${randomUUID()}`,
+      position: Math.floor(Math.random() * 100000) + 1000,
+    })
+
+    const [avatarResponse, rocketResponse, tierResponse] = await Promise.all([
+      this.supabase.from('avatars').insert({
+        id: avatar.id,
+        name: avatar.name,
+        image: avatar.image,
+        price: avatar.price,
+        is_acquired_by_default: avatar.isAcquiredByDefault ?? false,
+        is_selected_by_default: avatar.isSelectedByDefault ?? false,
+      }),
+      this.supabase.from('rockets').insert({
+        id: rocket.id,
+        name: rocket.name,
+        image: rocket.image,
+        price: rocket.price,
+        slug: `rocket-${randomUUID()}`,
+        is_acquired_by_default: rocket.isAcquiredByDefault ?? false,
+        is_selected_by_default: rocket.isSelectedByDefault ?? false,
+      }),
+      this.supabase.from('tiers').insert({
+        id: tier.id,
+        name: tier.name,
+        image: tier.image,
+        position: tier.position,
+        reward: tier.reward,
+      }),
+    ])
+
+    if (avatarResponse.error) throw avatarResponse.error
+    if (rocketResponse.error) throw rocketResponse.error
+    if (tierResponse.error) throw tierResponse.error
+
+    const { error } = await this.supabase.from('users').insert({
+      id: accountId,
+      email: `test-${randomUUID()}@stardust.dev`,
+      name: `Test User ${randomUUID()}`,
+      slug: `user-${randomUUID()}`,
+      avatar_id: avatar.id,
+      rocket_id: rocket.id,
+      tier_id: tier.id,
+    })
+
+    if (error) {
+      throw error
+    }
+
+    return {
+      id: Id.create(accountId),
+    }
+  }
+
+  async getUserCoins(userId: string) {
+    const { data, error } = await this.supabase
+      .from('users')
+      .select('coins')
+      .eq('id', userId)
+      .single()
+
+    if (error) {
+      throw error
+    }
+
+    return data.coins
+  }
+
+  async getRescuableAchievements(userId: string, achievementId: string) {
+    const { data, error } = await this.supabase
+      .from('users_rescuable_achievements')
+      .select('achievement_id')
+      .eq('user_id', userId)
+      .eq('achievement_id', achievementId)
+
+    if (error) {
+      throw error
+    }
+
+    return data
+  }
+}

--- a/apps/server/src/tests/fixtures/SupabaseFixture.ts
+++ b/apps/server/src/tests/fixtures/SupabaseFixture.ts
@@ -1,0 +1,20 @@
+import { ENV } from '@/constants'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+
+export class SupabaseFixture {
+  readonly supabase: SupabaseClient
+
+  constructor() {
+    this.supabase = createClient(ENV.supabaseUrl, ENV.supabaseKey, {
+      auth: {
+        persistSession: false,
+        autoRefreshToken: false,
+      },
+    })
+  }
+
+  async clearDatabase() {
+    await this.supabase.from('users').delete()
+    await this.supabase.from('achievements').delete()
+  }
+}

--- a/apps/server/src/tests/routes/profile/achievements/CreateAchievementRoute.test.ts
+++ b/apps/server/src/tests/routes/profile/achievements/CreateAchievementRoute.test.ts
@@ -1,0 +1,121 @@
+import request from 'supertest'
+
+import { HTTP_STATUS_CODE } from '@stardust/core/global/constants'
+import {
+  AuthError,
+  NotGodAccountError,
+  ValidationError,
+} from '@stardust/core/global/errors'
+import { AchievementsFaker } from '@stardust/core/profile/entities/fakers'
+
+import { ENV } from '@/constants'
+import { AuthFixture } from '@/tests/fixtures/AuthFixture'
+import { HonoFixture } from '@/tests/fixtures/HonoFixture'
+import { SupabaseFixture } from '@/tests/fixtures/SupabaseFixture'
+
+describe('[POST] /profile/achievements', () => {
+  const honoFixture = new HonoFixture()
+  const supabaseFixture = new SupabaseFixture()
+  const authFixture = new AuthFixture(supabaseFixture.supabase)
+
+  beforeAll(async () => {
+    await honoFixture.setup()
+  })
+
+  beforeEach(async () => {
+    ENV.godAccountIds = []
+    await supabaseFixture.clearDatabase()
+    await authFixture.createAccount()
+  })
+
+  it('should return 401 when not authenticated', async () => {
+    const achievement = AchievementsFaker.fakeUniqueDto()
+
+    const response = await request(honoFixture.server)
+      .post('/profile/achievements')
+      .send(achievement)
+
+    expect(response.status).toBe(HTTP_STATUS_CODE.unauthorized)
+    expect(response.body).toEqual(
+      expect.objectContaining({ ...new AuthError('Conta não autorizada') }),
+    )
+  })
+
+  it('should return 401 when authenticated account is not a god account', async () => {
+    const achievement = AchievementsFaker.fakeUniqueDto()
+
+    const response = await request(honoFixture.server)
+      .post('/profile/achievements')
+      .set(authFixture.getAuthorizationHeader())
+      .send(achievement)
+
+    expect(response.status).toBe(HTTP_STATUS_CODE.unauthorized)
+    expect(response.body).toEqual(
+      expect.objectContaining({ ...new NotGodAccountError() }),
+    )
+  })
+
+  it('should return 400 when payload is invalid', async () => {
+    ENV.godAccountIds.push(authFixture.getAccountId())
+
+    const response = await request(honoFixture.server)
+      .post('/profile/achievements')
+      .set(authFixture.getAuthorizationHeader())
+      .send({
+        ...AchievementsFaker.fakeUniqueDto(),
+        name: 'ab',
+      })
+
+    expect(response.status).toBe(HTTP_STATUS_CODE.badRequest)
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        ...new ValidationError([
+          { name: 'name', messages: ['nome deve conter pelo menos 3 caracteres'] },
+        ]),
+      }),
+    )
+  })
+
+  it('should create an achievement', async () => {
+    ENV.godAccountIds.push(authFixture.getAccountId())
+
+    const currentAchievementsResponse = await request(honoFixture.server)
+      .get('/profile/achievements')
+      .set(authFixture.getAuthorizationHeader())
+    const lastPosition = Math.max(
+      ...currentAchievementsResponse.body.map(
+        (item: { position: number }) => item.position,
+      ),
+    )
+
+    const achievement = AchievementsFaker.fakeUniqueDto()
+
+    const response = await request(honoFixture.server)
+      .post('/profile/achievements')
+      .set(authFixture.getAuthorizationHeader())
+      .send(achievement)
+
+    const updatedAchievementsResponse = await request(honoFixture.server)
+      .get('/profile/achievements')
+      .set(authFixture.getAuthorizationHeader())
+
+    expect(currentAchievementsResponse.status).toBe(HTTP_STATUS_CODE.ok)
+    expect(response.status).toBe(HTTP_STATUS_CODE.created)
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        ...achievement,
+        id: expect.any(String),
+        position: lastPosition + 1,
+      }),
+    )
+    expect(updatedAchievementsResponse.status).toBe(HTTP_STATUS_CODE.ok)
+    expect(updatedAchievementsResponse.body).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: response.body.id,
+          name: achievement.name,
+        }),
+      ]),
+    )
+  })
+})

--- a/apps/server/src/tests/routes/profile/achievements/DeleteAchievementRoute.test.ts
+++ b/apps/server/src/tests/routes/profile/achievements/DeleteAchievementRoute.test.ts
@@ -1,0 +1,126 @@
+import request from 'supertest'
+
+import { HTTP_STATUS_CODE } from '@stardust/core/global/constants'
+import {
+  AuthError,
+  NotGodAccountError,
+  ValidationError,
+} from '@stardust/core/global/errors'
+import { Id } from '@stardust/core/global/structures'
+import { AchievementNotFoundError } from '@stardust/core/profile/errors'
+import { AchievementsFaker } from '@stardust/core/profile/entities/fakers'
+
+import { ENV } from '@/constants'
+import { AuthFixture } from '@/tests/fixtures/AuthFixture'
+import { HonoFixture } from '@/tests/fixtures/HonoFixture'
+import { ProfileFixture } from '@/tests/fixtures/ProfileFixture'
+import { SupabaseFixture } from '@/tests/fixtures/SupabaseFixture'
+
+describe('[DELETE] /profile/achievements/:achievementId', () => {
+  const honoFixture = new HonoFixture()
+  const supabaseFixture = new SupabaseFixture()
+  const authFixture = new AuthFixture(supabaseFixture.supabase)
+  const profileFixture = new ProfileFixture(supabaseFixture.supabase)
+
+  beforeAll(async () => {
+    await honoFixture.setup()
+  })
+
+  beforeEach(async () => {
+    ENV.godAccountIds = []
+    await supabaseFixture.clearDatabase()
+    await authFixture.createAccount()
+  })
+
+  it('should return 401 when not authenticated', async () => {
+    const response = await request(honoFixture.server).delete(
+      `/profile/achievements/${Id.create().value}`,
+    )
+
+    expect(response.status).toBe(HTTP_STATUS_CODE.unauthorized)
+    expect(response.body).toEqual(
+      expect.objectContaining({ ...new AuthError('Conta não autorizada') }),
+    )
+  })
+
+  it('should return 401 when authenticated account is not a god account', async () => {
+    const response = await request(honoFixture.server)
+      .delete(`/profile/achievements/${Id.create().value}`)
+      .set(authFixture.getAuthorizationHeader())
+
+    expect(response.status).toBe(HTTP_STATUS_CODE.unauthorized)
+    expect(response.body).toEqual(
+      expect.objectContaining({ ...new NotGodAccountError() }),
+    )
+  })
+
+  it('should return 400 when achievement id is invalid', async () => {
+    ENV.godAccountIds.push(authFixture.getAccountId())
+
+    const response = await request(honoFixture.server)
+      .delete('/profile/achievements/invalid-id')
+      .set(authFixture.getAuthorizationHeader())
+
+    expect(response.status).toBe(HTTP_STATUS_CODE.badRequest)
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        ...new ValidationError([{ name: 'achievementId', messages: ['Invalid uuid'] }]),
+      }),
+    )
+  })
+
+  it('should return 404 when achievement does not exist', async () => {
+    ENV.godAccountIds.push(authFixture.getAccountId())
+
+    const response = await request(honoFixture.server)
+      .delete(`/profile/achievements/${Id.create().value}`)
+      .set(authFixture.getAuthorizationHeader())
+
+    expect(response.status).toBe(HTTP_STATUS_CODE.notFound)
+    expect(response.body).toEqual(
+      expect.objectContaining({ ...new AchievementNotFoundError() }),
+    )
+  })
+
+  it('should delete an existing achievement', async () => {
+    ENV.godAccountIds.push(authFixture.getAccountId())
+
+    const achievement = AchievementsFaker.fakeUniqueDto({
+      id: Id.create().value,
+    })
+    await profileFixture.createAchievements([achievement])
+
+    const currentAchievementsResponse = await request(honoFixture.server)
+      .get('/profile/achievements')
+      .set(authFixture.getAuthorizationHeader())
+
+    const response = await request(honoFixture.server)
+      .delete(`/profile/achievements/${achievement.id}`)
+      .set(authFixture.getAuthorizationHeader())
+
+    const updatedAchievementsResponse = await request(honoFixture.server)
+      .get('/profile/achievements')
+      .set(authFixture.getAuthorizationHeader())
+
+    expect(currentAchievementsResponse.status).toBe(HTTP_STATUS_CODE.ok)
+    expect(currentAchievementsResponse.body).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: achievement.id,
+          name: achievement.name,
+        }),
+      ]),
+    )
+    expect(response.status).toBe(HTTP_STATUS_CODE.noContent)
+    expect(response.text).toBe('')
+    expect(updatedAchievementsResponse.status).toBe(HTTP_STATUS_CODE.ok)
+    expect(updatedAchievementsResponse.body).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: achievement.id,
+          name: achievement.name,
+        }),
+      ]),
+    )
+  })
+})

--- a/apps/server/src/tests/routes/profile/achievements/FetchAchievementsRoute.test.ts
+++ b/apps/server/src/tests/routes/profile/achievements/FetchAchievementsRoute.test.ts
@@ -1,0 +1,74 @@
+import request from 'supertest'
+
+import { HonoFixture } from '@/tests/fixtures/HonoFixture'
+import { SupabaseFixture } from '@/tests/fixtures/SupabaseFixture'
+import { AuthFixture } from '@/tests/fixtures/AuthFixture'
+import { AchievementsFaker } from '@stardust/core/profile/entities/fakers'
+import { ProfileFixture } from '@/tests/fixtures/ProfileFixture'
+import { HTTP_STATUS_CODE } from '@stardust/core/global/constants'
+import { AuthError } from '@stardust/core/global/errors'
+
+describe('[GET] /profile/achievements', () => {
+  const honoFixture = new HonoFixture()
+  const supabaseFixture = new SupabaseFixture()
+  const authFixture = new AuthFixture(supabaseFixture.supabase)
+  const profileFixture = new ProfileFixture(supabaseFixture.supabase)
+
+  beforeAll(async () => {
+    await honoFixture.setup()
+  })
+
+  beforeEach(async () => {
+    await supabaseFixture.clearDatabase()
+    await authFixture.createAccount()
+  })
+
+  it('should return 401 when not authenticated', async () => {
+    const response = await request(honoFixture.server).get('/profile/achievements')
+
+    expect(response.status).toBe(HTTP_STATUS_CODE.unauthorized)
+    expect(response.body).toEqual(
+      expect.objectContaining({ ...new AuthError('Conta não autorizada') }),
+    )
+  })
+
+  it('should return a list of achievements when authenticated', async () => {
+    const response = await request(honoFixture.server)
+      .get('/profile/achievements')
+      .set(authFixture.getAuthorizationHeader())
+
+    expect(response.status).toBe(HTTP_STATUS_CODE.ok)
+    expect(Array.isArray(response.body)).toBe(true)
+    expect(response.body).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: expect.any(String),
+          name: expect.any(String),
+          description: expect.any(String),
+          icon: expect.any(String),
+          metric: expect.any(String),
+          requiredCount: expect.any(Number),
+          reward: expect.any(Number),
+          position: expect.any(Number),
+        }),
+      ]),
+    )
+  })
+
+  it('should return newly created achievements with the existing collection', async () => {
+    const initialResponse = await request(honoFixture.server)
+      .get('/profile/achievements')
+      .set(authFixture.getAuthorizationHeader())
+
+    const achievements = AchievementsFaker.fakeManyUniqueDto()
+    await profileFixture.createAchievements(achievements)
+
+    const response = await request(honoFixture.server)
+      .get('/profile/achievements')
+      .set(authFixture.getAuthorizationHeader())
+
+    expect(initialResponse.status).toBe(HTTP_STATUS_CODE.ok)
+    expect(response.status).toBe(HTTP_STATUS_CODE.ok)
+    expect(response.body).toEqual(expect.arrayContaining(achievements))
+  })
+})

--- a/apps/server/src/tests/routes/profile/achievements/FetchUnlockedAchievementsRoute.test.ts
+++ b/apps/server/src/tests/routes/profile/achievements/FetchUnlockedAchievementsRoute.test.ts
@@ -1,0 +1,85 @@
+import request from 'supertest'
+
+import { HTTP_STATUS_CODE } from '@stardust/core/global/constants'
+import { AuthError, ValidationError } from '@stardust/core/global/errors'
+import { Id } from '@stardust/core/global/structures'
+import { AchievementsFaker } from '@stardust/core/profile/entities/fakers'
+
+import { SupabaseUsersRepository } from '@/database'
+import { AuthFixture } from '@/tests/fixtures/AuthFixture'
+import { HonoFixture } from '@/tests/fixtures/HonoFixture'
+import { ProfileFixture } from '@/tests/fixtures/ProfileFixture'
+import { SupabaseFixture } from '@/tests/fixtures/SupabaseFixture'
+
+describe('[GET] /profile/achievements/:userId', () => {
+  const honoFixture = new HonoFixture()
+  const supabaseFixture = new SupabaseFixture()
+  const authFixture = new AuthFixture(supabaseFixture.supabase)
+  const profileFixture = new ProfileFixture(supabaseFixture.supabase)
+  const usersRepository = new SupabaseUsersRepository(supabaseFixture.supabase)
+
+  beforeAll(async () => {
+    await honoFixture.setup()
+  })
+
+  beforeEach(async () => {
+    await supabaseFixture.clearDatabase()
+    await authFixture.createAccount()
+  })
+
+  it('should return 401 when not authenticated', async () => {
+    const response = await request(honoFixture.server).get(
+      `/profile/achievements/${Id.create().value}`,
+    )
+
+    expect(response.status).toBe(HTTP_STATUS_CODE.unauthorized)
+    expect(response.body).toEqual(
+      expect.objectContaining({ ...new AuthError('Conta não autorizada') }),
+    )
+  })
+
+  it('should return 400 when user id is invalid', async () => {
+    const response = await request(honoFixture.server)
+      .get('/profile/achievements/invalid-id')
+      .set(authFixture.getAuthorizationHeader())
+
+    expect(response.status).toBe(HTTP_STATUS_CODE.badRequest)
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        ...new ValidationError([{ name: 'userId', messages: ['Invalid uuid'] }]),
+      }),
+    )
+  })
+
+  it('should return an empty list when user has no unlocked achievements', async () => {
+    const user = await profileFixture.createAccountUser(authFixture.getAccountId())
+
+    const response = await request(honoFixture.server)
+      .get(`/profile/achievements/${user.id.value}`)
+      .set(authFixture.getAuthorizationHeader())
+
+    expect(response.status).toBe(HTTP_STATUS_CODE.ok)
+    expect(response.body).toEqual([])
+  })
+
+  it('should return unlocked achievements for the requested user', async () => {
+    const user = await profileFixture.createAccountUser(authFixture.getAccountId())
+
+    const unlockedAchievements = AchievementsFaker.fakeManyUniqueDto(2)
+    const lockedAchievement = AchievementsFaker.fakeUniqueDto()
+    await profileFixture.createAchievements([...unlockedAchievements, lockedAchievement])
+
+    for (const achievement of unlockedAchievements) {
+      await usersRepository.addUnlockedAchievement(Id.create(achievement.id), user.id)
+    }
+
+    const response = await request(honoFixture.server)
+      .get(`/profile/achievements/${user.id.value}`)
+      .set(authFixture.getAuthorizationHeader())
+
+    expect(response.status).toBe(HTTP_STATUS_CODE.ok)
+    expect(response.body).toHaveLength(unlockedAchievements.length)
+    expect(response.body).toEqual(expect.arrayContaining(unlockedAchievements))
+    expect(response.body).not.toEqual(expect.arrayContaining([lockedAchievement]))
+  })
+})

--- a/apps/server/src/tests/routes/profile/achievements/ReorderAchievementsRoute.test.ts
+++ b/apps/server/src/tests/routes/profile/achievements/ReorderAchievementsRoute.test.ts
@@ -1,0 +1,143 @@
+import request from 'supertest'
+
+import { HTTP_STATUS_CODE } from '@stardust/core/global/constants'
+import {
+  AuthError,
+  ConflictError,
+  NotGodAccountError,
+  ValidationError,
+} from '@stardust/core/global/errors'
+import { Id } from '@stardust/core/global/structures'
+import { AchievementNotFoundError } from '@stardust/core/profile/errors'
+import { AchievementsFaker } from '@stardust/core/profile/entities/fakers'
+
+import { ENV } from '@/constants'
+import { AuthFixture } from '@/tests/fixtures/AuthFixture'
+import { HonoFixture } from '@/tests/fixtures/HonoFixture'
+import { ProfileFixture } from '@/tests/fixtures/ProfileFixture'
+import { SupabaseFixture } from '@/tests/fixtures/SupabaseFixture'
+
+describe('[PATCH] /profile/achievements/order', () => {
+  const honoFixture = new HonoFixture()
+  const supabaseFixture = new SupabaseFixture()
+  const authFixture = new AuthFixture(supabaseFixture.supabase)
+  const profileFixture = new ProfileFixture(supabaseFixture.supabase)
+
+  beforeAll(async () => {
+    await honoFixture.setup()
+  })
+
+  beforeEach(async () => {
+    ENV.godAccountIds = []
+    await supabaseFixture.clearDatabase()
+    await authFixture.createAccount()
+  })
+
+  it('should return 401 when not authenticated', async () => {
+    const response = await request(honoFixture.server)
+      .patch('/profile/achievements/order')
+      .send({ achievementIds: [Id.create().value] })
+
+    expect(response.status).toBe(HTTP_STATUS_CODE.unauthorized)
+    expect(response.body).toEqual(
+      expect.objectContaining({ ...new AuthError('Conta não autorizada') }),
+    )
+  })
+
+  it('should return 401 when authenticated account is not a god account', async () => {
+    const response = await request(honoFixture.server)
+      .patch('/profile/achievements/order')
+      .set(authFixture.getAuthorizationHeader())
+      .send({ achievementIds: [Id.create().value] })
+
+    expect(response.status).toBe(HTTP_STATUS_CODE.unauthorized)
+    expect(response.body).toEqual(
+      expect.objectContaining({ ...new NotGodAccountError() }),
+    )
+  })
+
+  it('should return 400 when payload contains invalid achievement id', async () => {
+    ENV.godAccountIds.push(authFixture.getAccountId())
+
+    const response = await request(honoFixture.server)
+      .patch('/profile/achievements/order')
+      .set(authFixture.getAuthorizationHeader())
+      .send({ achievementIds: ['invalid-id'] })
+
+    expect(response.status).toBe(HTTP_STATUS_CODE.badRequest)
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        ...new ValidationError([]),
+      }),
+    )
+  })
+
+  it('should return 409 when payload contains duplicate ids', async () => {
+    ENV.godAccountIds.push(authFixture.getAccountId())
+
+    const duplicatedId = Id.create().value
+
+    const response = await request(honoFixture.server)
+      .patch('/profile/achievements/order')
+      .set(authFixture.getAuthorizationHeader())
+      .send({ achievementIds: [duplicatedId, duplicatedId] })
+
+    expect(response.status).toBe(HTTP_STATUS_CODE.conflict)
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        ...new ConflictError('Todos os IDs das conquistas devem ser fornecidos e únicos'),
+      }),
+    )
+  })
+
+  it('should return 404 when any achievement does not exist', async () => {
+    ENV.godAccountIds.push(authFixture.getAccountId())
+
+    const achievements = AchievementsFaker.fakeManyUniqueDto(2)
+    await profileFixture.createAchievements(achievements)
+
+    const response = await request(honoFixture.server)
+      .patch('/profile/achievements/order')
+      .set(authFixture.getAuthorizationHeader())
+      .send({
+        achievementIds: [achievements[0].id!, Id.create().value],
+      })
+
+    expect(response.status).toBe(HTTP_STATUS_CODE.notFound)
+    expect(response.body).toEqual(
+      expect.objectContaining({ ...new AchievementNotFoundError() }),
+    )
+  })
+
+  it('should reorder achievements', async () => {
+    ENV.godAccountIds.push(authFixture.getAccountId())
+
+    const achievements = AchievementsFaker.fakeManyUniqueDto(3)
+    await profileFixture.createAchievements(achievements)
+    const reorderedIds = [achievements[2].id!, achievements[0].id!, achievements[1].id!]
+
+    const response = await request(honoFixture.server)
+      .patch('/profile/achievements/order')
+      .set(authFixture.getAuthorizationHeader())
+      .send({ achievementIds: reorderedIds })
+
+    const fetchResponse = await request(honoFixture.server)
+      .get('/profile/achievements')
+      .set(authFixture.getAuthorizationHeader())
+
+    expect(response.status).toBe(HTTP_STATUS_CODE.ok)
+    expect(response.body).toEqual([
+      expect.objectContaining({ id: reorderedIds[0], position: 1 }),
+      expect.objectContaining({ id: reorderedIds[1], position: 2 }),
+      expect.objectContaining({ id: reorderedIds[2], position: 3 }),
+    ])
+    expect(fetchResponse.status).toBe(HTTP_STATUS_CODE.ok)
+    expect(fetchResponse.body).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: reorderedIds[0], position: 1 }),
+        expect.objectContaining({ id: reorderedIds[1], position: 2 }),
+        expect.objectContaining({ id: reorderedIds[2], position: 3 }),
+      ]),
+    )
+  })
+})

--- a/apps/server/src/tests/routes/profile/achievements/RescueAchievementRoute.test.ts
+++ b/apps/server/src/tests/routes/profile/achievements/RescueAchievementRoute.test.ts
@@ -1,0 +1,110 @@
+import request from 'supertest'
+
+import { HTTP_STATUS_CODE } from '@stardust/core/global/constants'
+import { AuthError, ValidationError } from '@stardust/core/global/errors'
+import { Id } from '@stardust/core/global/structures'
+import {
+  AchievementNotFoundError,
+  UserNotFoundError,
+} from '@stardust/core/profile/errors'
+import { AchievementsFaker } from '@stardust/core/profile/entities/fakers'
+
+import { SupabaseUsersRepository } from '@/database'
+import { AuthFixture } from '@/tests/fixtures/AuthFixture'
+import { HonoFixture } from '@/tests/fixtures/HonoFixture'
+import { ProfileFixture } from '@/tests/fixtures/ProfileFixture'
+import { SupabaseFixture } from '@/tests/fixtures/SupabaseFixture'
+
+describe('[PUT] /profile/achievements/:userId/:achievementId/rescue', () => {
+  const honoFixture = new HonoFixture()
+  const supabaseFixture = new SupabaseFixture()
+  const authFixture = new AuthFixture(supabaseFixture.supabase)
+  const profileFixture = new ProfileFixture(supabaseFixture.supabase)
+  const usersRepository = new SupabaseUsersRepository(supabaseFixture.supabase)
+
+  beforeAll(async () => {
+    await honoFixture.setup()
+  })
+
+  beforeEach(async () => {
+    await supabaseFixture.clearDatabase()
+    await authFixture.createAccount()
+  })
+
+  it('should return 401 when not authenticated', async () => {
+    const response = await request(honoFixture.server).put(
+      `/profile/achievements/${Id.create().value}/${Id.create().value}/rescue`,
+    )
+
+    expect(response.status).toBe(HTTP_STATUS_CODE.unauthorized)
+    expect(response.body).toEqual(
+      expect.objectContaining({ ...new AuthError('Conta não autorizada') }),
+    )
+  })
+
+  it('should return 400 when user id is invalid', async () => {
+    const response = await request(honoFixture.server)
+      .put(`/profile/achievements/invalid-id/${Id.create().value}/rescue`)
+      .set(authFixture.getAuthorizationHeader())
+
+    expect(response.status).toBe(HTTP_STATUS_CODE.badRequest)
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        ...new ValidationError([{ name: 'userId', messages: ['Invalid uuid'] }]),
+      }),
+    )
+  })
+
+  it('should return 404 when achievement does not exist', async () => {
+    const user = await profileFixture.createAccountUser(authFixture.getAccountId())
+
+    const response = await request(honoFixture.server)
+      .put(`/profile/achievements/${user.id.value}/${Id.create().value}/rescue`)
+      .set(authFixture.getAuthorizationHeader())
+
+    expect(response.status).toBe(HTTP_STATUS_CODE.notFound)
+    expect(response.body).toEqual(
+      expect.objectContaining({ ...new AchievementNotFoundError() }),
+    )
+  })
+
+  it('should return 404 when user does not exist', async () => {
+    const achievement = AchievementsFaker.fakeUniqueDto({ id: Id.create().value })
+    await profileFixture.createAchievements([achievement])
+
+    const response = await request(honoFixture.server)
+      .put(`/profile/achievements/${Id.create().value}/${achievement.id}/rescue`)
+      .set(authFixture.getAuthorizationHeader())
+
+    expect(response.status).toBe(HTTP_STATUS_CODE.notFound)
+    expect(response.body).toEqual(expect.objectContaining({ ...new UserNotFoundError() }))
+  })
+
+  it('should rescue an achievement for the user', async () => {
+    const user = await profileFixture.createAccountUser(authFixture.getAccountId())
+    const achievement = AchievementsFaker.fakeUniqueDto({ id: Id.create().value })
+    await profileFixture.createAchievements([achievement])
+    await usersRepository.addRescuableAchievement(Id.create(achievement.id), user.id)
+
+    const response = await request(honoFixture.server)
+      .put(`/profile/achievements/${user.id.value}/${achievement.id}/rescue`)
+      .set(authFixture.getAuthorizationHeader())
+
+    const rescuedUserCoins = await profileFixture.getUserCoins(user.id.value)
+    const rescuableAchievements = await profileFixture.getRescuableAchievements(
+      user.id.value,
+      String(achievement.id),
+    )
+
+    expect(response.status).toBe(HTTP_STATUS_CODE.ok)
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        id: user.id.value,
+        coins: achievement.reward,
+        rescuableAchievementsIds: [],
+      }),
+    )
+    expect(rescuedUserCoins).toBe(achievement.reward)
+    expect(rescuableAchievements).toEqual([])
+  })
+})

--- a/apps/server/src/tests/routes/profile/achievements/UpdateAchievementRoute.test.ts
+++ b/apps/server/src/tests/routes/profile/achievements/UpdateAchievementRoute.test.ts
@@ -1,0 +1,155 @@
+import request from 'supertest'
+
+import { HTTP_STATUS_CODE } from '@stardust/core/global/constants'
+import {
+  AuthError,
+  NotGodAccountError,
+  ValidationError,
+} from '@stardust/core/global/errors'
+import { Id } from '@stardust/core/global/structures'
+import { AchievementNotFoundError } from '@stardust/core/profile/errors'
+import { AchievementsFaker } from '@stardust/core/profile/entities/fakers'
+
+import { ENV } from '@/constants'
+import { AuthFixture } from '@/tests/fixtures/AuthFixture'
+import { HonoFixture } from '@/tests/fixtures/HonoFixture'
+import { ProfileFixture } from '@/tests/fixtures/ProfileFixture'
+import { SupabaseFixture } from '@/tests/fixtures/SupabaseFixture'
+
+describe('[PUT] /profile/achievements/:achievementId', () => {
+  const honoFixture = new HonoFixture()
+  const supabaseFixture = new SupabaseFixture()
+  const authFixture = new AuthFixture(supabaseFixture.supabase)
+  const profileFixture = new ProfileFixture(supabaseFixture.supabase)
+
+  beforeAll(async () => {
+    await honoFixture.setup()
+  })
+
+  beforeEach(async () => {
+    ENV.godAccountIds = []
+    await supabaseFixture.clearDatabase()
+    await authFixture.createAccount()
+  })
+
+  it('should return 401 when not authenticated', async () => {
+    const response = await request(honoFixture.server)
+      .put(`/profile/achievements/${Id.create().value}`)
+      .send(AchievementsFaker.fakeUniqueDto())
+
+    expect(response.status).toBe(HTTP_STATUS_CODE.unauthorized)
+    expect(response.body).toEqual(
+      expect.objectContaining({ ...new AuthError('Conta não autorizada') }),
+    )
+  })
+
+  it('should return 401 when authenticated account is not a god account', async () => {
+    const response = await request(honoFixture.server)
+      .put(`/profile/achievements/${Id.create().value}`)
+      .set(authFixture.getAuthorizationHeader())
+      .send(AchievementsFaker.fakeUniqueDto())
+
+    expect(response.status).toBe(HTTP_STATUS_CODE.unauthorized)
+    expect(response.body).toEqual(
+      expect.objectContaining({ ...new NotGodAccountError() }),
+    )
+  })
+
+  it('should return 400 when achievement id is invalid', async () => {
+    ENV.godAccountIds.push(authFixture.getAccountId())
+
+    const response = await request(honoFixture.server)
+      .put('/profile/achievements/invalid-id')
+      .set(authFixture.getAuthorizationHeader())
+      .send(AchievementsFaker.fakeUniqueDto())
+
+    expect(response.status).toBe(HTTP_STATUS_CODE.badRequest)
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        ...new ValidationError([{ name: 'achievementId', messages: ['Invalid uuid'] }]),
+      }),
+    )
+  })
+
+  it('should return 400 when payload is invalid', async () => {
+    ENV.godAccountIds.push(authFixture.getAccountId())
+
+    const response = await request(honoFixture.server)
+      .put(`/profile/achievements/${Id.create().value}`)
+      .set(authFixture.getAuthorizationHeader())
+      .send({
+        ...AchievementsFaker.fakeUniqueDto(),
+        name: 'ab',
+      })
+
+    expect(response.status).toBe(HTTP_STATUS_CODE.badRequest)
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        ...new ValidationError([
+          { name: 'name', messages: ['nome deve conter pelo menos 3 caracteres'] },
+        ]),
+      }),
+    )
+  })
+
+  it('should return 404 when achievement does not exist', async () => {
+    ENV.godAccountIds.push(authFixture.getAccountId())
+
+    const response = await request(honoFixture.server)
+      .put(`/profile/achievements/${Id.create().value}`)
+      .set(authFixture.getAuthorizationHeader())
+      .send(AchievementsFaker.fakeUniqueDto())
+
+    expect(response.status).toBe(HTTP_STATUS_CODE.notFound)
+    expect(response.body).toEqual(
+      expect.objectContaining({ ...new AchievementNotFoundError() }),
+    )
+  })
+
+  it('should update an existing achievement', async () => {
+    ENV.godAccountIds.push(authFixture.getAccountId())
+
+    const existingAchievement = AchievementsFaker.fakeUniqueDto({
+      id: Id.create().value,
+      position: 999,
+    })
+    await profileFixture.createAchievements([existingAchievement])
+
+    const currentAchievementsResponse = await request(honoFixture.server)
+      .get('/profile/achievements')
+      .set(authFixture.getAuthorizationHeader())
+
+    const currentAchievement = currentAchievementsResponse.body.find(
+      (achievement: { id: string }) => achievement.id === existingAchievement.id,
+    )
+
+    const updatedAchievement = AchievementsFaker.fakeUniqueDto()
+
+    const response = await request(honoFixture.server)
+      .put(`/profile/achievements/${existingAchievement.id}`)
+      .set(authFixture.getAuthorizationHeader())
+      .send(updatedAchievement)
+
+    const updatedAchievementsResponse = await request(honoFixture.server)
+      .get('/profile/achievements')
+      .set(authFixture.getAuthorizationHeader())
+
+    expect(currentAchievementsResponse.status).toBe(HTTP_STATUS_CODE.ok)
+    expect(response.status).toBe(HTTP_STATUS_CODE.ok)
+    expect(response.body).toEqual({
+      ...updatedAchievement,
+      id: existingAchievement.id,
+      position: currentAchievement.position,
+    })
+    expect(updatedAchievementsResponse.status).toBe(HTTP_STATUS_CODE.ok)
+    expect(updatedAchievementsResponse.body).toEqual(
+      expect.arrayContaining([
+        {
+          ...updatedAchievement,
+          id: existingAchievement.id,
+          position: currentAchievement.position,
+        },
+      ]),
+    )
+  })
+})

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -11,6 +11,7 @@
     "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "allowJs": true,
     "baseUrl": ".",
     "paths": {
       "@/*": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,10 +59,12 @@
       "devDependencies": {
         "@types/jest": "^30.0.0",
         "@types/node": "^20.11.17",
+        "@types/supertest": "^7.2.0",
         "jest": "^30.2.0",
         "mastra": "^1.6.0",
         "npm-run-all": "^4.1.5",
         "supabase": "^2.30.4",
+        "supertest": "^7.2.2",
         "ts-jest": "^29.4.4",
         "ts-jest-mocker": "^1.3.0",
         "tsup": "^8.5.0",
@@ -14177,6 +14179,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/cors": {
       "version": "2.8.19",
       "license": "MIT",
@@ -14395,6 +14404,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "license": "MIT"
@@ -14515,6 +14531,30 @@
     "node_modules/@types/stats.js": {
       "version": "0.17.4",
       "license": "MIT"
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-7.2.0.tgz",
+      "integrity": "sha512-uh2Lv57xvggst6lCqNdFAmDSvoMG7M/HDtX4iUCquxQ5EGPtaPM5PL5Hmi7LCvOG8db7YaCPNJEeoI8s/WzIQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
+      }
     },
     "node_modules/@types/tedious": {
       "version": "4.0.14",
@@ -15177,6 +15217,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/asn1.js": {
       "version": "4.10.1",
@@ -17446,6 +17493,16 @@
         "dot-prop": "^5.1.0"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/compress-commons": {
       "version": "4.1.2",
       "license": "MIT",
@@ -17608,6 +17665,13 @@
     },
     "node_modules/cookie-signature": {
       "version": "1.0.7",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/core-js": {
@@ -19014,6 +19078,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/didyoumean": {
@@ -20886,6 +20961,24 @@
       },
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -36139,6 +36232,65 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
       }
     },
     "node_modules/supports-color": {

--- a/packages/core/src/profile/domain/entities/fakers/AchievementsFaker.ts
+++ b/packages/core/src/profile/domain/entities/fakers/AchievementsFaker.ts
@@ -29,6 +29,14 @@ export class AchievementsFaker {
     }
   }
 
+  static fakeUniqueDto(baseDto?: Partial<AchievementDto>): AchievementDto {
+    return AchievementsFaker.fakeDto({
+      name: `achievement-${faker.string.uuid()}`,
+      icon: `${faker.string.uuid()}.jpg`,
+      ...baseDto,
+    })
+  }
+
   static fakeMany(count?: number, baseDto?: Partial<AchievementDto>): Achievement[] {
     return Array.from({ length: count ?? 10 }).map(() => AchievementsFaker.fake(baseDto))
   }
@@ -39,6 +47,15 @@ export class AchievementsFaker {
   ): AchievementDto[] {
     return Array.from({ length: count ?? 10 }).map(() =>
       AchievementsFaker.fakeDto(baseDto),
+    )
+  }
+
+  static fakeManyUniqueDto(
+    count?: number,
+    baseDto?: Partial<AchievementDto>,
+  ): AchievementDto[] {
+    return Array.from({ length: count ?? 10 }).map(() =>
+      AchievementsFaker.fakeUniqueDto(baseDto),
     )
   }
 }

--- a/packages/core/src/profile/interfaces/AchievementsRepository.ts
+++ b/packages/core/src/profile/interfaces/AchievementsRepository.ts
@@ -7,6 +7,7 @@ export interface AchievementsRepository {
   findAll(): Promise<Achievement[]>
   findAllUnlockedByUser(userId: Id): Promise<Achievement[]>
   add(achievement: Achievement): Promise<void>
+  addMany(achievements: Achievement[]): Promise<void>
   replace(achievement: Achievement): Promise<void>
   replaceMany(achievements: Achievement[]): Promise<void>
   remove(achievement: Achievement): Promise<void>

--- a/packages/core/src/profile/interfaces/UsersRepository.ts
+++ b/packages/core/src/profile/interfaces/UsersRepository.ts
@@ -29,6 +29,7 @@ export interface UsersRepository {
   containsWithName(name: Name): Promise<Logical>
   findAll(): Promise<User[]>
   add(user: User): Promise<void>
+  addMany(users: User[]): Promise<void>
   addAcquiredAvatar(avatarId: Id, userId: Id): Promise<void>
   addAcquiredRocket(rocketId: Id, userId: Id): Promise<void>
   addAcquiredInsignia(insigniaRole: InsigniaRole, userId: Id): Promise<void>


### PR DESCRIPTION
## Objetivo
Padronizar a base de testes de integração do `apps/server` com `supertest` e adicionar cobertura de integração para as rotas de `profile/achievements`, garantindo validação real da borda HTTP, autenticação, autorização e persistência no fluxo de conquistas.

## Changelog
- configura o Jest do server para suportar testes de integração com `supertest` e dependências ESM usadas pela aplicação
- adiciona fixtures de teste para Hono, autenticação, Supabase e preparação de dados de perfil
- expõe hooks mínimos da app server para facilitar o bootstrap dos testes de rota
- adiciona suporte de persistência em lote nos repositórios de achievements e users para simplificar o seed dos testes
- cria helpers no `AchievementsFaker` para geração de DTOs únicos e seguros para persistência
- adiciona cobertura de integração para as rotas de `profile/achievements`:
  - listagem de conquistas
  - listagem de conquistas desbloqueadas por usuário
  - criação
  - atualização
  - exclusão
  - resgate
  - reordenação
- melhora o fallback de `SupabaseUsersRepository.findById` para ambientes locais em que algumas relações do PostgREST não estão disponíveis no schema cache
- remove ruído desnecessário de log na inicialização do provider de Sentry usado nos testes

## Como testar
1. Execute `npm run test -w @stardust/server -- src/tests/routes/profile/achievements`.
2. Valide que todas as suítes de integração de `profile/achievements` passam cobrindo cenários de `401`, `400`, `404`, `409`, `200`, `201` e `204`.
3. Execute `npm run typecheck -w @stardust/server` para confirmar que os ajustes de fallback e tipagem do repositório continuam válidos.

## Observações
- O PR concentra a cobertura em `profile/achievements`, mas também introduz infraestrutura reutilizável para futuros testes de integração no server.
- Parte dos ajustes em `SupabaseUsersRepository` existe para acomodar diferenças entre o schema local exposto pelo PostgREST e os relacionamentos esperados pelos mapeadores do domínio.
- Algumas respostas de validação observadas na borda real não devolvem `fieldErrors` completos; os testes foram alinhados ao comportamento atual do servidor.