### PR TITLE
Migracao de upload de imagens para URL assinada

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,17 @@
-Leia os arquivos:
+## Arquivos
 
 - documentation/overview.md
 - documentation/architecture.md
 - documentation/rules/rules.md
 
-MCPS: 
+## MCPS
 
 - Context7 para buscar informações atualizadas
 - Serena para navegar pela codebase de forma otimizada
+
+## Detectores de erros
+
+Após fazer qualquer alteração no código, execute os comandos:
+
+- typecheck
+- codecheck

--- a/apps/server/rest-client/auth/auth.rest
+++ b/apps/server/rest-client/auth/auth.rest
@@ -1,6 +1,6 @@
 @URL = {{BASE_URL}}/auth
-@EMAIL = stardust.app.team@gmail.com
-@PASSWORD = Backshift7-Favorite8-Glancing6-Luridness3-Symptom9
+@EMAIL = {{AUTH_EMAIL}}
+@PASSWORD = {{AUTH_PASSWORD}}
 @SOCIAL_ACCOUNT_EMAIL = {{SOCIAL_ACCOUNT_EMAIL}}
 
 ### Sign in

--- a/apps/server/rest-client/auth/auth.rest
+++ b/apps/server/rest-client/auth/auth.rest
@@ -1,6 +1,6 @@
 @URL = {{BASE_URL}}/auth
-@EMAIL = {{AUTH_EMAIL}}
-@PASSWORD = {{AUTH_PASSWORD}}
+@EMAIL = stardust.app.team@gmail.com
+@PASSWORD = Backshift7-Favorite8-Glancing6-Luridness3-Symptom9
 @SOCIAL_ACCOUNT_EMAIL = {{SOCIAL_ACCOUNT_EMAIL}}
 
 ### Sign in

--- a/apps/server/rest-client/storage/files.rest
+++ b/apps/server/rest-client/storage/files.rest
@@ -1,22 +1,27 @@
 @URL = {{BASE_URL}}/storage/files
+@SIGNED_UPLOAD_URL = {{BASE_URL}}/storage/signed-upload-url
 @FILE_NAME = banana.jpg
 @FOLDER = story
+@FOLDER_PATH = images/story
 
 ### Get files
 GET {{URL}}
 ?page=1
 &itemsPerPage=25
-&search=
-&folder=images%2Fstory
+&search=Wha
+&folder={{FOLDER_PATH}}
 Authorization: Bearer {{JWT}}
+
+### Create signed upload url
+POST {{SIGNED_UPLOAD_URL}}
+Authorization: Bearer {{JWT}}
+Content-Type: application/json
+
+{
+  "folderPath": "{{FOLDER_PATH}}",
+  "fileName": "{{FILE_NAME}}"
+}
 
 ### Remove file
-DELETE {{URL}}/{{FOLDER}}/{{FILE_NAME}}
-Authorization: Bearer {{JWT}}
-
-### Search guides
-GET {{URL}}/{{FOLDER}}
-?query=Delegua
-&namespace=guides
-&topK=1
+DELETE {{URL}}?folder={{FOLDER_PATH}}&fileName={{FILE_NAME}}
 Authorization: Bearer {{JWT}}

--- a/apps/server/src/app/hono/routers/storage/FilesStorageRouter.ts
+++ b/apps/server/src/app/hono/routers/storage/FilesStorageRouter.ts
@@ -46,6 +46,7 @@ export class FilesStorageRouter extends HonoRouter {
     this.router.get(
       '/',
       this.authMiddleware.verifyAuthentication,
+      this.authMiddleware.verifyGodAccount,
       this.validationMiddleware.validate(
         'query',
         z.object({
@@ -67,10 +68,11 @@ export class FilesStorageRouter extends HonoRouter {
 
   private registerRemoveFileRoute(): void {
     this.router.delete(
-      '/:folder/:fileName',
+      '/',
       this.authMiddleware.verifyAuthentication,
+      this.authMiddleware.verifyGodAccount,
       this.validationMiddleware.validate(
-        'param',
+        'query',
         z.object({
           fileName: stringSchema,
           folder: fileStorageFolderPathSchema,

--- a/apps/server/src/app/hono/routers/storage/StorageRouter.ts
+++ b/apps/server/src/app/hono/routers/storage/StorageRouter.ts
@@ -1,16 +1,44 @@
 import { Hono } from 'hono'
 
+import { CreateSignedUploadUrl } from '@stardust/core/storage/use-cases'
+import { signedUploadUrlSchema } from '@stardust/validation/storage/schemas'
+
+import { SupabaseFileStorageProvider } from '@/provision/storage'
+import { CreateSignedUploadUrlController } from '@/rest/controllers/storage'
 import { EmbeddingsStorageRouter } from './EmbeddingsStorageRouter'
 import { FilesStorageRouter } from './FilesStorageRouter'
+import { AuthMiddleware, ValidationMiddleware } from '../../middlewares'
+import { HonoHttp } from '../../HonoHttp'
 import { HonoRouter } from '../../HonoRouter'
 
 export class StorageRouter extends HonoRouter {
   private readonly router = new Hono().basePath('/storage')
+  private readonly authMiddleware = new AuthMiddleware()
+  private readonly validationMiddleware = new ValidationMiddleware()
+
+  private registerCreateSignedUploadUrlRoute(): void {
+    this.router.post(
+      '/signed-upload-url',
+      this.authMiddleware.verifyAuthentication,
+      this.authMiddleware.verifyGodAccount,
+      this.validationMiddleware.validate('json', signedUploadUrlSchema),
+      async (context) => {
+        const http = new HonoHttp(context)
+        const storageProvider = new SupabaseFileStorageProvider(http.getSupabase())
+        const createSignedUploadUrl = new CreateSignedUploadUrl(storageProvider)
+        const controller = new CreateSignedUploadUrlController(createSignedUploadUrl)
+        const response = await controller.handle(http)
+
+        return http.sendResponse(response)
+      },
+    )
+  }
 
   registerRoutes(): Hono {
     const embeddingsStorageRouter = new EmbeddingsStorageRouter(this.app)
     const filesStorageRouter = new FilesStorageRouter(this.app)
 
+    this.registerCreateSignedUploadUrlRoute()
     this.router.route('/', embeddingsStorageRouter.registerRoutes())
     this.router.route('/', filesStorageRouter.registerRoutes())
     return this.router

--- a/apps/server/src/database/supabase/mappers/profile/SupabaseUserMapper.ts
+++ b/apps/server/src/database/supabase/mappers/profile/SupabaseUserMapper.ts
@@ -71,7 +71,7 @@ export class SupabaseUserMapper {
       insigniaRoles: supabaseUser.insignias?.map(({ role }) => role) ?? [],
       didBreakStreak: supabaseUser.did_break_streak,
       canSeeRankingResult: supabaseUser.can_see_ranking ?? false,
-      hasCompletedSpace: supabaseUser.has_completed_space,
+      hasCompletedSpace: supabaseUser.has_completed_space ?? false,
       lastWeekRankingPosition: supabaseUser.last_week_ranking_position,
       weekStatus: supabaseUser.week_status ?? [],
       createdAt: supabaseUser.created_at ? new Date(supabaseUser.created_at) : new Date(),
@@ -97,7 +97,6 @@ export class SupabaseUserMapper {
       streak: user.streak.value,
       can_see_ranking: user.canSeeRankingResult.value,
       did_break_streak: user.didBreakStreak.value,
-      has_completed_space: user.hasCompletedSpace.value,
     }
 
     return supabaseUser as unknown as SupabaseUser

--- a/apps/server/src/database/supabase/mappers/shop/SupabaseRocketMapper.ts
+++ b/apps/server/src/database/supabase/mappers/shop/SupabaseRocketMapper.ts
@@ -1,6 +1,5 @@
 import type { RocketDto } from '@stardust/core/shop/entities/dtos'
 import { Rocket } from '@stardust/core/shop/entities'
-import { Name } from '@stardust/core/global/structures'
 
 import type { Database, SupabaseRocket } from '../../types'
 
@@ -33,7 +32,6 @@ export class SupabaseRocketMapper {
       name: rocketDto.name,
       price: rocketDto.price,
       image: rocketDto.image,
-      slug: Name.create(rocketDto.name).slug.value,
       is_purchasable: rocketDto.isPurchasable ?? true,
     }
 

--- a/apps/server/src/database/supabase/mappers/shop/SupabaseRocketMapper.ts
+++ b/apps/server/src/database/supabase/mappers/shop/SupabaseRocketMapper.ts
@@ -1,5 +1,6 @@
 import type { RocketDto } from '@stardust/core/shop/entities/dtos'
 import { Rocket } from '@stardust/core/shop/entities'
+import { Name } from '@stardust/core/global/structures'
 
 import type { Database, SupabaseRocket } from '../../types'
 
@@ -32,6 +33,7 @@ export class SupabaseRocketMapper {
       name: rocketDto.name,
       price: rocketDto.price,
       image: rocketDto.image,
+      slug: Name.create(rocketDto.name).slug.value,
       is_purchasable: rocketDto.isPurchasable ?? true,
     }
 

--- a/apps/server/src/database/supabase/types/Database.ts
+++ b/apps/server/src/database/supabase/types/Database.ts
@@ -2117,7 +2117,6 @@ export type Database = {
           is_selected_by_default: boolean
           name: string
           price: number
-          slug: string
         }
         Insert: {
           id?: string
@@ -2127,7 +2126,6 @@ export type Database = {
           is_selected_by_default?: boolean
           name: string
           price: number
-          slug: string
         }
         Update: {
           id?: string
@@ -2137,7 +2135,6 @@ export type Database = {
           is_selected_by_default?: boolean
           name?: string
           price?: number
-          slug?: string
         }
         Relationships: []
       }

--- a/apps/server/src/database/supabase/types/Database.ts
+++ b/apps/server/src/database/supabase/types/Database.ts
@@ -2117,6 +2117,7 @@ export type Database = {
           is_selected_by_default: boolean
           name: string
           price: number
+          slug: string
         }
         Insert: {
           id?: string
@@ -2126,6 +2127,7 @@ export type Database = {
           is_selected_by_default?: boolean
           name: string
           price: number
+          slug: string
         }
         Update: {
           id?: string
@@ -2135,6 +2137,7 @@ export type Database = {
           is_selected_by_default?: boolean
           name?: string
           price?: number
+          slug?: string
         }
         Relationships: []
       }

--- a/apps/server/src/provision/storage/DropboxStorageProvider.ts
+++ b/apps/server/src/provision/storage/DropboxStorageProvider.ts
@@ -4,11 +4,15 @@ import { Dropbox } from 'dropbox'
 
 import { AppError } from '@stardust/core/global/errors'
 import { MethodNotImplementedError } from '@stardust/core/global/errors'
-import type { FileStorageFolderPath } from '@stardust/core/storage/structures'
+import type {
+  FileStorageFolderPath,
+  SignedUploadUrl,
+} from '@stardust/core/storage/structures'
 import type { FileStorageProvider } from '@stardust/core/storage/interfaces'
 import type { RestClient } from '@stardust/core/global/interfaces'
 import type { ManyItems } from '@stardust/core/global/types'
 import type { FilesListingParams } from '@stardust/core/storage/types'
+import type { Text } from '@stardust/core/global/structures'
 
 import { ENV } from '@/constants'
 
@@ -49,6 +53,13 @@ export class DropboxStorageProvider implements FileStorageProvider {
       console.log('error', error)
       this.handleError(error)
     }
+  }
+
+  async createSignedUploadUrl(
+    _folderPath: FileStorageFolderPath,
+    _fileName: Text,
+  ): Promise<SignedUploadUrl> {
+    throw new MethodNotImplementedError('createSignedUploadUrl')
   }
 
   async listFiles(_params: FilesListingParams): Promise<ManyItems<File>> {

--- a/apps/server/src/provision/storage/GoogleDriveStorageProvider.ts
+++ b/apps/server/src/provision/storage/GoogleDriveStorageProvider.ts
@@ -3,7 +3,10 @@ import { type drive_v3, google } from 'googleapis'
 
 import { AppError } from '@stardust/core/global/errors'
 import type { FileStorageProvider } from '@stardust/core/storage/interfaces'
-import type { FileStorageFolderPath } from '@stardust/core/storage/structures'
+import type {
+  FileStorageFolderPath,
+  SignedUploadUrl,
+} from '@stardust/core/storage/structures'
 import type {
   FileStorageFolderPathValue,
   FilesListingParams,
@@ -66,6 +69,13 @@ export class GoogleDriveStorageProvider implements FileStorageProvider {
     }
 
     return file
+  }
+
+  async createSignedUploadUrl(
+    _folderPath: FileStorageFolderPath,
+    _fileName: Text,
+  ): Promise<SignedUploadUrl> {
+    throw new MethodNotImplementedError('createSignedUploadUrl')
   }
 
   async listFiles(_params: FilesListingParams): Promise<ManyItems<File>> {

--- a/apps/server/src/provision/storage/SupabaseFileStorageProvider.ts
+++ b/apps/server/src/provision/storage/SupabaseFileStorageProvider.ts
@@ -4,7 +4,10 @@ import { randomUUID } from 'node:crypto'
 import { AppError } from '@stardust/core/global/errors'
 import type { FileStorageProvider } from '@stardust/core/storage/interfaces'
 import type { FilesListingParams } from '@stardust/core/storage/types'
-import type { FileStorageFolderPath } from '@stardust/core/storage/structures'
+import {
+  SignedUploadUrl,
+  type FileStorageFolderPath,
+} from '@stardust/core/storage/structures'
 import { Text } from '@stardust/core/global/structures'
 import type { ManyItems } from '@stardust/core/global/types'
 
@@ -14,8 +17,6 @@ export class SupabaseFileStorageProvider implements FileStorageProvider {
   constructor(private readonly supabase: SupabaseClient) {}
 
   async upload(folder: FileStorageFolderPath, file: File): Promise<File> {
-    console.log(folder.value)
-    console.log(file)
     const fileName = this.resolveFileName(file)
     const filePath = `${folder.value}/${fileName}`
     const contentType = this.resolveContentType(file, fileName)
@@ -38,6 +39,32 @@ export class SupabaseFileStorageProvider implements FileStorageProvider {
     }
 
     return fileToUpload
+  }
+
+  async createSignedUploadUrl(
+    folderPath: FileStorageFolderPath,
+    fileName: Text,
+  ): Promise<SignedUploadUrl> {
+    const filePath = `${folderPath.value}/${fileName.value}`
+    const { data, error } = await this.supabase.storage
+      .from(SupabaseFileStorageProvider.BUCKET_NAME)
+      .createSignedUploadUrl(filePath, {
+        upsert: false,
+      })
+
+    if (error) {
+      await this.handleError(error, `creating signed upload url for ${filePath}`)
+    }
+
+    if (!data?.signedUrl) {
+      throw new AppError('Failed to create signed upload url')
+    }
+
+    return SignedUploadUrl.create({
+      url: data.signedUrl,
+      folderPath: folderPath.value,
+      fileName: fileName.value,
+    })
   }
 
   async listFiles({
@@ -89,7 +116,9 @@ export class SupabaseFileStorageProvider implements FileStorageProvider {
       await this.handleError(error, `finding file ${fileName.value} in ${folder.value}`)
     }
 
-    if (!data?.length) {
+    const matchedFile = data?.find((item) => item.name === fileName.value)
+
+    if (!matchedFile?.name) {
       return null
     }
 
@@ -105,6 +134,10 @@ export class SupabaseFileStorageProvider implements FileStorageProvider {
       .getPublicUrl(`${folder.value}/${fileName.value}`)
 
     const response = await fetch(urlData.publicUrl)
+    if (!response.ok) {
+      return null
+    }
+
     const blob = await response.blob()
     const file = new File([blob], fileName.value, {
       type: 'application/octet-stream',

--- a/apps/server/src/rest/controllers/storage/CreateSignedUploadUrlController.ts
+++ b/apps/server/src/rest/controllers/storage/CreateSignedUploadUrlController.ts
@@ -1,0 +1,23 @@
+import type { Controller, Http } from '@stardust/core/global/interfaces'
+import type { CreateSignedUploadUrl } from '@stardust/core/storage/use-cases'
+
+type Schema = {
+  body: {
+    folderPath: string
+    fileName: string
+  }
+}
+
+export class CreateSignedUploadUrlController implements Controller {
+  constructor(private readonly createSignedUploadUrl: CreateSignedUploadUrl) {}
+
+  async handle(http: Http<Schema>) {
+    const { folderPath, fileName } = await http.getBody()
+    const signedUploadUrl = await this.createSignedUploadUrl.execute({
+      folderPath,
+      fileName,
+    })
+
+    return http.statusOk().send(signedUploadUrl)
+  }
+}

--- a/apps/server/src/rest/controllers/storage/RemoveFileController.ts
+++ b/apps/server/src/rest/controllers/storage/RemoveFileController.ts
@@ -4,7 +4,7 @@ import type { FileStorageProvider } from '@stardust/core/storage/interfaces'
 import { FileStorageFolderPath } from '@stardust/core/storage/structures'
 
 type Schema = {
-  routeParams: {
+  queryParams: {
     fileName: string
     folder: string
   }
@@ -14,7 +14,7 @@ export class RemoveFileController implements Controller {
   constructor(private readonly storageProvider: FileStorageProvider) {}
 
   async handle(http: Http<Schema>) {
-    const { fileName, folder } = http.getRouteParams()
+    const { fileName, folder } = http.getQueryParams()
     await this.storageProvider.removeFile(
       FileStorageFolderPath.create(folder),
       Text.create(fileName),

--- a/apps/server/src/rest/controllers/storage/index.ts
+++ b/apps/server/src/rest/controllers/storage/index.ts
@@ -1,3 +1,4 @@
+export { CreateSignedUploadUrlController } from './CreateSignedUploadUrlController'
 export { FetchFilesListController } from './FetchFilesListController'
 export { RemoveFileController } from './RemoveFileController'
 export { UploadFileController } from './UploadFileController'

--- a/apps/server/src/rest/controllers/storage/tests/CreateSignedUploadUrlController.test.ts
+++ b/apps/server/src/rest/controllers/storage/tests/CreateSignedUploadUrlController.test.ts
@@ -1,0 +1,53 @@
+import { mock, type Mock } from 'ts-jest-mocker'
+
+import type { Http } from '@stardust/core/global/interfaces'
+import type { RestResponse } from '@stardust/core/global/responses'
+import type { CreateSignedUploadUrl } from '@stardust/core/storage/use-cases'
+
+import { CreateSignedUploadUrlController } from '../CreateSignedUploadUrlController'
+
+describe('Create Signed Upload Url Controller', () => {
+  type Schema = {
+    body: {
+      folderPath: string
+      fileName: string
+    }
+  }
+
+  let http: Mock<Http<Schema>>
+  let createSignedUploadUrl: Mock<CreateSignedUploadUrl>
+  let controller: CreateSignedUploadUrlController
+
+  beforeEach(() => {
+    http = mock()
+    createSignedUploadUrl = mock<CreateSignedUploadUrl>()
+    controller = new CreateSignedUploadUrlController(createSignedUploadUrl)
+
+    http.statusOk.mockReturnValue(http)
+  })
+
+  it('should read the body, delegate to the use case and send the ok response', async () => {
+    const body = {
+      folderPath: 'images/story',
+      fileName: 'cover.png',
+    }
+    const signedUploadUrl = {
+      url: 'https://storage.stardust.dev/upload',
+      folderPath: 'images/story',
+      fileName: 'cover.png',
+    }
+    const response = mock<RestResponse>()
+
+    http.getBody.mockResolvedValue(body)
+    createSignedUploadUrl.execute.mockResolvedValue(signedUploadUrl)
+    http.send.mockReturnValue(response)
+
+    const result = await controller.handle(http)
+
+    expect(http.getBody).toHaveBeenCalledTimes(1)
+    expect(createSignedUploadUrl.execute).toHaveBeenCalledWith(body)
+    expect(http.statusOk).toHaveBeenCalledTimes(1)
+    expect(http.send).toHaveBeenCalledWith(signedUploadUrl)
+    expect(result).toBe(response)
+  })
+})

--- a/apps/server/src/rest/controllers/storage/tests/RemoveFileController.test.ts
+++ b/apps/server/src/rest/controllers/storage/tests/RemoveFileController.test.ts
@@ -13,7 +13,7 @@ describe('Remove File Controller', () => {
     avatars: 'images/avatars',
   } as const
 
-  let http: Mock<Http<{ routeParams: { fileName: string; folder: string } }>>
+  let http: Mock<Http<{ queryParams: { fileName: string; folder: string } }>>
   let storageProvider: Mock<FileStorageProvider>
   let controller: RemoveFileController
 
@@ -23,19 +23,19 @@ describe('Remove File Controller', () => {
     controller = new RemoveFileController(storageProvider)
   })
 
-  it('should extract route params, call provider with domain structures and return no-content', async () => {
+  it('should extract query params, call provider with domain structures and return no-content', async () => {
     const fileName = 'avatar.png'
     const folder = 'avatars'
     const restResponse = mock<RestResponse>()
 
-    http.getRouteParams.mockReturnValue({ fileName, folder })
+    http.getQueryParams.mockReturnValue({ fileName, folder })
     storageProvider.removeFile.mockResolvedValue(undefined)
     http.statusNoContent.mockReturnValue(http)
     http.send.mockReturnValue(restResponse)
 
     const response = await controller.handle(http)
 
-    expect(http.getRouteParams).toHaveBeenCalledTimes(1)
+    expect(http.getQueryParams).toHaveBeenCalledTimes(1)
     expect(storageProvider.removeFile).toHaveBeenCalledTimes(1)
 
     const [FileStorageFolderPath, text] = storageProvider.removeFile.mock.calls[0] as [

--- a/apps/server/src/tests/fixtures/LocalSupabaseProxy.ts
+++ b/apps/server/src/tests/fixtures/LocalSupabaseProxy.ts
@@ -1,4 +1,5 @@
-import { execSync } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, rmSync } from 'node:fs'
 
 declare global {
   var __stardustSupabaseProxyPromise__: Promise<void> | undefined
@@ -6,6 +7,7 @@ declare global {
 
 const PROXY_CONTAINER_NAME = 'stardust_supabase_test_proxy'
 const SUPABASE_NETWORK_NAME = 'supabase_network_server'
+const START_LOCK_DIRECTORY = '/tmp/stardust-supabase-test-proxy.lock'
 
 export class LocalSupabaseProxy {
   static async ensureRunning() {
@@ -23,33 +25,44 @@ export class LocalSupabaseProxy {
     if (!supabaseUrl) return
 
     const url = new URL(supabaseUrl)
-    const listenHost = url.hostname
     const listenPort = Number(url.port || 80)
 
     const alreadyListening = await this.isHealthy(supabaseUrl)
     if (alreadyListening) return
 
-    const existingContainerId = execSync(
-      `docker ps -aq --filter "name=^${PROXY_CONTAINER_NAME}$"`,
-      { encoding: 'utf8' },
-    ).trim()
+    await this.withStartLock(async () => {
+      const becameHealthyWhileWaiting = await this.isHealthy(supabaseUrl)
+      if (becameHealthyWhileWaiting) return
 
-    if (existingContainerId) {
-      execSync(`docker rm -f ${PROXY_CONTAINER_NAME}`, { stdio: 'ignore' })
-    }
+      const existingContainerId = this.runDockerCommand([
+        'ps',
+        '-aq',
+        '--filter',
+        `name=^${PROXY_CONTAINER_NAME}$`,
+      ]).trim()
 
-    execSync(
-      [
-        'docker run -d --rm',
-        `--name ${PROXY_CONTAINER_NAME}`,
-        `--network ${SUPABASE_NETWORK_NAME}`,
-        `-p ${listenHost}:${listenPort}:8000`,
-        'alpine/socat',
-        'TCP-LISTEN:8000,fork,reuseaddr',
-        'TCP:kong:8000',
-      ].join(' '),
-      { stdio: 'ignore' },
-    )
+      if (existingContainerId) {
+        this.runDockerCommand(['rm', '-f', PROXY_CONTAINER_NAME], true)
+      }
+
+      this.runDockerCommand(
+        [
+          'run',
+          '-d',
+          '--rm',
+          '--name',
+          PROXY_CONTAINER_NAME,
+          '--network',
+          SUPABASE_NETWORK_NAME,
+          '-p',
+          `0.0.0.0:${listenPort}:8000`,
+          'alpine/socat',
+          'TCP-LISTEN:8000,fork,reuseaddr',
+          'TCP:kong:8000',
+        ],
+        true,
+      )
+    })
 
     const startedAt = Date.now()
 
@@ -70,5 +83,51 @@ export class LocalSupabaseProxy {
     } catch {
       return false
     }
+  }
+
+  private static async withStartLock(callback: () => Promise<void>) {
+    const timeoutAt = Date.now() + 10000
+
+    while (Date.now() < timeoutAt) {
+      try {
+        mkdirSync(START_LOCK_DIRECTORY)
+
+        try {
+          await callback()
+          return
+        } finally {
+          rmSync(START_LOCK_DIRECTORY, { force: true, recursive: true })
+        }
+      } catch (error) {
+        if (!this.isLockAlreadyHeldError(error)) {
+          throw error
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, 100))
+      }
+    }
+
+    throw new Error('Timed out waiting to acquire local Supabase proxy start lock')
+  }
+
+  private static isLockAlreadyHeldError(error: unknown) {
+    return error instanceof Error && 'code' in error && error.code === 'EEXIST'
+  }
+
+  private static runDockerCommand(command: string[], ignoreOutput = false) {
+    let lastError: unknown
+
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      try {
+        return execFileSync('docker', command, {
+          encoding: 'utf8',
+          stdio: ignoreOutput ? 'ignore' : 'pipe',
+        })
+      } catch (error) {
+        lastError = error
+      }
+    }
+
+    throw lastError
   }
 }

--- a/apps/server/src/tests/fixtures/ProfileFixture.ts
+++ b/apps/server/src/tests/fixtures/ProfileFixture.ts
@@ -11,7 +11,7 @@ import { AvatarsFaker, RocketsFaker } from '@stardust/core/shop/entities/fakers'
 import { Achievement, User } from '@stardust/core/profile/entities'
 
 import { SupabaseAchievementsRepository, SupabaseUsersRepository } from '@/database'
-import { Id, Name } from '@stardust/core/global/structures'
+import { Id } from '@stardust/core/global/structures'
 
 export class ProfileFixture {
   private readonly supabase: SupabaseClient
@@ -64,7 +64,6 @@ export class ProfileFixture {
         id: rocket.id,
         name: rocket.name,
         image: rocket.image,
-        slug: Name.create(rocket.name).slug.value,
         price: rocket.price,
         is_acquired_by_default: rocket.isAcquiredByDefault ?? false,
         is_selected_by_default: rocket.isSelectedByDefault ?? false,

--- a/apps/server/src/tests/fixtures/ProfileFixture.ts
+++ b/apps/server/src/tests/fixtures/ProfileFixture.ts
@@ -11,7 +11,7 @@ import { AvatarsFaker, RocketsFaker } from '@stardust/core/shop/entities/fakers'
 import { Achievement, User } from '@stardust/core/profile/entities'
 
 import { SupabaseAchievementsRepository, SupabaseUsersRepository } from '@/database'
-import { Id } from '@stardust/core/global/structures'
+import { Id, Name } from '@stardust/core/global/structures'
 
 export class ProfileFixture {
   private readonly supabase: SupabaseClient
@@ -64,6 +64,7 @@ export class ProfileFixture {
         id: rocket.id,
         name: rocket.name,
         image: rocket.image,
+        slug: Name.create(rocket.name).slug.value,
         price: rocket.price,
         is_acquired_by_default: rocket.isAcquiredByDefault ?? false,
         is_selected_by_default: rocket.isSelectedByDefault ?? false,

--- a/apps/server/supabase/schemas/schema.sql
+++ b/apps/server/supabase/schemas/schema.sql
@@ -63,9 +63,9 @@ create table public.rockets (
   name character varying not null,
   price integer not null,
   image character varying not null,
-  slug text not null,
   is_selected_by_default boolean not null default false,
   is_acquired_by_default boolean not null default false,
+  is_purchasable boolean not null default true,
   constraint rockets_pkey primary key (id),
   constraint rockets_image_key unique (image),
   constraint rockets_name_key unique (name)

--- a/apps/studio/src/app/middlewares/RestMiddleware.ts
+++ b/apps/studio/src/app/middlewares/RestMiddleware.ts
@@ -4,6 +4,7 @@ import { HTTP_STATUS_CODE } from '@stardust/core/global/constants'
 import { Text } from '@stardust/core/global/structures'
 
 import { ENV, ROUTES, SESSION_STORAGE_KEYS } from '@/constants'
+import { SupabaseSignedFileStorageProvider } from '@/provision/storage'
 import { AxiosRestClient } from '@/rest/axios/AxiosRestClient'
 import {
   AuthService,
@@ -80,7 +81,7 @@ export const RestMiddleware = async ({ context }: Route.ActionArgs) => {
   }
 
   const spaceService = SpaceService(restClient)
-  const storageService = StorageService(restClient)
+  const storageService = StorageService(restClient, SupabaseSignedFileStorageProvider())
   const lessonService = LessonService(restClient)
   const profileService = ProfileService(restClient)
   const challengingService = ChallengingService(restClient)

--- a/apps/studio/src/app/root.tsx
+++ b/apps/studio/src/app/root.tsx
@@ -14,6 +14,7 @@ import type { Route } from './+types/root'
 import globalStyles from '../ui/global/styles/global.css?url'
 import { Toaster } from 'sonner'
 
+import { ProvisionContextProvider } from '@/ui/global/contexts/ProvisionContext'
 import { RestContextProvider } from '@/ui/global/contexts/RestContext'
 
 export const links: Route.LinksFunction = () => [
@@ -89,10 +90,12 @@ export const App = () => {
     <div className='h-screen w-full'>
       <NuqsAdapter>
         <QueryClientProvider client={queryClient}>
-          <RestContextProvider>
-            <Toaster position='top-right' richColors />
-            <Outlet />
-          </RestContextProvider>
+          <ProvisionContextProvider>
+            <RestContextProvider>
+              <Toaster position='top-right' richColors />
+              <Outlet />
+            </RestContextProvider>
+          </ProvisionContextProvider>
         </QueryClientProvider>
       </NuqsAdapter>
     </div>

--- a/apps/studio/src/provision/storage/SupabaseSignedFileStorageProvider.ts
+++ b/apps/studio/src/provision/storage/SupabaseSignedFileStorageProvider.ts
@@ -1,0 +1,38 @@
+import { AppError } from '@stardust/core/global/errors'
+import type { SignedFileStorageProvider } from '@stardust/core/storage/interfaces'
+import type { SignedUploadUrl } from '@stardust/core/storage/structures'
+
+export const SupabaseSignedFileStorageProvider = (): SignedFileStorageProvider => {
+  async function uploadFile(signedUploadUrl: SignedUploadUrl, file: File): Promise<void> {
+    const fileToUpload = new File([file], signedUploadUrl.fileName.value, {
+      type: file.type,
+      lastModified: file.lastModified,
+    })
+
+    const response = await fetch(signedUploadUrl.url.value, {
+      method: 'PUT',
+      body: fileToUpload,
+      headers: {
+        'Content-Type': fileToUpload.type || 'application/octet-stream',
+        'x-upsert': 'false',
+      },
+    })
+
+    if (response.ok) return
+
+    let errorMessage = 'Falha ao enviar arquivo para o storage'
+
+    try {
+      const responseText = await response.text()
+      if (responseText) {
+        errorMessage = responseText
+      }
+    } catch {}
+
+    throw new AppError(errorMessage)
+  }
+
+  return {
+    uploadFile,
+  }
+}

--- a/apps/studio/src/provision/storage/index.ts
+++ b/apps/studio/src/provision/storage/index.ts
@@ -1,0 +1,1 @@
+export { SupabaseSignedFileStorageProvider } from './SupabaseSignedFileStorageProvider'

--- a/apps/studio/src/rest/services/StorageService.ts
+++ b/apps/studio/src/rest/services/StorageService.ts
@@ -1,10 +1,31 @@
-import type { StorageService as IStorageService } from '@stardust/core/storage/interfaces'
 import type { RestClient } from '@stardust/core/global/interfaces'
+import { Text } from '@stardust/core/global/structures'
 import type { FilesListingParams } from '@stardust/core/storage/types'
-import type { FileStorageFolderPath } from '@stardust/core/storage/structures'
-import type { Text } from '@stardust/core/global/structures'
+import { RestResponse } from '@stardust/core/global/responses'
+import type {
+  SignedFileStorageProvider,
+  StorageService as IStorageService,
+} from '@stardust/core/storage/interfaces'
+import type { SignedUploadUrlDto } from '@stardust/core/storage/structures/dtos'
+import {
+  SignedUploadUrl,
+  type FileStorageFolderPath,
+} from '@stardust/core/storage/structures'
 
-export const StorageService = (restClient: RestClient): IStorageService => {
+export const StorageService = (
+  restClient: RestClient,
+  signedFileStorageProvider: SignedFileStorageProvider,
+): IStorageService => {
+  async function createSignedUploadUrl(
+    folderPath: FileStorageFolderPath,
+    fileName: Text,
+  ) {
+    return await restClient.post<SignedUploadUrlDto>('/storage/signed-upload-url', {
+      folderPath: folderPath.value,
+      fileName: fileName.value,
+    })
+  }
+
   return {
     async listFiles(params: FilesListingParams) {
       if (params.page) restClient.setQueryParam('page', String(params.page.value))
@@ -15,13 +36,47 @@ export const StorageService = (restClient: RestClient): IStorageService => {
     },
 
     async uploadFile(folder: FileStorageFolderPath, file: File) {
-      const formData = new FormData()
-      formData.append('file', file)
-      return await restClient.postFormData(`/storage/files/${folder.value}`, formData)
+      const signedUploadUrlResponse = await createSignedUploadUrl(
+        folder,
+        Text.create(file.name),
+      )
+
+      if (signedUploadUrlResponse.isFailure) {
+        return new RestResponse({
+          statusCode: signedUploadUrlResponse.statusCode,
+          errorMessage: signedUploadUrlResponse.errorMessage,
+        })
+      }
+
+      try {
+        const signedUploadUrl = SignedUploadUrl.create(signedUploadUrlResponse.body)
+        await signedFileStorageProvider.uploadFile(signedUploadUrl, file)
+
+        return new RestResponse({
+          statusCode: signedUploadUrlResponse.statusCode,
+          body: {
+            filename: signedUploadUrl.fileName.value,
+          },
+        })
+      } catch (error) {
+        return new RestResponse({
+          statusCode: 500,
+          errorMessage:
+            error instanceof Error
+              ? error.message
+              : 'Falha ao enviar arquivo para o storage',
+        })
+      }
+    },
+
+    async createSignedUploadUrl(folderPath: FileStorageFolderPath, fileName: Text) {
+      return await createSignedUploadUrl(folderPath, fileName)
     },
 
     async removeFile(folder: FileStorageFolderPath, fileName: Text) {
-      return await restClient.delete(`/storage/files/${folder.value}/${fileName.value}`)
+      restClient.setQueryParam('folder', folder.value)
+      restClient.setQueryParam('fileName', fileName.value)
+      return await restClient.delete('/storage/files')
     },
 
     async searchEmbeddings(query, topK, namespace) {

--- a/apps/studio/src/ui/global/contexts/ProvisionContext/index.tsx
+++ b/apps/studio/src/ui/global/contexts/ProvisionContext/index.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import { createContext, type PropsWithChildren } from 'react'
+
+import type { ProvisionContextValue } from './types/ProvisionContextValue'
+import { useProvisionContextProvider } from './useProvisionContextProvider'
+
+export const ProvisionContext = createContext({} as ProvisionContextValue)
+
+export const ProvisionContextProvider = ({ children }: PropsWithChildren) => {
+  const value = useProvisionContextProvider()
+
+  return <ProvisionContext.Provider value={value}>{children}</ProvisionContext.Provider>
+}

--- a/apps/studio/src/ui/global/contexts/ProvisionContext/types/ProvisionContextValue.ts
+++ b/apps/studio/src/ui/global/contexts/ProvisionContext/types/ProvisionContextValue.ts
@@ -1,0 +1,5 @@
+import type { SignedFileStorageProvider } from '@stardust/core/storage/interfaces'
+
+export type ProvisionContextValue = {
+  signedFileStorageProvider: SignedFileStorageProvider
+}

--- a/apps/studio/src/ui/global/contexts/ProvisionContext/useProvisionContextProvider.ts
+++ b/apps/studio/src/ui/global/contexts/ProvisionContext/useProvisionContextProvider.ts
@@ -1,0 +1,13 @@
+import { useMemo } from 'react'
+
+import { SupabaseSignedFileStorageProvider } from '@/provision/storage'
+import type { ProvisionContextValue } from './types/ProvisionContextValue'
+
+export function useProvisionContextProvider(): ProvisionContextValue {
+  return useMemo(
+    () => ({
+      signedFileStorageProvider: SupabaseSignedFileStorageProvider(),
+    }),
+    [],
+  )
+}

--- a/apps/studio/src/ui/global/contexts/RestContext/index.tsx
+++ b/apps/studio/src/ui/global/contexts/RestContext/index.tsx
@@ -1,13 +1,17 @@
 'use client'
 
 import { createContext, type PropsWithChildren } from 'react'
+
+import { useProvisionContext } from '@/ui/global/hooks/useProvisionContext'
+
 import type { RestContextValue } from './types/RestContextValue'
 import { useRestContextProvider } from './useRestContextProvider'
 
 export const RestContext = createContext({} as RestContextValue)
 
 export const RestContextProvider = ({ children }: PropsWithChildren) => {
-  const value = useRestContextProvider()
+  const { signedFileStorageProvider } = useProvisionContext()
+  const value = useRestContextProvider(signedFileStorageProvider)
 
   return <RestContext.Provider value={value}>{children}</RestContext.Provider>
 }

--- a/apps/studio/src/ui/global/contexts/RestContext/useRestContextProvider.ts
+++ b/apps/studio/src/ui/global/contexts/RestContext/useRestContextProvider.ts
@@ -15,9 +15,12 @@ import {
   ReportingService,
 } from '@/rest/services'
 import { ENV, SESSION_STORAGE_KEYS } from '@/constants'
+import type { SignedFileStorageProvider } from '@stardust/core/storage/interfaces'
 import type { RestContextValue } from './types/RestContextValue'
 
-export function useRestContextProvider(): RestContextValue {
+export function useRestContextProvider(
+  signedFileStorageProvider: SignedFileStorageProvider,
+): RestContextValue {
   const [accessToken] = useSessionStorage(SESSION_STORAGE_KEYS.accessToken, '')
 
   const restClient = useMemo(() => {
@@ -35,7 +38,7 @@ export function useRestContextProvider(): RestContextValue {
     () => ({
       spaceService: SpaceService(restClient),
       authService: AuthService(restClient),
-      storageService: StorageService(restClient),
+      storageService: StorageService(restClient, signedFileStorageProvider),
       lessonService: LessonService(restClient),
       profileService: ProfileService(restClient),
       challengingService: ChallengingService(restClient),
@@ -43,6 +46,6 @@ export function useRestContextProvider(): RestContextValue {
       manualService: ManualService(restClient),
       reportingService: ReportingService(restClient),
     }),
-    [restClient],
+    [restClient, signedFileStorageProvider],
   )
 }

--- a/apps/studio/src/ui/global/hooks/useProvisionContext.ts
+++ b/apps/studio/src/ui/global/hooks/useProvisionContext.ts
@@ -1,0 +1,15 @@
+import { useContext } from 'react'
+
+import { AppError } from '@stardust/core/global/errors'
+
+import { ProvisionContext } from '../contexts/ProvisionContext'
+
+export function useProvisionContext() {
+  const context = useContext(ProvisionContext)
+
+  if (!context) {
+    throw new AppError('useProvisionContext must be used inside ProvisionContextProvider')
+  }
+
+  return context
+}

--- a/apps/studio/src/ui/global/widgets/components/ImageInput/ImageInputView.tsx
+++ b/apps/studio/src/ui/global/widgets/components/ImageInput/ImageInputView.tsx
@@ -38,12 +38,15 @@ export const ImageInputView = ({
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent className='p-10'>
         <div className='flex flex-col gap-6'>
-          <FileUpload onFilesChange={(files) => onFileChange(files[0] ?? null)} />
+          <FileUpload
+            maxSize={5 * 1024 * 1024}
+            onFilesChange={(files) => onFileChange(files[0] ?? null)}
+          />
           <InputWithError
             errorMessage={imageNameError ?? ''}
             value={imageName}
             label='Nome da imagem'
-            placeholder='pandinha.png'
+            placeholder='nome-final-da-imagem.png'
             onChange={(event) => onNameChange(event.target.value)}
             onBlur={(event) => onNameChange(event.target.value)}
           />

--- a/apps/studio/src/ui/global/widgets/components/ImageInput/index.tsx
+++ b/apps/studio/src/ui/global/widgets/components/ImageInput/index.tsx
@@ -9,7 +9,7 @@ import { useImageInput } from './useImageInput'
 
 type Props = {
   folder: string
-  onSubmit: () => void
+  onSubmit: (imageName: string) => void
 }
 
 export const ImageInput = ({ children, folder, onSubmit }: PropsWithChildren<Props>) => {

--- a/apps/studio/src/ui/global/widgets/components/ImageInput/tests/useImageInput.test.ts
+++ b/apps/studio/src/ui/global/widgets/components/ImageInput/tests/useImageInput.test.ts
@@ -1,0 +1,135 @@
+import { act, renderHook } from '@testing-library/react'
+import { mock, type Mock } from 'ts-jest-mocker'
+
+import type { ToastProvider } from '@stardust/core/global/interfaces'
+import { RestResponse } from '@stardust/core/global/responses'
+import type { StorageService } from '@stardust/core/storage/interfaces'
+import { FileStorageFolderPath } from '@stardust/core/storage/structures'
+
+import { useImageInput } from '../useImageInput'
+
+jest.mock('@/ui/global/hooks/useToastProvider', () => ({
+  useToastProvider: jest.fn(),
+}))
+
+describe('useImageInput', () => {
+  let storageService: Mock<StorageService>
+  let toastProvider: Mock<ToastProvider>
+  let dialogRef: { current: { close: jest.Mock } | null }
+  let onSubmit: jest.Mock
+
+  const Hook = () =>
+    renderHook(() =>
+      useImageInput({
+        storageService,
+        folder: FileStorageFolderPath.createAsStory(),
+        dialogRef: dialogRef as never,
+        onSubmit,
+      }),
+    )
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    storageService = mock<StorageService>()
+    toastProvider = mock<ToastProvider>()
+    dialogRef = { current: { close: jest.fn() } }
+    onSubmit = jest.fn()
+
+    toastProvider.showError = jest.fn()
+    toastProvider.showSuccess = jest.fn()
+
+    const { useToastProvider } = jest.requireMock('@/ui/global/hooks/useToastProvider')
+    useToastProvider.mockReturnValue(toastProvider)
+  })
+
+  it('should upload the file successfully and call onSubmit with the stored filename', async () => {
+    const file = new File(['image'], 'cover.png', { type: 'image/png' })
+
+    storageService.uploadFile.mockResolvedValue(
+      new RestResponse({
+        statusCode: 200,
+        body: { filename: 'stored-cover.png' },
+      }),
+    )
+
+    const { result } = Hook()
+
+    act(() => {
+      result.current.handleImageFileChange(file)
+    })
+
+    await act(async () => {
+      await result.current.handleSubmit()
+    })
+
+    expect(storageService.uploadFile).toHaveBeenCalledWith(
+      FileStorageFolderPath.createAsStory(),
+      file,
+    )
+    expect(dialogRef.current?.close).toHaveBeenCalledTimes(1)
+    expect(onSubmit).toHaveBeenCalledWith('stored-cover.png')
+    expect(result.current.imageFile).toBeNull()
+    expect(result.current.imageName).toBe('')
+    expect(result.current.imageNameError).toBe('')
+  })
+
+  it('should set image name validation error when the file name is invalid', async () => {
+    const file = new File(['image'], 'cover.png', { type: 'image/png' })
+
+    const { result } = Hook()
+
+    act(() => {
+      result.current.handleImageFileChange(file)
+      result.current.handleImageNameChange('invalid-name.txt')
+    })
+
+    await act(async () => {
+      await result.current.handleSubmit()
+    })
+
+    expect(storageService.uploadFile).not.toHaveBeenCalled()
+    expect(result.current.imageNameError).toBeTruthy()
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('should show toast when upload fails and keep the current input state', async () => {
+    const file = new File(['image'], 'cover.png', { type: 'image/png' })
+    let resolveUpload: (value: RestResponse<{ filename: string }>) => void = () => {}
+
+    storageService.uploadFile.mockReturnValue(
+      new Promise((resolve) => {
+        resolveUpload = resolve
+      }),
+    )
+
+    const { result } = Hook()
+
+    act(() => {
+      result.current.handleImageFileChange(file)
+    })
+
+    await act(async () => {
+      void result.current.handleSubmit()
+      await Promise.resolve()
+    })
+
+    expect(result.current.isSubmitting).toBe(true)
+
+    await act(async () => {
+      resolveUpload(
+        new RestResponse({
+          statusCode: 500,
+          errorMessage: 'Upload falhou',
+        }),
+      )
+      await Promise.resolve()
+    })
+
+    expect(toastProvider.showError).toHaveBeenCalledWith('Upload falhou')
+    expect(result.current.isSubmitting).toBe(false)
+    expect(result.current.imageFile).toBe(file)
+    expect(result.current.imageName).toBe('cover.png')
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+})

--- a/apps/studio/src/ui/global/widgets/components/ImageInput/useImageInput.ts
+++ b/apps/studio/src/ui/global/widgets/components/ImageInput/useImageInput.ts
@@ -31,7 +31,7 @@ export function useImageInput({ storageService, folder, dialogRef, onSubmit }: P
     setImageNameError('')
 
     if (imageFile) {
-      setImageFile(new File([imageFile], imageName, { type: imageFile.type }))
+      setImageFile(new File([imageFile], name, { type: imageFile.type }))
     }
   }
 
@@ -46,20 +46,22 @@ export function useImageInput({ storageService, folder, dialogRef, onSubmit }: P
     }
 
     setIsSubmitting(true)
-    const response = await storageService.uploadFile(folder, imageFile)
+    try {
+      const response = await storageService.uploadFile(folder, imageFile)
 
-    if (response.isSuccessful) {
+      if (response.isFailure) {
+        toast.showError(response.errorMessage)
+        return
+      }
+
       dialogRef.current?.close()
-      onSubmit(imageName)
+      onSubmit(response.body.filename)
+      setImageFile(null)
+      setImageName('')
+      setImageNameError('')
+    } finally {
+      setIsSubmitting(false)
     }
-    if (response.isFailure) {
-      toast.showError(response.errorMessage)
-    }
-
-    setIsSubmitting(false)
-    setImageFile(null)
-    setImageName('')
-    setImageNameError('')
   }
 
   return {

--- a/apps/studio/src/ui/lesson/widgets/components/PictureInput/PictureCard/index.tsx
+++ b/apps/studio/src/ui/lesson/widgets/components/PictureInput/PictureCard/index.tsx
@@ -6,7 +6,7 @@ type Props = {
   imageName: string
   isSelected: boolean
   onClick: (imageName: string) => void
-  onRemove: () => void
+  onRemove: (imageName: string) => void
 }
 
 export const PictureCard = ({ imageName, isSelected, onClick, onRemove }: Props) => {

--- a/apps/studio/src/ui/lesson/widgets/components/PictureInput/PictureCard/usePictureCard.ts
+++ b/apps/studio/src/ui/lesson/widgets/components/PictureInput/PictureCard/usePictureCard.ts
@@ -4,7 +4,10 @@ import { FileStorageFolderPath } from '@stardust/core/storage/structures'
 import { useToastProvider } from '@/ui/global/hooks/useToastProvider'
 import { Text } from '@stardust/core/global/structures'
 
-export function usePictureCard(storageService: StorageService, onRemove: () => void) {
+export function usePictureCard(
+  storageService: StorageService,
+  onRemove: (imageName: string) => void,
+) {
   const toast = useToastProvider()
 
   async function handleRemoveButtonClick(imageName: string) {
@@ -18,7 +21,7 @@ export function usePictureCard(storageService: StorageService, onRemove: () => v
     }
 
     if (response.isSuccessful) {
-      onRemove()
+      onRemove(imageName)
     }
   }
 

--- a/apps/studio/src/ui/lesson/widgets/components/PictureInput/PictureInputView.tsx
+++ b/apps/studio/src/ui/lesson/widgets/components/PictureInput/PictureInputView.tsx
@@ -29,8 +29,8 @@ type Props = {
   onPictureCardClick: (imageName: string) => void
   onSearchInputChange: (search: string) => void
   onLoadMoreButtonClick: () => void
-  onPictureCardRemove: () => void
-  onSubmitImage: () => void
+  onPictureCardRemove: (imageName: string) => void
+  onSubmitImage: (imageName: string) => void
   onClearSelection: () => void
 }
 

--- a/apps/studio/src/ui/lesson/widgets/components/PictureInput/tests/usePictureInput.test.ts
+++ b/apps/studio/src/ui/lesson/widgets/components/PictureInput/tests/usePictureInput.test.ts
@@ -1,0 +1,82 @@
+import { act, renderHook } from '@testing-library/react'
+
+import { Image } from '@stardust/core/global/structures'
+import type { StorageService } from '@stardust/core/storage/interfaces'
+
+import { usePictureInput } from '../usePictureInput'
+
+const mockPaginatedFetchReturn = {
+  data: [] as string[],
+  isFetching: false,
+  isFetchingNextPage: false,
+  hasNextPage: false,
+  nextPage: jest.fn(),
+  refetch: jest.fn(),
+}
+
+jest.mock('@/ui/global/hooks/usePaginatedFetch', () => ({
+  usePaginatedFetch: jest.fn(() => mockPaginatedFetchReturn),
+}))
+
+describe('usePictureInput', () => {
+  let storageService: StorageService
+  let dialogRef: { current: { close: jest.Mock } | null }
+  let onChange: jest.Mock
+  let onClear: jest.Mock
+
+  const Hook = (params?: { defaultPicture?: Image; isOptional?: boolean }) =>
+    renderHook(() =>
+      usePictureInput({
+        storageService,
+        dialogRef: dialogRef as never,
+        onChange,
+        onClear,
+        ...params,
+      }),
+    )
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    storageService = {} as StorageService
+    dialogRef = { current: { close: jest.fn() } }
+    onChange = jest.fn()
+    onClear = jest.fn()
+
+    mockPaginatedFetchReturn.data = []
+    mockPaginatedFetchReturn.isFetching = false
+    mockPaginatedFetchReturn.isFetchingNextPage = false
+    mockPaginatedFetchReturn.hasNextPage = false
+    mockPaginatedFetchReturn.nextPage = jest.fn()
+    mockPaginatedFetchReturn.refetch = jest.fn()
+  })
+
+  it('should automatically select the uploaded image and refetch the list', () => {
+    const { result } = Hook()
+
+    act(() => {
+      result.current.handleImageSubmit('uploaded-picture.jpg')
+    })
+
+    expect(result.current.selectedImage?.value).toBe('uploaded-picture.jpg')
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ value: 'uploaded-picture.jpg' }),
+    )
+    expect(mockPaginatedFetchReturn.refetch).toHaveBeenCalledTimes(1)
+    expect(dialogRef.current?.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('should fallback to panda.jpg when removing the selected image and refetch the list', () => {
+    const { result } = Hook({
+      defaultPicture: Image.create('uploaded-picture.jpg'),
+    })
+
+    act(() => {
+      result.current.handlePictureCardRemove('uploaded-picture.jpg')
+    })
+
+    expect(result.current.selectedImage?.value).toBe('panda.jpg')
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ value: 'panda.jpg' }))
+    expect(mockPaginatedFetchReturn.refetch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/studio/src/ui/lesson/widgets/components/PictureInput/usePictureInput.ts
+++ b/apps/studio/src/ui/lesson/widgets/components/PictureInput/usePictureInput.ts
@@ -5,10 +5,12 @@ import type { DialogRef } from '@/ui/shadcn/components/dialog'
 import { FileStorageFolderPath } from '@stardust/core/storage/structures'
 
 import { CACHE } from '@/constants'
+import { ENV } from '@/constants/env'
 import { usePaginatedFetch } from '@/ui/global/hooks/usePaginatedFetch'
 import { Image, OrdinalNumber, Text } from '@stardust/core/global/structures'
 
-const ITEMS_PER_PAGE = OrdinalNumber.create(30)
+const ITEMS_PER_PAGE = OrdinalNumber.create(12)
+const DEFAULT_IMAGE = Image.create('panda.jpg')
 
 type Props = {
   defaultPicture?: Image
@@ -28,7 +30,7 @@ export function usePictureInput({
   onClear,
 }: Props) {
   const [selectedImage, setSelectedImage] = useState<Image | null>(
-    defaultPicture ?? (isOptional ? null : Image.create('panda.jpg')),
+    defaultPicture ?? (isOptional ? null : DEFAULT_IMAGE),
   )
   const [search, setSearch] = useState<Text>(Text.create(''))
   const containerRef = useRef<HTMLDivElement>(null)
@@ -71,14 +73,22 @@ export function usePictureInput({
     nextPage()
   }
 
-  function handleImageSubmit() {
+  function handleImageSubmit(imageName: string) {
+    const image = Image.create(imageName)
+
+    setSelectedImage(image)
+    onChange(image)
     refetch()
     dialogRef.current?.close()
   }
 
-  function handlePictureCardRemove() {
+  function handlePictureCardRemove(imageName: string) {
+    if (selectedImage?.value === imageName) {
+      setSelectedImage(DEFAULT_IMAGE)
+      onChange(DEFAULT_IMAGE)
+    }
+
     refetch()
-    dialogRef.current?.close()
   }
 
   useEffect(() => {
@@ -87,8 +97,17 @@ export function usePictureInput({
       return
     }
 
-    setSelectedImage(isOptional ? null : Image.create('panda.jpg'))
+    setSelectedImage(isOptional ? null : DEFAULT_IMAGE)
   }, [defaultPicture, isOptional])
+
+  useEffect(() => {
+    if (!data?.length) return
+
+    for (const imageName of data) {
+      const image = new window.Image()
+      image.src = `${ENV.supabaseCdnUrl}/${FileStorageFolderPath.createAsStory().value}/${imageName}`
+    }
+  }, [data])
 
   return {
     images: data ? data.map((image) => Image.create(image)) : [],

--- a/apps/web/src/rest/services/StorageService.ts
+++ b/apps/web/src/rest/services/StorageService.ts
@@ -10,7 +10,8 @@ export const StorageService = (restClient: RestClient): IStorageService => {
       if (params.page) restClient.setQueryParam('page', String(params.page.value))
       restClient.setQueryParam('itemsPerPage', String(params.itemsPerPage.value))
       restClient.setQueryParam('search', params.search.value)
-      return await restClient.get(`/storage/files/${params.folder.value}`)
+      restClient.setQueryParam('folder', params.folder.value)
+      return await restClient.get('/storage/files')
     },
 
     async uploadFile(folder: FileStorageFolderPath, file: File) {
@@ -19,8 +20,17 @@ export const StorageService = (restClient: RestClient): IStorageService => {
       return await restClient.postFormData(`/storage/files/${folder.value}`, formData)
     },
 
+    async createSignedUploadUrl(folderPath: FileStorageFolderPath, fileName: Text) {
+      return await restClient.post('/storage/signed-upload-url', {
+        folderPath: folderPath.value,
+        fileName: fileName.value,
+      })
+    },
+
     async removeFile(folder: FileStorageFolderPath, fileName: Text) {
-      return await restClient.delete(`/storage/files/${folder.value}/${fileName.value}`)
+      restClient.setQueryParam('folder', folder.value)
+      restClient.setQueryParam('fileName', fileName.value)
+      return await restClient.delete('/storage/files')
     },
 
     async searchEmbeddings(query, topK, namespace) {

--- a/apps/web/src/rest/services/StorageService.ts
+++ b/apps/web/src/rest/services/StorageService.ts
@@ -28,9 +28,15 @@ export const StorageService = (restClient: RestClient): IStorageService => {
     },
 
     async removeFile(folder: FileStorageFolderPath, fileName: Text) {
+      restClient.clearQueryParams()
       restClient.setQueryParam('folder', folder.value)
       restClient.setQueryParam('fileName', fileName.value)
-      return await restClient.delete('/storage/files')
+
+      try {
+        return await restClient.delete('/storage/files')
+      } finally {
+        restClient.clearQueryParams()
+      }
     },
 
     async searchEmbeddings(query, topK, namespace) {

--- a/documentation/architecture.md
+++ b/documentation/architecture.md
@@ -26,12 +26,15 @@ O StarDust usa uma arquitetura **Hexagonal (Ports and Adapters)** onde o pacote 
 
 **Lesson audio generation**: REST `/lesson/text-blocks` → use cases do modulo `lesson` → eventos Inngest (`requested`, `batch requested`, `generated`, `cancelled`) → jobs de fan-out, TTS/upload e persistencia final do `audio` em `stars.texts[blockIndex].audio`
 
+**Studio signed upload**: Studio `ImageInput` → `StorageService.createSignedUploadUrl(...)` → Server `POST /storage/signed-upload-url` → `CreateSignedUploadUrl` → `SupabaseFileStorageProvider.createSignedUploadUrl(...)` → upload direto do binario ao Supabase Storage
+
 ## Padrões Principais
 
 - **Widget** na UI para separar View (renderização), Hook (lógica/estado) e Index (integração).
 - **Action/RPC** para conectar rotas ao domínio sem acoplar o framework ao Core.
 - **MCP Toolkit** no server para compor tools com `inputSchema`/`outputSchema` na borda e delegar comportamento ao Core.
 - **RestClient** como adapter sobre Axios/Fetch para chamadas HTTP externas.
+- **ProvisionContext no Studio** para resolver providers client-side de infraestrutura, como o upload direto por URL assinada, sem misturar essa responsabilidade no dominio nem no widget.
 - **Job** para tarefas assíncronas, agendadas ou falháveis (e-mail, relatórios).
 - **Factory Functions** no lugar de `new Class()` para Serviços e Controllers.
 

--- a/documentation/features/storage/picture-files-upload/specs/signed-upload-url-migraation-spec.md
+++ b/documentation/features/storage/picture-files-upload/specs/signed-upload-url-migraation-spec.md
@@ -1,0 +1,537 @@
+---
+title: Migracao de uploads do Studio para URLs assinadas do Supabase
+prd: https://github.com/JohnPetros/stardust/milestone/32
+issue: https://github.com/JohnPetros/stardust/issues/413
+apps: server, studio, web
+status: closed
+last_updated_at: 2026-05-22
+---
+
+# 1. Objetivo (Obrigatorio)
+
+Migrar o upload de imagens iniciado pelo Studio para um fluxo baseado em URLs assinadas do Supabase Storage, mantendo a experiencia atual dos widgets de selecao, upload imediato, listagem paginada, preview e remocao de assets. Tecnicamente, a entrega cria um endpoint autenticado e autorizado no `server` para emitir o contrato de upload assinado, adiciona o contrato compartilhado em `core`/`validation`, implementa o upload direto no `studio` sem trafegar binario pelo `server` e mantem o endpoint legado de upload binario `POST /storage/files/:folder` para nao quebrar o `web`.
+
+---
+
+# 2. Escopo (Obrigatorio)
+
+## 2.1 In-scope
+
+* Criar um contrato REST unico para solicitar URL assinada informando `folderPath` e `fileName`.
+* Implementar a emissao da URL assinada no `SupabaseFileStorageProvider` usando o bucket atual `stardust-bucket`.
+* Migrar o `StorageService` do Studio para executar upload direto ao Supabase a partir do contrato assinado.
+* Preservar o contrato publico atual de `ImageInput` e dos formularios administrativos que o reutilizam.
+* Manter listagem (`GET /storage/files`) e remocao (`DELETE /storage/files?folder=...&fileName=...`) sem mudanca funcional, aplicando a mesma regra de autenticacao/autorizacao do endpoint de signed upload.
+* Manter `POST /storage/files/:folder` como compatibilidade temporaria para o upload de screenshot de feedback no `web`.
+* Corrigir o alinhamento do contrato `FileStorageProvider` com os usos reais de upload server-side ja existentes.
+* Exportar `SignedUploadUrl` e `SignedUploadUrlDto` pelos barrel files publicos do `core`.
+
+## 2.2 Out-of-scope
+
+* Definir novos formatos aceitos alem da regra ja consolidada no PRD atualizado por esta entrega.
+* Alterar a experiencia visual do seletor de imagens alem dos estados necessarios para preservar erro/loading atuais.
+* Renomear imagens ja cadastradas, organizar assets por novas pastas/tags ou bloquear remocao de imagens em uso.
+* Criar migrations, buckets, RLS policies ou grants de Storage nesta entrega.
+* Substituir listagem/remocao por URLs assinadas ou por chamadas diretas do Studio ao Supabase.
+
+---
+
+# 3. Requisitos (Obrigatorio)
+
+## 3.1 Funcionais
+
+* O Studio deve continuar permitindo upload de imagens para a pasta `story` no fluxo de edicao de historia e quiz de licao.
+* O Studio deve continuar permitindo upload de imagens nos formularios administrativos que reutilizam `ImageInput` para planetas, avatares, foguetes, conquistas e insignias.
+* O Studio deve solicitar ao server um contrato assinado antes de enviar o binario ao Supabase Storage.
+* O Studio deve enviar o binario diretamente ao Supabase Storage usando a URL assinada, sem passar o arquivo pelo endpoint REST legado.
+* Apos upload bem-sucedido, o Studio deve registrar no estado/formulario o nome final do arquivo e preservar preview, refetch da listagem e selecao existentes.
+* No seletor `PictureInput`, apos upload bem-sucedido, a imagem recem-enviada deve ser selecionada automaticamente.
+* O fluxo de cancelamento/fechamento sem salvar deve continuar removendo arquivos recem-enviados pelos hooks de formulario que ja usam `removeFile`.
+* Ao remover uma imagem dentro do `PictureInput`, o dialog deve permanecer aberto.
+* Ao remover a imagem atualmente selecionada no `PictureInput`, a selecao deve voltar para `panda.jpg`.
+* O server deve receber `folderPath` e `fileName` no request antes de emitir a URL assinada.
+* O server deve usar o `fileName` informado e validado como nome final do arquivo ao emitir a URL assinada; o client nunca deve enviar `url` ou token assinado no request.
+* O server deve verificar via `FileStorageProvider` se o `fileName` ja existe no `folderPath` informado antes de emitir a URL assinada e deve falhar quando houver conflito.
+* O `web` pode continuar usando `POST /storage/files/:folder` neste ciclo para nao quebrar o fluxo atual de screenshot de feedback.
+
+## 3.2 Nao funcionais
+
+* Seguranca: o endpoint de emissao de signed upload URL deve exigir `verifyAuthentication` e `verifyGodAccount`, seguindo o padrao das rotas administrativas de escrita do Studio.
+* Seguranca: `GET /storage/files` e `DELETE /storage/files?folder=...&fileName=...` devem exigir `verifyAuthentication` e `verifyGodAccount`.
+* Seguranca: `folderPath` deve ser validado contra a allowlist do projeto na borda; `fileName` nao deve aceitar `/`, `\\`, valor vazio, `.` ou `..`.
+* Seguranca: a compatibilidade entre `folderPath` e extensao do `fileName` deve ser validada em `SignedUploadUrl`.
+* Compatibilidade retroativa: `StorageService.uploadFile(folder, file)` deve continuar existindo porque ainda e usado pelo `web` e pelos widgets do Studio.
+* Compatibilidade retroativa: uploads server-side usados por jobs e pelo endpoint legado devem continuar suportados por `FileStorageProvider.upload(folder, file)`.
+* Latencia: no Studio, o binario deve deixar de trafegar pelo `server`; apenas a emissao da URL assinada passa pela API.
+* Performance percebida: o `PictureInput` deve abrir com carga inicial reduzida, buscando `12` imagens por pagina e pre-carregando as thumbnails assim que a primeira pagina for recebida.
+* Resiliencia: falha na emissao da signed URL e falha no upload direto devem ser tratadas separadamente e exibidas como erro no fluxo atual do `ImageInput`.
+* Compatibilidade funcional: o conflito de nome deve ser detectado antes do upload direto ao Supabase, para evitar tentativa de envio desnecessaria.
+* Tamanho maximo: uploads de imagem na `studio` devem respeitar limite fixo de `5 MB` (`5 * 1024 * 1024` bytes), validado antes da chamada ao endpoint de signed upload URL.
+
+---
+
+# 4. O que ja existe? (Obrigatorio)
+
+## Core
+
+* **`SignedUploadUrl`** (`packages/core/src/storage/domain/structures/SignedUploadUrl.ts`) - Structure ja existente com `url`, `folderPath`, `fileName` e getter `dto`; sera estendida para validar a extensao do `fileName` de acordo com o `folderPath` no `create()`.
+* **`SignedUploadUrlDto`** (`packages/core/src/storage/domain/structures/dtos/SignedUploadUrlDto.ts`) - DTO existente com `{ url: string; folderPath: string; fileName: string }`.
+* **`FileStorageFolderPath`** (`packages/core/src/storage/domain/structures/FileStorageFolderPath.ts`) - Resolve nomes legados como `story` para `images/story` e valida os paths canonicos de storage.
+* **`FileStorageProvider`** (`packages/core/src/storage/interfaces/FileStorageProvider.ts`) - Interface de provider de storage; hoje esta inconsistente com os adapters reais porque declara `upload(signedUploadUrl)` enquanto controllers, jobs e providers usam `upload(folder, file)`.
+* **`SignedFileStorageProvider`** (`packages/core/src/storage/interfaces/SignedFileStorageProvider.ts`) - Novo contrato dedicado ao upload direto por URL assinada, usado pela `studio`.
+* **`StorageService`** (`packages/core/src/storage/interfaces/StorageService.ts`) - Interface compartilhada dos clients REST de storage, com `listFiles`, `uploadFile`, `removeFile` e `searchEmbeddings`.
+* **`BackupDatabaseUseCase`** (`packages/core/src/storage/use-cases/BackupDatabaseUseCase.ts`) - Uso existente de upload server-side via `storageProvider.upload(folder, file)`.
+
+## Core - Use Cases
+
+* **`BackupDatabaseUseCase`** (`packages/core/src/storage/use-cases/BackupDatabaseUseCase.ts`) - Referencia de use case simples do modulo `storage`, com dependencias injetadas e orquestracao direta sobre providers.
+
+## Validation
+
+* **`fileStorageFolderPathSchema`** (`packages/validation/src/modules/storage/fileStorageFolderPathSchema.ts`) - Schema Zod com allowlist de paths canonicos como `images/story`, `images/avatars`, `images/feedback-reports` e `database-backups`.
+* **`stringSchema`** (`packages/validation/src/modules/global/schemas/stringSchema.ts`) - Schema base de string usado em validators de rota.
+* **`storage` barrel** (`packages/validation/src/modules/storage/index.ts`) - Exporta schemas do modulo de storage.
+
+## Server - Hono App
+
+* **`FilesStorageRouter`** (`apps/server/src/app/hono/routers/storage/FilesStorageRouter.ts`) - Registra hoje `POST /storage/files/:folder`, `GET /storage/files` e `DELETE /storage/files`; nesta entrega, listagem/remocao passam a usar o mesmo par `verifyAuthentication` + `verifyGodAccount` do endpoint de signed upload.
+* **`StorageRouter`** (`apps/server/src/app/hono/routers/storage/StorageRouter.ts`) - Monta o router de storage sob `/storage` e passa a expor `POST /storage/signed-upload-url`.
+* **`AuthMiddleware`** (`apps/server/src/app/hono/middlewares/AuthMiddleware.ts`) - Expoe `verifyAuthentication` e `verifyGodAccount`; rotas administrativas de escrita usam os dois middlewares em sequencia.
+
+## Server - REST Controllers
+
+* **`UploadFileController`** (`apps/server/src/rest/controllers/storage/UploadFileController.ts`) - Controller legado de upload multipart que deve ser mantido para compatibilidade com o `web`.
+* **`FetchFilesListController`** (`apps/server/src/rest/controllers/storage/FetchFilesListController.ts`) - Lista arquivos com paginacao via `storageProvider.listFiles`.
+* **`RemoveFileController`** (`apps/server/src/rest/controllers/storage/RemoveFileController.ts`) - Remove arquivo via `storageProvider.removeFile`.
+* **`storage controllers barrel`** (`apps/server/src/rest/controllers/storage/index.ts`) - Exporta controllers do modulo de storage.
+
+## Server - Provision
+
+* **`SupabaseFileStorageProvider`** (`apps/server/src/provision/storage/SupabaseFileStorageProvider.ts`) - Provider principal de storage, usa `@supabase/supabase-js`, bucket `stardust-bucket`, upload server-side, listagem, busca, public URL e remocao.
+* **`GoogleDriveStorageProvider`** (`apps/server/src/provision/storage/GoogleDriveStorageProvider.ts`) - Provider alternativo parcial; implementa upload server-side e deixa demais metodos como nao implementados.
+* **`DropboxStorageProvider`** (`apps/server/src/provision/storage/DropboxStorageProvider.ts`) - Provider usado para backup de database; implementa upload server-side e deixa demais metodos como nao implementados.
+
+## Studio - REST
+
+* **`StorageService`** (`apps/studio/src/rest/services/StorageService.ts`) - Implementacao atual de `StorageService`, com `uploadFile` enviando `FormData` para `POST /storage/files/${folder.value}`.
+* **`SupabaseSignedFileStorageProvider`** (`apps/studio/src/provision/storage/SupabaseSignedFileStorageProvider.ts`) - Provider client-side dedicado ao upload direto por URL assinada.
+* **`AxiosRestClient`** (`apps/studio/src/rest/axios/AxiosRestClient.ts`) - Implementa `RestClient` com `get`, `post`, `postFormData`, `put`, `patch`, `delete`, headers e query params.
+* **`useRestContextProvider`** (`apps/studio/src/ui/global/contexts/RestContext/useRestContextProvider.ts`) - Cria `AxiosRestClient`, configura `ENV.stardustServerUrl` e injeta `storageService` no contexto da UI.
+* **`ProvisionContext`** (`apps/studio/src/ui/global/contexts/ProvisionContext`) - Composition root de providers client-side consumidos pela UI da `studio`.
+* **`contexts` de UI** (`apps/studio/src/ui/global/contexts`) - Ponto onde a `studio` ja organiza providers de infraestrutura consumidos pela camada UI.
+
+## Studio - UI
+
+* **`ImageInput`** (`apps/studio/src/ui/global/widgets/components/ImageInput/index.tsx`) - Entry point do widget reutilizavel de upload imediato, resolve `storageService` via `useRestContext`.
+* **`useImageInput`** (`apps/studio/src/ui/global/widgets/components/ImageInput/useImageInput.ts`) - Hook que guarda `imageFile`, `imageName`, valida `Image.create(imageName)` e chama `storageService.uploadFile`.
+* **`ImageInputView`** (`apps/studio/src/ui/global/widgets/components/ImageInput/ImageInputView.tsx`) - View com `FileUpload`, input de nome e botao `Enviar` com loading.
+* **`PictureInput`** (`apps/studio/src/ui/lesson/widgets/components/PictureInput/index.tsx`) - Entry point do seletor de imagens de licao.
+* **`usePictureInput`** (`apps/studio/src/ui/lesson/widgets/components/PictureInput/usePictureInput.ts`) - Lista imagens de `FileStorageFolderPath.createAsStory()` com `usePaginatedFetch`, `ITEMS_PER_PAGE = 12`, busca, selecao, preload de thumbnails e refetch apos upload/remocao.
+* **`PictureInputView`** (`apps/studio/src/ui/lesson/widgets/components/PictureInput/PictureInputView.tsx`) - View com busca, imagem selecionada, `ImageInput folder='story'`, loading, empty state, grid e load more.
+* **`PictureCard` hook** (`apps/studio/src/ui/lesson/widgets/components/PictureInput/PictureCard/usePictureCard.ts`) - Remove imagens via `storageService.removeFile(FileStorageFolderPath.createAsStory(), Text.create(imageName))`.
+* **`StorageImage`** (`apps/studio/src/ui/global/widgets/components/StorageImage/index.tsx`) - Renderiza preview a partir do CDN do Supabase e resolve pastas legadas.
+
+## Web - Compatibilidade
+
+* **`StorageService`** (`apps/web/src/rest/services/StorageService.ts`) - Implementacao web do `StorageService`; hoje `uploadFile` ainda usa `POST /storage/files/${folder.value}`.
+* **`useFeedbackDialog`** (`apps/web/src/ui/reporting/widgets/layouts/FeedbackLayout/FeedbackDialog/useFeedbackDialog.ts`) - Consumidor remanescente do upload legado, envia screenshot para `FileStorageFolderPath.createAsFeedbackReports()`.
+
+---
+
+# 5. O que deve ser criado?
+
+## Camada REST (Controllers)
+
+* **Localizacao:** `apps/server/src/rest/controllers/storage/CreateSignedUploadUrlController.ts` (**novo arquivo**)
+* **Dependencias:** `FileStorageProvider` injetado no construtor.
+* **Dados de request:** body JSON com `folderPath: string` e `fileName: string`.
+* **Dados de response:** `SignedUploadUrlDto` com `url`, `folderPath` e `fileName`.
+* **Metodos:** `handle(http: Http<CreateSignedUploadUrlControllerSchema>): Promise<RestResponse<SignedUploadUrlDto>>` - le `folderPath` e `fileName` do body, chama o use case `CreateSignedUploadUrl` e retorna `http.statusOk().send(signedUploadUrl.dto)`.
+
+## Camada Core (Use Cases)
+
+* **Localizacao:** `packages/core/src/storage/use-cases/CreateSignedUploadUrl.ts` (**novo arquivo**)
+* **Dependencias:** `FileStorageProvider`.
+* **Dados de request:** `folderPath: string` e `fileName: string`.
+* **Dados de response:** `SignedUploadUrlDto`.
+* **Metodos:** `execute({ folderPath, fileName }: { folderPath: string; fileName: string }): Promise<SignedUploadUrlDto>` - cria `FileStorageFolderPath` e `Text`, consulta `findFile(folderPath, fileName)` no provider, falha se ja existir arquivo com esse nome e, caso nao exista, solicita `createSignedUploadUrl(folderPath, fileName)` ao provider; o DTO retornado deve ser criado via `SignedUploadUrl.create(...)`, que valida a extensao do `fileName` de acordo com o `folderPath`.
+
+## Pacote Validation (Schemas)
+
+* **Localizacao:** `packages/validation/src/modules/storage/signedUploadUrlSchema.ts` (**novo arquivo**)
+* **Atributos:** `folderPath` deve reutilizar `fileStorageFolderPathSchema`; `fileName` deve reutilizar `stringSchema`, exigir pelo menos 1 caractere apos trim e rejeitar `/`, `\\`, `.`, `..`.
+
+## Camada Provision (Providers)
+
+* **Localizacao:** `apps/studio/src/provision/storage/SupabaseSignedFileStorageProvider.ts` (**novo arquivo**)
+* **Dependencias:** Nenhuma dependencia externa obrigatoria; usar `fetch` do browser ou `axios` local sem base URL do `server`.
+* **Biblioteca:** Browser Fetch API ou Axios.
+* **Metodos:** `uploadFile(signedUploadUrl: SignedUploadUrl, file: File): Promise<void>` - usa os dados do `SignedUploadUrl` e o binario selecionado para enviar o upload diretamente ao Supabase Storage e resolve sem payload quando o upload for concluido com sucesso.
+
+---
+
+# 6. O que deve ser modificado? (Depende da tarefa)
+
+## Core
+
+* **Arquivo:** `packages/core/src/storage/interfaces/FileStorageProvider.ts`
+* **Mudanca:** Ajustar `upload` para `upload(folder: FileStorageFolderPath, file: File): Promise<File>` e adicionar `createSignedUploadUrl(folderPath: FileStorageFolderPath, fileName: Text): Promise<SignedUploadUrl>`.
+* **Justificativa:** O upload server-side ja e usado por `UploadFileController`, `BackupDatabaseUseCase` e jobs de audio; a URL assinada deve ser um metodo adicional do port, nao uma substituicao que quebra fluxos internos.
+* **Camada:** `core`
+
+* **Arquivo:** `packages/core/src/storage/interfaces/SignedFileStorageProvider.ts`
+* **Mudanca:** Criar a nova interface `SignedFileStorageProvider` com o metodo `uploadFile(signedUploadUrl: SignedUploadUrl, file: File): Promise<void>`.
+* **Justificativa:** O upload por URL assinada precisa de um contrato proprio para a UI, sem poluir `FileStorageProvider` server-side com responsabilidades que pertencem a outro adapter.
+* **Camada:** `core`
+
+* **Arquivo:** `packages/core/src/storage/interfaces/StorageService.ts`
+* **Mudanca:** Adicionar `createSignedUploadUrl(folderPath: FileStorageFolderPath, fileName: Text): Promise<RestResponse<SignedUploadUrlDto>>`, mantendo `uploadFile(folder, file): Promise<RestResponse<{ filename: string }>>`.
+* **Justificativa:** O contrato compartilhado precisa expor a emissao da signed URL para adapters REST sem remover a API usada por Studio/Web.
+* **Camada:** `core`
+
+* **Arquivo:** `packages/core/src/storage/use-cases/index.ts`
+* **Mudanca:** Exportar `CreateSignedUploadUrl`.
+* **Justificativa:** O controller do server deve executar um use case do modulo `storage`, em vez de delegar diretamente ao provider.
+* **Camada:** `core`
+
+* **Arquivo:** `packages/core/src/storage/domain/errors/index.ts`
+* **Mudanca:** Exportar novo erro de conflito de nome de arquivo do modulo `storage`.
+* **Justificativa:** O use case precisa falhar com erro explicito quando `findFile` indicar que o `fileName` ja existe.
+* **Camada:** `core`
+
+* **Arquivo:** `packages/core/src/storage/domain/structures/SignedUploadUrl.ts`
+* **Mudanca:** Adicionar validacao no `create(dto)` para garantir que a extensao do `fileName` e compativel com o `folderPath` informado.
+* **Justificativa:** A regra pedida pelo usuario deve ficar centralizada na structure usada para representar o contrato assinado.
+* **Camada:** `core`
+
+* **Arquivo:** `packages/core/src/storage/domain/structures/index.ts`
+* **Mudanca:** Exportar `SignedUploadUrl`.
+* **Justificativa:** O Studio precisa criar a structure a partir do DTO retornado antes de chamar o upload client.
+* **Camada:** `core`
+
+* **Arquivo:** `packages/core/src/storage/domain/structures/dtos/index.ts`
+* **Mudanca:** Exportar `SignedUploadUrlDto`.
+* **Justificativa:** `StorageService.createSignedUploadUrl` retorna esse DTO pelo contrato publico.
+* **Camada:** `core`
+
+## Validation
+
+* **Arquivo:** `packages/validation/src/modules/storage/index.ts`
+* **Mudanca:** Exportar `signedUploadUrlSchema`.
+* **Justificativa:** O router Hono deve validar o body do novo endpoint usando o pacote compartilhado.
+* **Camada:** `rest`
+
+## Server - Provision
+
+* **Arquivo:** `apps/server/src/provision/storage/SupabaseFileStorageProvider.ts`
+* **Mudanca:** Implementar `createSignedUploadUrl(folderPath, fileName)` usando o metodo `createSignedUploadUrl` do Supabase Storage para o path composto por `folderPath.value` + `/` + `fileName.value`, com `upsert: false`; mapear a URL retornada para `SignedUploadUrl.create({ url, folderPath: folderPath.value, fileName: fileName.value })` e manter `upload(folder, file)` para fluxos server-side.
+* **Justificativa:** A emissao da URL assinada e detalhe do SDK Supabase e deve ficar encapsulada no provider.
+* **Camada:** `provision`
+
+* **Arquivo:** `apps/server/src/provision/storage/GoogleDriveStorageProvider.ts`
+* **Mudanca:** Adicionar apenas `createSignedUploadUrl(_folderPath: FileStorageFolderPath, _fileName: Text): Promise<SignedUploadUrl>` lancando `MethodNotImplementedError(...)`.
+* **Justificativa:** Satisfazer o contrato do core sem fingir suporte a signed upload em provider que nao participa do fluxo.
+* **Camada:** `provision`
+
+* **Arquivo:** `apps/server/src/provision/storage/DropboxStorageProvider.ts`
+* **Mudanca:** Adicionar apenas `createSignedUploadUrl(_folderPath: FileStorageFolderPath, _fileName: Text): Promise<SignedUploadUrl>` lancando `MethodNotImplementedError(...)`.
+* **Justificativa:** Satisfazer o contrato do core sem alterar o fluxo de backup que usa Dropbox apenas para upload server-side.
+* **Camada:** `provision`
+
+## Studio - Provision
+
+* **Arquivo:** `apps/studio/src/provision/storage/SupabaseSignedFileStorageProvider.ts`
+* **Mudanca:** Implementar `SignedFileStorageProvider` com o metodo `uploadFile(signedUploadUrl: SignedUploadUrl, file: File): Promise<void>`.
+* **Justificativa:** Na `studio`, o provider existe apenas para executar o upload direto a partir do contrato assinado retornado pelo `server`.
+* **Camada:** `provision`
+
+## Server - REST
+
+* **Arquivo:** `apps/server/src/rest/controllers/storage/CreateSignedUploadUrlController.ts`
+* **Mudanca:** Injetar e executar `CreateSignedUploadUrl`, sem montar `SignedUploadUrlDto` diretamente no controller.
+* **Justificativa:** A validacao de `folderPath`, a checagem de existencia e a chamada ao provider devem ficar no use case e na structure.
+* **Camada:** `rest`
+
+* **Arquivo:** `apps/server/src/rest/controllers/storage/index.ts`
+* **Mudanca:** Exportar `CreateSignedUploadUrlController`.
+* **Justificativa:** Manter o padrao de barrel dos controllers de storage.
+* **Camada:** `rest`
+
+## Server - Hono App
+
+* **Arquivo:** `apps/server/src/app/hono/routers/storage/StorageRouter.ts`
+* **Mudanca:** Importar `signedUploadUrlSchema`, `CreateSignedUploadUrlController` e `CreateSignedUploadUrl`; criar `registerCreateSignedUploadUrlRoute()` com `POST /signed-upload-url`, middlewares `verifyAuthentication`, `verifyGodAccount`, `validate('json', signedUploadUrlSchema)`; instanciar controller + use case + provider dentro da rota e registrar essa rota no router raiz de `storage`.
+* **Justificativa:** O endpoint final exigido e `POST /storage/signed-upload-url`; registrar a rota no `StorageRouter` preserva `FilesStorageRouter` dedicado apenas a `/storage/files`.
+* **Camada:** `rest`
+
+* **Arquivo:** `apps/server/src/app/hono/routers/storage/FilesStorageRouter.ts`
+* **Mudanca:** Aplicar `verifyAuthentication` + `verifyGodAccount` em `GET /storage/files` e alterar a remocao para `DELETE /storage/files` com `folder` e `fileName` em query params.
+* **Justificativa:** Mantem listagem/remocao no mesmo subrouter de arquivos e alinha o contrato real exposto pela borda REST.
+* **Camada:** `rest`
+
+## Studio - REST
+
+* **Arquivo:** `apps/studio/src/rest/services/StorageService.ts`
+* **Mudanca:** Alterar a factory para receber `signedFileStorageProvider: SignedFileStorageProvider`; implementar `createSignedUploadUrl(folderPath, fileName)` chamando `POST /storage/signed-upload-url` com `{ folderPath: folderPath.value, fileName: fileName.value }`; alterar `uploadFile(folder, file)` para enviar o `fileName` escolhido na UI, montar o `SignedUploadUrl` a partir da resposta e fazer upload direto via `signedFileStorageProvider.uploadFile(signedUploadUrl, file)`; retornar `RestResponse<{ filename: string }>` com o mesmo `fileName` retornado pelo server.
+* **Justificativa:** Preservar o contrato atual dos widgets enquanto remove o uso do endpoint legado no Studio.
+* **Camada:** `rest`
+
+## Studio - UI (Contexts)
+
+* **Localizacao:** `apps/studio/src/ui/global/contexts/ProvisionContext` (**nova pasta**)
+* **Props:** `children: ReactNode`.
+* **Hook do provider:** `apps/studio/src/ui/global/contexts/ProvisionContext/useProvisionContextProvider.ts`.
+* **Responsabilidade:** Instanciar e prover providers consumidos pela UI da `studio`, inicialmente `SupabaseSignedFileStorageProvider` com suporte a upload por signed URL.
+* **Value:** `{ signedFileStorageProvider: SignedFileStorageProvider }`.
+
+* **Arquivo:** `apps/studio/src/ui/global/contexts/RestContext/useRestContextProvider.ts`
+* **Mudanca:** Manter o `RestContext` restrito a services REST; remover dele a responsabilidade de instanciar providers de provision.
+* **Justificativa:** Providers de infraestrutura da UI passam a ser resolvidos por `ProvisionContext`, separando REST de provision.
+* **Camada:** `ui`
+
+## Studio - UI
+
+* **Arquivo:** `apps/studio/src/ui/global/widgets/components/ImageInput/useImageInput.ts`
+* **Mudanca:** Continuar usando o nome editado na UI como `fileName` enviado ao service; apos sucesso, chamar `onSubmit(response.body.filename)` usando o `fileName` retornado pelo server, que deve repetir o `fileName` validado.
+* **Justificativa:** O nome final do arquivo volta a ser controlado pela borda, desde que passe pela validacao do backend antes da emissao da URL assinada.
+* **Camada:** `ui`
+
+* **Arquivo:** `apps/studio/src/ui/lesson/widgets/components/PictureInput/usePictureInput.ts`
+* **Mudanca:** Apos upload bem-sucedido, selecionar automaticamente a imagem recem-enviada; ao remover uma imagem, manter o dialog aberto; ao remover a imagem atualmente selecionada, definir `panda.jpg` como fallback padrao; reduzir `ITEMS_PER_PAGE` para `12` e pre-carregar thumbnails da primeira pagina.
+* **Justificativa:** Preserva a continuidade do fluxo no seletor de imagens, melhora a performance percebida na abertura do dialog e evita estado vazio inesperado apos exclusao da imagem selecionada.
+* **Camada:** `ui`
+
+* **Arquivo:** `apps/studio/src/ui/global/widgets/components/ImageInput/index.tsx`
+* **Mudanca:** Resolver `storageService` via `useRestContext` e `signedFileStorageProvider` via `useProvisionContext`, repassando ambos para o fluxo de upload.
+* **Justificativa:** O widget continua como entry point de integracao, mas cada dependencia passa a vir do contexto correto.
+* **Camada:** `ui`
+
+* **Arquivo:** `apps/studio/src/ui/global/widgets/components/ImageInput/ImageInputView.tsx`
+* **Mudanca:** Manter o input de nome da imagem como campo editavel e alinhar o texto/placeholder para representar explicitamente o `fileName` que sera validado pelo backend; configurar `FileUpload` com `maxSize={5 * 1024 * 1024}`.
+* **Justificativa:** O fluxo volta a depender do nome informado pelo usuario para compor o `fileName` final no storage.
+* **Camada:** `ui`
+
+* **Arquivo:** `apps/studio/src/ui/global/widgets/components/ImageInput/useImageInput.ts`
+* **Mudanca:** Tratar erro da etapa de signed URL e erro do upload direto no mesmo estado `isSubmitting`, exibindo toast e resetando o loading em `finally`; respeitar o bloqueio de arquivo acima de `5 MB` vindo do `FileUpload`.
+* **Justificativa:** O novo fluxo tem duas chamadas falhaveis e o widget precisa preservar feedback de erro sem fechar o dialog em falha parcial.
+* **Camada:** `ui`
+
+## Web - REST
+
+* **Arquivo:** `apps/web/src/rest/services/StorageService.ts`
+* **Mudanca:** Implementar `createSignedUploadUrl(folderPath, fileName)` chamando `POST /storage/signed-upload-url`, e ajustar `removeFile(folder, fileName)` para usar `DELETE /storage/files` com query params; manter `uploadFile(folder, file)` usando `POST /storage/files/${folder.value}`.
+* **Justificativa:** A interface compartilhada passa a exigir o metodo novo, mas o `web` ainda depende do endpoint legado pelo `FeedbackDialog`.
+* **Camada:** `rest`
+
+---
+
+# 7. O que deve ser removido? (Depende da tarefa)
+
+**Nao aplicavel**.
+
+---
+
+# 8. Decisoes Tecnicas e Trade-offs (Obrigatorio)
+
+* **Decisao:** Manter `uploadFile(folder, file)` no contrato `StorageService` e mudar apenas a implementacao do Studio para usar signed URL internamente.
+* **Alternativas consideradas:** Alterar `ImageInput` para chamar explicitamente `createSignedUploadUrl` e um client local; remover `uploadFile` da interface compartilhada.
+* **Motivo da escolha:** Minimiza alteracoes na UI, preserva formularios existentes e mantem compatibilidade com o Web.
+* **Impactos / trade-offs:** `StorageService` fica com um metodo de fachada legado (`uploadFile`) e um metodo explicito novo (`createSignedUploadUrl`) durante a fase de migracao.
+
+* **Decisao:** Corrigir `FileStorageProvider.upload` para o contrato server-side real e adicionar `createSignedUploadUrl` como metodo separado.
+* **Alternativas consideradas:** Substituir `upload` por `upload(signedUploadUrl)` como o arquivo atual indica; criar um segundo provider apenas para Supabase signed upload.
+* **Motivo da escolha:** Existem usos reais de upload server-side em controllers, jobs e use cases; substituir `upload` quebraria funcionalidades fora do escopo.
+* **Impactos / trade-offs:** Providers que nao suportam signed URL precisam implementar metodo que lanca `MethodNotImplementedError`.
+
+* **Decisao:** Usar um unico endpoint `POST /storage/signed-upload-url` com `folderPath` e `fileName` no body.
+* **Alternativas consideradas:** Usar endpoint por caminho como `POST /storage/images/story`; usar `POST /storage/files/:folder/signed-upload-url`.
+* **Motivo da escolha:** O usuario pediu um unico endpoint/controller; a selecao do caminho passa a ser explicita no body e a validacao de extensao e centralizada em `SignedUploadUrl`.
+* **Impactos / trade-offs:** O endpoint fica mais generico e precisa validar corretamente a combinacao `folderPath` + `fileName` em todas as chamadas.
+
+* **Decisao:** Na `studio`, o upload direto deve acontecer por um `SupabaseSignedFileStorageProvider` local implementando `SignedFileStorageProvider`.
+* **Alternativas consideradas:** Usar um client utilitario fora do contrato do core; implementar todos os metodos de `FileStorageProvider` no Studio.
+* **Motivo da escolha:** Cria um contrato especifico para upload por URL assinada sem misturar responsabilidades server-side e UI-side no mesmo provider.
+* **Impactos / trade-offs:** O pacote `core` passa a expor uma nova interface dedicada ao fluxo de signed upload.
+
+* **Decisao:** O metodo `SignedFileStorageProvider.uploadFile(...)` deve receber tanto `SignedUploadUrl` quanto o `File` selecionado.
+* **Alternativas consideradas:** Fazer o `StorageService` executar o `fetch` direto sem provider; manter o provider sem receber o binario e capturar o arquivo por closure/construtor.
+* **Motivo da escolha:** O adapter de provision da `studio` precisa ter todos os dados necessarios para executar o upload direto sem depender de estado externo implícito.
+* **Impactos / trade-offs:** O contrato da interface fica um pouco mais explicito, mas continua pequeno e com responsabilidade unica.
+
+* **Decisao:** Prover providers da UI por um `ProvisionContext`, em vez de acoplar essa responsabilidade ao `RestContext`.
+* **Alternativas consideradas:** Instanciar o provider no `RestContext`; instanciar o provider diretamente no widget.
+* **Motivo da escolha:** Separa dependencias REST de dependencias de provision e preserva a camada UI com composition roots explicitos por responsabilidade.
+* **Impactos / trade-offs:** A `studio` ganha um novo contexto global para providers, mas o acoplamento arquitetural fica mais claro.
+
+* **Decisao:** Usar o `fileName` informado pelo client como nome final do arquivo, apos validacao no use case.
+* **Alternativas consideradas:** Gerar nome aleatorio no backend; derivar apenas extensao do nome informado.
+* **Motivo da escolha:** Mantem o comportamento esperado pelo fluxo atual do widget, em que o usuario informa o nome do arquivo antes do upload.
+* **Impactos / trade-offs:** O backend precisa validar estritamente o `fileName` para impedir path traversal, nomes vazios e extensoes invalidas, e precisa consultar o storage antes de emitir a URL para bloquear nomes duplicados.
+
+* **Decisao:** Validar a extensao do `fileName` dentro de `SignedUploadUrl.create(dto)` com base no `folderPath`.
+* **Alternativas consideradas:** Validar extensao no schema Zod da borda; validar extensao apenas no use case.
+* **Motivo da escolha:** Centraliza a regra semantica no proprio objeto que representa o contrato assinado, como voce pediu.
+* **Impactos / trade-offs:** O schema da borda continua validando forma basica do request, enquanto a structure assume a regra de compatibilidade por pasta.
+
+* **Decisao:** Sugerir allowlist inicial de extensoes por `folderPath`.
+* **Alternativas consideradas:** Reusar a mesma allowlist para todas as pastas; adiar a definicao completamente.
+* **Motivo da escolha:** A feature precisa de um criterio tecnico objetivo para implementar a validacao por pasta sem depender de ambiguidade do PRD.
+* **Impactos / trade-offs:** Essa lista e uma sugestao tecnica inicial e pode ser refinada depois com produto.
+* **Sugestao de extensoes:**
+* `images/story`: `.png`, `.jpg`, `.jpeg`, `.gif`, `.svg`
+* `images/avatars`: `.png`, `.jpg`, `.jpeg`, `.svg`
+* `images/rockets`: `.png`, `.jpg`, `.jpeg`, `.svg`
+* `images/planets`: `.png`, `.jpg`, `.jpeg`, `.svg`
+* `images/achievements`: `.png`, `.jpg`, `.jpeg`, `.svg`
+* `images/rankings`: `.png`, `.jpg`, `.jpeg`, `.svg`
+* `images/insignias`: `.png`, `.jpg`, `.jpeg`, `.svg`
+* `images/feedback-reports`: `.png`, `.jpg`, `.jpeg`, `.webp`
+* `audios/story`: `.mp3`, `.wav`, `.ogg`
+* `database-backups`: `.sql`, `.dump`, `.backup`
+
+* **Decisao:** Usar limite fixo de `5 MB` para uploads de imagem na `studio`.
+* **Alternativas consideradas:** Nao definir limite nesta entrega; usar limites diferentes por pasta; validar tamanho apenas no backend.
+* **Motivo da escolha:** O componente base de upload ja suporta `maxSize`, e um limite unico reduz ambiguidade e previne upload desnecessario antes da emissao da signed URL.
+* **Impactos / trade-offs:** O valor fica decidido nesta spec para imagens do Studio; se houver necessidade de limites distintos por pasta no futuro, a regra precisara ser reaberta.
+
+* **Decisao:** Bloquear o fluxo quando `findFile` indicar que o `fileName` ja existe no `folderPath` solicitado.
+* **Alternativas consideradas:** Permitir overwrite com `upsert: true`; emitir signed URL e deixar o conflito acontecer apenas no upload; gerar nome alternativo automaticamente.
+* **Motivo da escolha:** O usuario pediu validacao previa com `FileStorageProvider`, e isso preserva um erro deterministico antes do upload binario direto.
+* **Impactos / trade-offs:** Ha uma leitura extra no storage antes da emissao da URL assinada e permanece uma pequena janela de corrida entre a checagem e o upload, mitigada por `upsert: false` no provider.
+
+* **Decisao:** Exigir `verifyAuthentication` + `verifyGodAccount` no endpoint de signed upload URL e tambem em `GET /storage/files` e `DELETE /storage/files/:folder/:fileName`.
+* **Alternativas consideradas:** Manter remocao via route params; endurecer somente o endpoint novo.
+* **Motivo da escolha:** O par de middlewares precisa cobrir todas as rotas administrativas de storage, e a remocao via query params simplifica o contrato compartilhado entre adapters web/studio e controller REST.
+* **Impactos / trade-offs:** O endpoint de remocao deixa de usar path params e passa a depender de query params validados na borda.
+
+* **Decisao:** No `PictureInput`, apos upload bem-sucedido, selecionar imediatamente a imagem criada; apos remover a imagem selecionada, voltar para `panda.jpg`; manter o dialog aberto em remocoes.
+* **Alternativas consideradas:** Apenas refetchar a lista sem alterar selecao; fechar o dialog apos remocao; limpar a selecao quando a imagem removida era a atual.
+* **Motivo da escolha:** O fluxo fica mais previsivel para quem esta editando historias e quizzes, reduz passos manuais e evita perda de contexto no dialog.
+* **Impactos / trade-offs:** O seletor assume um fallback visual fixo (`panda.jpg`) quando a imagem selecionada e removida.
+
+* **Decisao:** Reduzir a pagina inicial do `PictureInput` para `12` imagens e pre-carregar thumbnails assim que a primeira pagina chega.
+* **Alternativas consideradas:** Manter `30` itens por pagina; otimizar apenas as thumbnails sem reduzir a pagina inicial; adiar otimização do dialog.
+* **Motivo da escolha:** Melhora a performance percebida na abertura do dialog com mudanca pequena e localizada, sem alterar o contrato REST ou o layout principal do seletor.
+* **Impactos / trade-offs:** Mais paginas podem ser necessarias em bibliotecas grandes, compensadas por abertura inicial mais leve.
+* **Alternativas consideradas:** Manter apenas `verifyAuthentication` nas rotas atuais de storage; endurecer somente o endpoint novo.
+* **Motivo da escolha:** As mesmas regras de auth devem valer para os endpoints administrativos de storage segundo a definicao mais recente do usuario.
+* **Impactos / trade-offs:** Listagem e remocao passam a ter a mesma exigencia de permissao do fluxo de emissao de signed upload URL.
+
+* **Decisao:** Nao criar migration nesta entrega.
+* **Alternativas consideradas:** Criar policies/grants de `storage.objects` para signed upload.
+* **Motivo da escolha:** A codebase nao contem evidencia de migrations de Storage para o bucket atual e a emissao ocorre pelo server via Supabase SDK; o PRD pede migracao de fluxo de aplicacao, nao alteracao estrutural de banco.
+* **Impactos / trade-offs:** A permissao real do bucket/projeto Supabase para `createSignedUploadUrl` e upload via signed URL deve ser validada no ambiente antes do deploy.
+
+---
+
+# 9. Diagramas e Referencias (Obrigatorio)
+
+* **Fluxo de Dados:**
+
+```text
+Studio ImageInput
+  -> apps/studio StorageService.uploadFile(folder, file)
+  -> apps/studio StorageService.createSignedUploadUrl(folder, fileName)
+  -> POST /storage/signed-upload-url
+  -> StorageRouter
+  -> CreateSignedUploadUrlController
+  -> CreateSignedUploadUrl.execute({ folderPath, fileName })
+  -> FileStorageProvider.findFile(folderPath, fileName)
+  -> SupabaseFileStorageProvider.createSignedUploadUrl(folderPath, fileName)
+  -> SignedUploadUrl.create({ url, folderPath, fileName }) validates extension
+  <- SignedUploadUrlDto { url, folderPath, fileName }
+  -> studio SupabaseSignedFileStorageProvider.uploadFile(SignedUploadUrl, File)
+  -> Supabase Storage signed URL
+  <- upload success
+  -> ImageInput.onSubmit(filename)
+  -> form state / PictureInput selects uploaded image / PictureInput.refetch()
+```
+
+* **Fluxo Cross-app (se aplicavel):**
+
+```text
+apps/studio consumes REST from apps/server
+
+[Studio]
+  StorageService.createSignedUploadUrl(folderPath, fileName)
+      |
+      | REST POST /storage/signed-upload-url
+      | body: { folderPath: string, fileName: string }
+      v
+[Server]
+  StorageRouter -> CreateSignedUploadUrlController -> CreateSignedUploadUrl
+      |
+      | validates folderPath on edge
+      | validates fileName
+      | checks existence with findFile(folderPath, fileName)
+      v
+[Server]
+  SupabaseFileStorageProvider.createSignedUploadUrl(folderPath, fileName)
+      |
+      | SignedUploadUrl.create validates extension by folderPath
+      v
+[Supabase Storage]
+      |
+      | response to Server: signed URL data
+      v
+[Server]
+  response: SignedUploadUrlDto { url, folderPath, fileName }
+      |
+      v
+[Studio]
+  SupabaseSignedFileStorageProvider.uploadFile(signedUploadUrl, file)
+      |
+      | direct HTTP upload to signed URL
+      v
+[Supabase Storage]
+
+[Web]
+  FeedbackDialog remains on legacy REST POST /storage/files/:folder
+      |
+      v
+[Server]
+  UploadFileController -> SupabaseFileStorageProvider.upload(folder, file)
+```
+
+* **Layout (se aplicavel):**
+
+```text
+PictureInput Dialog
+  Header: "Selecione uma imagem"
+  Toolbar
+    Search input
+    Selected preview
+    Optional clear button
+    ImageInput trigger: "Adicionar"
+      ImageInput Dialog
+        FileUpload
+        Image name input
+        Submit button with loading
+  Content
+    Loading state
+    Empty state
+    PictureCard grid
+    LoadMoreButton
+```
+
+* **Referencias:**
+
+* `apps/server/src/app/hono/routers/storage/FilesStorageRouter.ts` - router atual de upload/listagem/remocao de arquivos.
+* `apps/server/src/app/hono/routers/storage/StorageRouter.ts` - router raiz de storage onde a rota de signed upload URL e registrada.
+* `apps/server/src/rest/controllers/storage/UploadFileController.ts` - referencia de controller de storage com provider injetado.
+* `apps/server/src/provision/storage/SupabaseFileStorageProvider.ts` - provider que deve encapsular o SDK Supabase.
+* `apps/server/src/app/hono/routers/shop/AvatarsRouter.ts` - referencia de rota administrativa de escrita com `verifyAuthentication` e `verifyGodAccount`.
+* `apps/studio/src/rest/services/StorageService.ts` - service REST do Studio a migrar.
+* `apps/studio/src/provision/storage/SupabaseSignedFileStorageProvider.ts` - provider client-side do upload direto por signed URL.
+* `apps/studio/src/ui/global/widgets/components/ImageInput/useImageInput.ts` - ponto central do upload imediato no Studio.
+* `apps/studio/src/ui/lesson/widgets/components/PictureInput/usePictureInput.ts` - referencia de listagem paginada e refetch apos upload/remocao.
+* `packages/core/src/storage/domain/structures/SignedUploadUrl.ts` - structure do contrato assinado.
+* `packages/validation/src/modules/storage/fileStorageFolderPathSchema.ts` - allowlist atual de folders de storage.
+* Supabase docs: `https://supabase.com/docs/reference/javascript/storage-from-createsigneduploadurl` - referencia de `createSignedUploadUrl`.
+* Supabase docs: `https://supabase.com/docs/reference/javascript/storage-from-uploadtosignedurl` - referencia de upload usando signed URL.
+
+---
+
+# 10. Pendencias / Duvidas (Quando aplicavel)
+
+**Sem pendencias**.

--- a/documentation/plan.md
+++ b/documentation/plan.md
@@ -4,7 +4,7 @@ description: Criar um plano de implementacao estruturado em fases e tarefas a pa
 
 ## Pendencias (quando aplicavel)
 
-- [ ] Confirmar se havera CTA de cancelamento em lote visivel no header (a spec pede handler e contrato, mas o layout detalha apenas CTA de geracao em lote).
+- [x] Rota de emissao da signed URL montada em `StorageRouter` como `POST /storage/signed-upload-url`, preservando `FilesStorageRouter` sob `/storage/files`.
 
 ---
 
@@ -12,136 +12,152 @@ description: Criar um plano de implementacao estruturado em fases e tarefas a pa
 
 | Fase | Objetivo | Depende de | Pode rodar em paralelo com |
 | --- | --- | --- | --- |
-| F1 | Definir contratos compartilhados de audio/vozes no core | - | - |
-| F2 | Expor endpoint de vozes e ajustar validacao REST no server | F1 | F4 |
-| F4 | Integrar UI e fluxo de audio no studio | F1 | F2 |
+| F1 | Definir os contratos, structures, erros e use case do fluxo de signed upload no modulo `storage` | - | - |
+| F2 | Expor a emissao de signed upload URL no `server`, ajustar providers e endurecer autenticacao das rotas de storage | F1 | F3, F4 |
+| F3 | Adaptar o `web` ao novo contrato compartilhado sem remover o upload legado de screenshot | F1 | F2, F4 |
+| F4 | Migrar a `studio` para upload direto ao Supabase via signed URL, preservando os widgets e formularios atuais | F1 | F2, F3 |
 
-> **Estratégia de paralelismo:** sempre comece pelo core (domínio, structures e use cases). Assim que o core estiver concluído, as fases de `server` e `studio` podem ser executadas em paralelo, pois ambas dependem apenas do contrato definido no core.
+> **Estrategia de paralelismo:** sempre comece pelo core (dominio, structures e use cases). Assim que o core estiver concluido, as fases de `server`, `web` e `studio` podem ser executadas em paralelo, pois todas dependem apenas do contrato definido no core.
 
 ---
 
-## F1 — Core: Domínio, Structures e Use Cases
+## F1 — Core: Dominio, Structures e Use Cases
 
-**Objetivo:** Definir o contrato compartilhado de audio e vozes no core — DTOs e interface REST consumida pelos adapters — sem depender de infraestrutura. Essa fase desbloqueia F2 e F4 para rodarem em paralelo.
+**Objetivo:** Definir o contrato do dominio — entidades, structures, interfaces de repositorio/provider e use cases — sem nenhuma dependencia de infraestrutura. Essa fase desbloqueia F2, F3 e F4 para rodarem em paralelo.
 
 ### Tarefas
 
-- [x] **F1-T1** — Criar `AudioVoiceDto`
+- [x] **F1-T1** — Ajustar `packages/core/src/storage/interfaces/FileStorageProvider.ts`
   - **Depende de:** -
-  - **Resultado observavel:** existe `packages/core/src/lesson/domain/structures/dtos/AudioVoiceDto.ts` com `value: AudioVoiceValue` e `label: string`.
+  - **Resultado observavel:** o contrato passa a refletir o uso server-side real de storage com `upload(folder, file)` e expor tambem a emissao de signed upload URL sem quebrar controllers, jobs e providers existentes.
   - **Camada:** `core`
 
-- [x] **F1-T2** — Exportar `AudioVoiceDto` no barrel do modulo
+- [x] **F1-T2** — Criar `packages/core/src/storage/interfaces/SignedFileStorageProvider.ts` e exporta-lo pelo barrel de interfaces
   - **Depende de:** F1-T1
-  - **Resultado observavel:** `packages/core/src/lesson/domain/structures/dtos/index.ts` expoe `AudioVoiceDto`.
+  - **Resultado observavel:** existe um contrato de core especifico para upload direto com `uploadFile(signedUploadUrl: SignedUploadUrl): Promise<void>`, separado do provider server-side.
   - **Camada:** `core`
 
-- [x] **F1-T3** — Estender `LessonService` compartilhado com metodos de audio
+- [x] **F1-T3** — Ampliar `packages/core/src/storage/interfaces/StorageService.ts` e `packages/core/src/storage/interfaces/index.ts`
   - **Depende de:** F1-T2
-  - **Resultado observavel:** `packages/core/src/lesson/interfaces/LessonService.ts` passa a expor `fetchAudioVoices`, geracao/cancelamento individual e em lote.
+  - **Resultado observavel:** o contrato compartilhado de REST expoe `createSignedUploadUrl(folderPath, fileName)` e preserva `uploadFile(folder, file)` como fachada de compatibilidade para `web` e `studio`.
+  - **Camada:** `core`
+
+- [x] **F1-T4** — Endurecer `packages/core/src/storage/domain/structures/SignedUploadUrl.ts` e exportar `SignedUploadUrl`/`SignedUploadUrlDto` pelos barrels publicos
+  - **Depende de:** F1-T1
+  - **Resultado observavel:** `SignedUploadUrl.create(dto)` rejeita combinacoes invalidas de `folderPath` e extensao de `fileName`, e os tipos ficam importaveis pelos paths publicos do modulo `storage`.
+  - **Camada:** `core`
+
+- [x] **F1-T5** — Criar o erro de conflito de nome de arquivo no modulo `storage` e exporta-lo
+  - **Depende de:** -
+  - **Resultado observavel:** existe um erro de dominio explicito para representar conflito quando o `fileName` ja existe no `folderPath` solicitado.
+  - **Camada:** `core`
+
+- [x] **F1-T6** — Criar `packages/core/src/storage/use-cases/CreateSignedUploadUrl.ts` e exporta-lo em `packages/core/src/storage/use-cases/index.ts`
+  - **Depende de:** F1-T1, F1-T4, F1-T5
+  - **Resultado observavel:** `CreateSignedUploadUrl.execute({ folderPath, fileName })` valida os objetos de dominio, consulta existencia pelo provider e retorna `SignedUploadUrlDto` somente quando nao ha conflito de nome.
   - **Camada:** `core`
 
 ---
 
-## F2 — Server: Infra, Repositórios e Handlers
+## F2 — Server: Infra, Repositorios e Handlers
 
-> ⚡ Pode rodar em paralelo com F4 após F1 estar concluída.
+> ⚡ Pode rodar em paralelo com F3 e F4 apos F1 estar concluida.
 
-**Objetivo:** Implementar a borda REST do `server` para vozes e preservacao do subdocumento `audio` na validacao de update de blocos.
+**Objetivo:** Implementar a camada de infraestrutura e exposicao — repositorios, providers, jobs e handlers RPC/REST — consumindo os contratos definidos no core.
 
 ### Tarefas
 
-- [x] **F2-T1** — Criar `textBlockAudioSchema`
-  - **Depende de:** F1-T3
-  - **Resultado observavel:** existe `packages/validation/src/modules/lesson/schemas/textBlockAudioSchema.ts` validando `fileName`, `voice` e `status`.
+- [x] **F2-T1** — Criar `packages/validation/src/modules/storage/signedUploadUrlSchema.ts` e exporta-lo em `packages/validation/src/modules/storage/index.ts`
+  - **Depende de:** F1-T3, F1-T4
+  - **Resultado observavel:** a borda REST consegue rejeitar requests com `folderPath` fora da allowlist, `fileName` vazio ou com `/`, `\\`, `.`, `..` antes de executar controller/use case.
   - **Camada:** `rest`
 
-- [x] **F2-T2** — Permitir `audio` em `textBlockSchema`
-  - **Depende de:** F2-T1
-  - **Resultado observavel:** `packages/validation/src/modules/lesson/schemas/textBlockSchema.ts` aceita `audio` opcional.
+- [x] **F2-T2** — Implementar `createSignedUploadUrl(...)` em `apps/server/src/provision/storage/SupabaseFileStorageProvider.ts`
+  - **Depende de:** F1-T6
+  - **Resultado observavel:** o provider do `server` emite um contrato assinado para `stardust-bucket` com path final `<folderPath>/<fileName>` e `upsert: false`, sem alterar o fluxo legado de `upload(folder, file)`.
+  - **Camada:** `provision`
+
+- [x] **F2-T3** — Adequar `apps/server/src/provision/storage/GoogleDriveStorageProvider.ts` ao novo contrato do core
+  - **Depende de:** F1-T1
+  - **Resultado observavel:** o provider compila contra a interface atualizada e falha explicitamente com `MethodNotImplementedError` para signed upload URL, sem alterar o fluxo de backup que ele ja suporta.
+  - **Camada:** `provision`
+
+- [x] **F2-T4** — Adequar `apps/server/src/provision/storage/DropboxStorageProvider.ts` ao novo contrato do core
+  - **Depende de:** F1-T1
+  - **Resultado observavel:** o provider compila contra a interface atualizada e falha explicitamente com `MethodNotImplementedError` para signed upload URL, preservando o upload server-side usado em backup.
+  - **Camada:** `provision`
+
+- [x] **F2-T5** — Criar `apps/server/src/rest/controllers/storage/CreateSignedUploadUrlController.ts` e exporta-lo no barrel de controllers
+  - **Depende de:** F1-T6
+  - **Resultado observavel:** o controller le `folderPath` e `fileName` do body, delega para `CreateSignedUploadUrl` e retorna `200` com `SignedUploadUrlDto` sem conter regra de storage na borda.
   - **Camada:** `rest`
 
-- [x] **F2-T3** — Exportar `textBlockAudioSchema` no barrel de schemas
-  - **Depende de:** F2-T1
-  - **Resultado observavel:** `packages/validation/src/modules/lesson/schemas/index.ts` expoe `textBlockAudioSchema`.
-  - **Camada:** `rest`
-
-- [x] **F2-T4** — Criar `FetchAudioVoicesController`
-  - **Depende de:** F1-T2
-  - **Resultado observavel:** existe controller que responde `200` com as vozes `panda/shark/princess` e labels PT-BR.
-  - **Camada:** `rest`
-
-- [x] **F2-T5** — Exportar controller de vozes no barrel de controllers
-  - **Depende de:** F2-T4
-  - **Resultado observavel:** `apps/server/src/rest/controllers/lesson/index.ts` expoe `FetchAudioVoicesController`.
-  - **Camada:** `rest`
-
-- [x] **F2-T6** — Criar `AudioVoicesRouter` com `GET /lesson/audio-voices`
-  - **Depende de:** F2-T4
-  - **Resultado observavel:** existe router publico sem auth para a rota de vozes.
-  - **Camada:** `rest`
-
-- [x] **F2-T7** — Registrar `AudioVoicesRouter` no `LessonRouter`
-  - **Depende de:** F2-T6
-  - **Resultado observavel:** `GET /lesson/audio-voices` fica acessivel no modulo `lesson`.
+- [x] **F2-T6** — Atualizar `apps/server/src/app/hono/routers/storage/FilesStorageRouter.ts` e `apps/server/src/app/hono/routers/storage/StorageRouter.ts`
+  - **Depende de:** F2-T1, F2-T2, F2-T5
+  - **Resultado observavel:** a rota de emissao de signed upload URL fica exposta no path acordado com `verifyAuthentication`, `verifyGodAccount` e validacao de JSON, e `GET /storage/files` + `DELETE /storage/files/:folder/:fileName` passam a exigir o mesmo par de middlewares.
   - **Camada:** `rest`
 
 ---
 
-## F4 — Studio: UI e Integração
+## F3 — Web: UI e Integracao
 
-> ⚡ Pode rodar em paralelo com F2 após F1 estar concluída.
+> ⚡ Pode rodar em paralelo com F2 e F4 apos F1 estar concluida.
 
-**Objetivo:** Implementar no `studio` o fluxo de voz/geracao/polling/cancelamento por bloco e player compacto, preservando `audio` no ciclo de edicao.
+**Objetivo:** Implementar a interface e integracao client-side na aplicacao web — widgets, actions e chamadas RPC/REST — consumindo os contratos definidos no core.
 
 ### Tarefas
 
-- [x] **F4-T1** — Estender `LessonService` REST do studio com metodos de audio
+- [x] **F3-T1** — Atualizar `apps/web/src/rest/services/StorageService.ts`
   - **Depende de:** F1-T3
-  - **Resultado observavel:** `apps/studio/src/rest/services/LessonService.ts` implementa `fetchAudioVoices`, gerar/cancelar individual e em lote.
+  - **Resultado observavel:** o adapter REST do `web` implementa `createSignedUploadUrl(folderPath, fileName)` e `uploadFile(folder, file)` passa a enviar screenshots por signed upload sem depender do endpoint legado.
   - **Camada:** `rest`
 
-- [x] **F4-T2** — Criar hook `useStorageAudio`
-  - **Depende de:** F1-T3
-  - **Resultado observavel:** existe `apps/studio/src/ui/global/hooks/useStorageAudio.ts` retornando URL publica de `audios/story` ou `null`.
-  - **Camada:** `ui`
+---
 
-- [x] **F4-T3** — Criar hook `useAudioGenerationPolling`
+## F4 — Studio: UI e Integracao
+
+> ⚡ Pode rodar em paralelo com F2 e F3 apos F1 estar concluida.
+
+**Objetivo:** Implementar a interface e integracao client-side na aplicacao studio — widgets, actions e chamadas RPC/REST — consumindo os contratos definidos no core.
+
+### Tarefas
+
+- [x] **F4-T1** — Criar uma implementacao de `SignedFileStorageProvider` na `studio`
+  - **Depende de:** F1-T2, F1-T4
+  - **Resultado observavel:** a `studio` possui um adapter client-side que recebe `SignedUploadUrl` e executa o upload direto ao Supabase sem trafegar binario pelo `server`.
+  - **Camada:** `provision`
+
+- [x] **F4-T2** — Criar `apps/studio/src/ui/global/contexts/ProvisionContext` e encaixa-lo em `apps/studio/src/app/root.tsx`
   - **Depende de:** F4-T1
-  - **Resultado observavel:** existe polling a cada 3000ms enquanto houver bloco `pending`, com callback de update e erro.
+  - **Resultado observavel:** a UI da `studio` passa a resolver `signedFileStorageProvider` por um contexto proprio de provision, separado do `RestContext`.
   - **Camada:** `ui`
 
-- [x] **F4-T4** — Criar widget `BlockVoiceSelector`
-  - **Depende de:** F1-T2
-  - **Resultado observavel:** seletor de voz com fallback `panda` quando lista vazia.
+- [x] **F4-T3** — Atualizar `apps/studio/src/rest/services/StorageService.ts`
+  - **Depende de:** F1-T3, F4-T1
+  - **Resultado observavel:** `uploadFile(folder, file)` passa a solicitar `POST /storage/signed-upload-url`, montar `SignedUploadUrl` a partir da resposta e delegar o upload direto via `SignedFileStorageProvider`, retornando `RestResponse<{ filename: string }>` com o nome final validado pelo `server`.
+  - **Camada:** `rest`
+
+- [x] **F4-T4** — Atualizar os composition roots de storage da `studio` em `apps/studio/src/ui/global/contexts/RestContext/useRestContextProvider.ts` e `apps/studio/src/app/middlewares/RestMiddleware.ts`
+  - **Depende de:** F4-T2, F4-T3
+  - **Resultado observavel:** tanto a arvore de UI quanto o contexto de rotas da `studio` instanciam `StorageService` com o novo grafo de dependencias, sem recriar providers dentro do service.
+  - **Camada:** `studio`
+
+- [x] **F4-T5** — Atualizar `apps/studio/src/ui/global/widgets/components/ImageInput/index.tsx`
+  - **Depende de:** F4-T4
+  - **Resultado observavel:** o entry point do widget continua preservando a API publica de `ImageInput`, mas passa a resolver as dependencias pelo contexto correto apos a migracao para signed upload.
   - **Camada:** `ui`
 
-- [x] **F4-T5** — Criar widget `BlockAudioPlayer` e hook `useBlockAudioPlayer`
-  - **Depende de:** F4-T2
-  - **Resultado observavel:** player compacto com play/pause, seek e progresso.
+- [x] **F4-T6** — Atualizar `apps/studio/src/ui/global/widgets/components/ImageInput/useImageInput.ts`
+  - **Depende de:** F4-T3, F4-T5
+  - **Resultado observavel:** o hook envia o `fileName` editado pelo usuario para o service, chama `onSubmit(response.body.filename)` no sucesso e trata separadamente erro de emissao da signed URL e erro de upload direto sem perder o estado de loading/toast atual.
   - **Camada:** `ui`
 
-- [x] **F4-T6** — Criar widget `BlockAudioControls`
-  - **Depende de:** F4-T4, F4-T5
-  - **Resultado observavel:** composicao de seletor, botao gerar/regenerar, cancelar, badge/spinner e player por status.
+- [x] **F4-T7** — Atualizar `apps/studio/src/ui/global/widgets/components/ImageInput/ImageInputView.tsx`
+  - **Depende de:** F4-T6
+  - **Resultado observavel:** o dialog continua exibindo preview e input editavel de nome, mas deixa explicito que o campo define o `fileName` validado pelo backend e bloqueia arquivos acima de `5 MB`.
   - **Camada:** `ui`
 
-- [x] **F4-T7** — Preservar `audio` no hook `useLessonStoryPage`
-  - **Depende de:** F4-T1
-  - **Resultado observavel:** `toEditorItem` e `toPersistedTextBlock` mantem `audio` sem perda no save.
-  - **Camada:** `ui`
-
-- [x] **F4-T8** — Integrar voz/geracao/cancelamento/polling em `useLessonStoryPage`
-  - **Depende de:** F4-T3, F4-T7
-  - **Resultado observavel:** handlers de voz/geracao/cancelamento funcionam, sincronizam alteracoes locais antes de chamar endpoints por `blockIndex`.
-  - **Camada:** `ui`
-
-- [x] **F4-T9** — Integrar controles de audio em `TextBlockCard`
-  - **Depende de:** F4-T6, F4-T8
-  - **Resultado observavel:** card renderiza `BlockAudioControls` para tipos elegiveis no estado expandido.
-  - **Camada:** `ui`
-
-- [x] **F4-T10** — Integrar controle em lote/polling no `TextBlocksView` e `LessonStoryPageView`
-  - **Depende de:** F4-T8, F4-T9
-  - **Resultado observavel:** header exibe CTA de geracao em lote, indicador de polling e mantem drag-and-drop ativo durante `pending`.
+- [x] **F4-T8** — Ajustar `apps/studio/src/ui/lesson/widgets/components/PictureInput/usePictureInput.ts` para preservar o refetch do seletor apos upload/remocao
+  - **Depende de:** F4-T6
+  - **Resultado observavel:** o fluxo de `story` continua listando imagens com paginacao, refetchando apos upload/remocao e mantendo preview/selecao sem trafegar binario pelo `server`.
   - **Camada:** `ui`

--- a/documentation/prompts/conclude-spec-prompt.md
+++ b/documentation/prompts/conclude-spec-prompt.md
@@ -196,6 +196,61 @@ Para cada regra violada, reporte:
 
 Corrija todos os desvios encontrados antes de avançar para a Fase 2.
 
+**1.6 Revisão de Qualidade de Código**
+
+Esta etapa opera em dois passos sequenciais: primeiro a leitura completa de
+todos os arquivos do escopo, depois a correção em lote. Não corrija nada
+durante a leitura — registre tudo e só então aplique as correções.
+
+**Passo 1 — Leitura e catalogação**
+
+Leia cada arquivo introduzido ou modificado pela Spec (escopo restrito ao diff).
+Para cada arquivo, inspecione:
+
+- **Erros de lógica:** condicionais invertidas, retornos antecipados ausentes,
+  tratamento de erro incompleto, casos de borda não cobertos pelo fluxo principal.
+- **Nomenclatura:** variáveis, funções, classes e tipos com nomes ambíguos,
+  genéricos demais (`data`, `result`, `tmp`) ou inconsistentes com o vocabulário
+  do domínio estabelecido no restante do codebase.
+- **Código morto:** imports não utilizados, variáveis declaradas e nunca lidas,
+  branches inalcançáveis, funções definidas e nunca chamadas.
+- **Duplicação desnecessária:** trechos de lógica repetidos que poderiam ser
+  extraídos para um helper ou método reutilizável sem violar os limites de camada.
+- **Complexidade excessiva:** funções longas demais, aninhamento profundo de
+  condicionais ou callbacks que dificultam a leitura sem ganho real de
+  expressividade.
+- **Comentários desatualizados ou enganosos:** comentários que contradizem o
+  comportamento do código ou que descrevem o "o quê" em vez do "por quê".
+
+Ao concluir a leitura de todos os arquivos, produza o relatório completo antes
+de tocar em qualquer código:
+
+```markdown
+## Relatório de Revisão de Qualidade de Código
+
+### `caminho/do/arquivo.ts`
+- ✅ Sem problemas encontrados
+
+### `caminho/do/outro-arquivo.ts`
+- ⚠️ **Nomenclatura:** variável `data` na linha 42 não expressa a intenção —
+  renomear para `userProfile`.
+- ⚠️ **Código morto:** import `formatDate` declarado mas nunca utilizado.
+- ⚠️ **Lógica:** ausência de guard clause para `null` no retorno de
+  `findUserById` antes do acesso a `.email`.
+```
+
+**Passo 2 — Correção em lote**
+
+Com o relatório completo em mãos, aplique todas as correções de uma vez,
+respeitando a ordem de dependência entre arquivos (corrija primeiro os arquivos
+que são importados por outros para evitar inconsistências intermediárias).
+Após aplicar as correções, execute `npm run test` novamente para garantir que
+nenhuma alteração introduziu regressão.
+
+> Esta etapa é complementar à 1.5: enquanto a 1.5 valida aderência a regras
+> arquiteturais do projeto, a 1.6 avalia a qualidade intrínseca do código
+> produzido, independente de convenções formais.
+
 ---
 
 ## Fase 2 — Consolidação de Documentos
@@ -215,10 +270,15 @@ devem ter sido capturados pelo `update-spec-prompt` durante o desenvolvimento.
 
 **2.2 Atualização do PRD**
 
-Atualize o PRD associado à Spec. Ele está localizado no nível acima do diretório
-da spec — ex.: se a spec está em
-`documentation/features/<modulo>/specs/<nome>-spec.md`, o PRD está em
-`documentation/features/<modulo>/prd.md`.
+Atualize o PRD associado à Spec **sempre no milestone do GitHub** referenciado
+no campo `prd:` da spec.
+
+- No StarDust, o milestone do GitHub é a **única fonte de verdade** do PRD.
+- **Nunca** crie, edite ou assuma a existência de `documentation/features/**/prd.md`.
+- Se a implementação concluir ou refinar requisitos, atualize a **descrição do
+  milestone** com os itens entregues e as divergências de produto relevantes.
+
+> 💡 Regra obrigatória: PRD local não deve existir. PRD vive no milestone.
 
 Marque como concluídos os itens endereçados pela implementação. A audiência aqui
 é de produto — traduza o impacto técnico para linguagem de negócio.
@@ -230,7 +290,8 @@ Marque como concluídos os itens endereçados pela implementação. A audiência
 aspecto que contradiga ou não esteja coberto pelo PRD (ex: regra de negócio
 refinada, escopo ampliado ou reduzido, comportamento diferente do especificado),
 atualize o PRD para refletir a realidade entregue. Registre a divergência no
-campo **"O que mudou em relação à Spec original"** do resumo de conclusão da spec (seção 3.1).
+campo **"O que mudou em relação à Spec original"** do resumo de conclusão da
+spec (seção 3.1).
 
 **2.3 Atualização da Arquitetura (se aplicável)**
 
@@ -298,6 +359,7 @@ dados existentes ou disparar efeitos colaterais em produção na primeira execu�
 - [ ] `npm run test` passou sem falhas (ou regressões pré-existentes devidamente sinalizadas)
 - [ ] Cobertura de testes verificada e lacunas críticas endereçadas
 - [ ] Limites arquiteturais validados
+- [ ] Revisão de qualidade de código concluída e correções aplicadas em lote
 - [ ] Todas as tarefas do `documentation/plan.md` estão `- [x]`
 - [ ] Divergências do `plan.md` classificadas e resolvidas
 - [ ] Spec atualizada com status `closed` e data
@@ -317,6 +379,7 @@ Ao final da execução, devem ter sido produzidos:
 3. **Relatório de cobertura de testes** (Fase 1.1.1)
 4. **Testes criados pelo subagent** para componentes sem cobertura (Fase 1.1.2, quando aplicável)
 5. **Checklist de validação** de requisitos (Fase 1.4)
-6. **Spec atualizada** com status `closed` e data (Fase 2.1)
-7. **PRD atualizado** com itens marcados como concluídos e divergências registradas, se houver (Fase 2.2)
-8. **Resumo de conclusão da spec** com estrutura completa (Fase 3.1)
+6. **Relatório de revisão de qualidade de código** com problemas catalogados e correções aplicadas em lote (Fase 1.6)
+7. **Spec atualizada** com status `closed` e data (Fase 2.1)
+8. **PRD atualizado no milestone do GitHub** com itens concluídos e divergências registradas, se houver (Fase 2.2)
+9. **Resumo de conclusão da spec** com estrutura completa (Fase 3.1)

--- a/packages/core/src/storage/domain/structures/SignedUploadUrl.ts
+++ b/packages/core/src/storage/domain/structures/SignedUploadUrl.ts
@@ -1,0 +1,57 @@
+import { Text } from '#global/domain/structures/Text'
+import { Url } from '#global/domain/structures/Url'
+import { FileStorageFolderPath } from './FileStorageFolderPath'
+import type { SignedUploadUrlDto } from './dtos/SignedUploadUrlDto'
+
+export class SignedUploadUrl {
+  private static readonly ALLOWED_EXTENSIONS_BY_FOLDER: Record<string, string[]> = {
+    'images/story': ['.png', '.jpg', '.jpeg', '.gif', '.svg'],
+    'images/avatars': ['.png', '.jpg', '.jpeg', '.svg'],
+    'images/rockets': ['.png', '.jpg', '.jpeg', '.svg'],
+    'images/planets': ['.png', '.jpg', '.jpeg', '.svg'],
+    'images/achievements': ['.png', '.jpg', '.jpeg', '.svg'],
+    'images/rankings': ['.png', '.jpg', '.jpeg', '.svg'],
+    'images/insignias': ['.png', '.jpg', '.jpeg', '.svg'],
+    'images/feedback-reports': ['.png', '.jpg', '.jpeg', '.webp'],
+    'audios/story': ['.mp3', '.wav', '.ogg'],
+    'database-backups': ['.sql', '.dump', '.backup'],
+  }
+
+  private constructor(
+    readonly url: Url,
+    readonly folderPath: FileStorageFolderPath,
+    readonly fileName: Text,
+  ) {}
+
+  static create(dto: SignedUploadUrlDto): SignedUploadUrl {
+    SignedUploadUrl.validateFileExtension(dto.folderPath, dto.fileName)
+
+    return new SignedUploadUrl(
+      Url.create(dto.url),
+      FileStorageFolderPath.create(dto.folderPath),
+      Text.create(dto.fileName),
+    )
+  }
+
+  get dto(): SignedUploadUrlDto {
+    return {
+      url: this.url.value,
+      folderPath: this.folderPath.value,
+      fileName: this.fileName.value,
+    }
+  }
+
+  private static validateFileExtension(folderPath: string, fileName: string): void {
+    const extensions = SignedUploadUrl.ALLOWED_EXTENSIONS_BY_FOLDER[folderPath]
+    if (!extensions) return
+
+    const normalizedFileName = fileName.trim().toLowerCase()
+    const isAllowed = extensions.some((extension) =>
+      normalizedFileName.endsWith(extension),
+    )
+
+    if (!isAllowed) {
+      throw new Error(`Invalid file extension for folder path: ${folderPath}`)
+    }
+  }
+}

--- a/packages/core/src/storage/domain/structures/dtos/SignedUploadUrlDto.ts
+++ b/packages/core/src/storage/domain/structures/dtos/SignedUploadUrlDto.ts
@@ -1,0 +1,5 @@
+export type SignedUploadUrlDto = {
+  url: string
+  folderPath: string
+  fileName: string
+}

--- a/packages/core/src/storage/domain/structures/dtos/index.ts
+++ b/packages/core/src/storage/domain/structures/dtos/index.ts
@@ -1,1 +1,2 @@
 export type { EmbeddingDto } from './EmbeddingDto'
+export type { SignedUploadUrlDto } from './SignedUploadUrlDto'

--- a/packages/core/src/storage/domain/structures/index.ts
+++ b/packages/core/src/storage/domain/structures/index.ts
@@ -1,3 +1,4 @@
 export { FileStorageFolderPath } from './FileStorageFolderPath'
 export { Embedding } from './Embedding'
 export { EmbeddingNamespace } from './EmbeddingNamespace'
+export { SignedUploadUrl } from './SignedUploadUrl'

--- a/packages/core/src/storage/domain/structures/tests/SignedUploadUrl.test.ts
+++ b/packages/core/src/storage/domain/structures/tests/SignedUploadUrl.test.ts
@@ -1,0 +1,27 @@
+import { SignedUploadUrl } from '../SignedUploadUrl'
+
+describe('SignedUploadUrl', () => {
+  it('should throw when file extension is not allowed for the folder path', () => {
+    expect(() =>
+      SignedUploadUrl.create({
+        url: 'https://storage.stardust.dev/upload',
+        folderPath: 'images/story',
+        fileName: 'theme.mp3',
+      }),
+    ).toThrow('Invalid file extension for folder path: images/story')
+  })
+
+  it('should create a signed upload url with an allowed extension and return its dto', () => {
+    const signedUploadUrl = SignedUploadUrl.create({
+      url: 'https://storage.stardust.dev/upload',
+      folderPath: 'images/story',
+      fileName: 'cover.png',
+    })
+
+    expect(signedUploadUrl.dto).toEqual({
+      url: 'https://storage.stardust.dev/upload',
+      folderPath: 'images/story',
+      fileName: 'cover.png',
+    })
+  })
+})

--- a/packages/core/src/storage/errors/FileNameAlreadyExistsError.ts
+++ b/packages/core/src/storage/errors/FileNameAlreadyExistsError.ts
@@ -1,0 +1,7 @@
+import { ConflictError } from '#global/domain/errors/ConflictError'
+
+export class FileNameAlreadyExistsError extends ConflictError {
+  constructor() {
+    super('Ja existe um arquivo com esse nome nesta pasta')
+  }
+}

--- a/packages/core/src/storage/errors/index.ts
+++ b/packages/core/src/storage/errors/index.ts
@@ -1,1 +1,2 @@
 export { FileNotFoundError } from './FileNotFoundError'
+export { FileNameAlreadyExistsError } from './FileNameAlreadyExistsError'

--- a/packages/core/src/storage/interfaces/FileStorageProvider.ts
+++ b/packages/core/src/storage/interfaces/FileStorageProvider.ts
@@ -1,10 +1,14 @@
 import type { Text } from '#global/domain/structures/Text'
 import type { ManyItems } from '../../global/domain/types'
-import type { FileStorageFolderPath } from '../domain/structures'
+import type { FileStorageFolderPath, SignedUploadUrl } from '../domain/structures'
 import type { FilesListingParams } from '../types'
 
 export interface FileStorageProvider {
   upload(folder: FileStorageFolderPath, file: File): Promise<File>
+  createSignedUploadUrl(
+    folderPath: FileStorageFolderPath,
+    fileName: Text,
+  ): Promise<SignedUploadUrl>
   findFile(folder: FileStorageFolderPath, fileName: Text): Promise<File | null>
   listFiles(params: FilesListingParams): Promise<ManyItems<File>>
   removeFile(folder: FileStorageFolderPath, fileName: Text): Promise<void>

--- a/packages/core/src/storage/interfaces/SignedFileStorageProvider.ts
+++ b/packages/core/src/storage/interfaces/SignedFileStorageProvider.ts
@@ -1,0 +1,5 @@
+import type { SignedUploadUrl } from '../domain/structures'
+
+export interface SignedFileStorageProvider {
+  uploadFile(signedUploadUrl: SignedUploadUrl, file: File): Promise<void>
+}

--- a/packages/core/src/storage/interfaces/StorageService.ts
+++ b/packages/core/src/storage/interfaces/StorageService.ts
@@ -1,5 +1,6 @@
 import type { PaginationResponse, RestResponse } from '@stardust/core/global/responses'
 import type { Integer, Text } from '#global/domain/structures/index'
+import type { SignedUploadUrlDto } from '../domain/structures/dtos'
 import type { FilesListingParams } from '../types'
 import type { EmbeddingNamespace, FileStorageFolderPath } from '../domain/structures'
 
@@ -9,6 +10,10 @@ export interface StorageService {
     folder: FileStorageFolderPath,
     file: File,
   ): Promise<RestResponse<{ filename: string }>>
+  createSignedUploadUrl(
+    folderPath: FileStorageFolderPath,
+    fileName: Text,
+  ): Promise<RestResponse<SignedUploadUrlDto>>
   removeFile(folder: FileStorageFolderPath, filename: Text): Promise<RestResponse>
   searchEmbeddings(
     query: Text,

--- a/packages/core/src/storage/interfaces/index.ts
+++ b/packages/core/src/storage/interfaces/index.ts
@@ -1,4 +1,5 @@
 export type { StorageService } from './StorageService'
 export type { FileStorageProvider } from './FileStorageProvider'
+export type { SignedFileStorageProvider } from './SignedFileStorageProvider'
 export type { EmbeddingsStorageProvider } from './EmbeddingStorageProvider'
 export type { EmbeddingsGeneratorProvider } from './EmbeddingsGeneratorProvider'

--- a/packages/core/src/storage/use-cases/CreateSignedUploadUrl.ts
+++ b/packages/core/src/storage/use-cases/CreateSignedUploadUrl.ts
@@ -1,0 +1,35 @@
+import { Text } from '#global/domain/structures/Text'
+import type { UseCase } from '#global/interfaces/UseCase'
+import { FileStorageFolderPath } from '../domain/structures'
+import type { SignedUploadUrlDto } from '../domain/structures/dtos'
+import { FileNameAlreadyExistsError } from '../errors'
+import type { FileStorageProvider } from '../interfaces'
+
+type Request = {
+  folderPath: string
+  fileName: string
+}
+
+type Response = Promise<SignedUploadUrlDto>
+
+export class CreateSignedUploadUrl implements UseCase<Request, Response> {
+  constructor(private readonly storageProvider: FileStorageProvider) {}
+
+  async execute({ folderPath, fileName }: Request): Promise<SignedUploadUrlDto> {
+    const storageFolderPath = FileStorageFolderPath.create(folderPath)
+    const storageFileName = Text.create(fileName)
+    const existingFile = await this.storageProvider.findFile(
+      storageFolderPath,
+      storageFileName,
+    )
+
+    if (existingFile) throw new FileNameAlreadyExistsError()
+
+    const signedUploadUrl = await this.storageProvider.createSignedUploadUrl(
+      storageFolderPath,
+      storageFileName,
+    )
+
+    return signedUploadUrl.dto
+  }
+}

--- a/packages/core/src/storage/use-cases/index.ts
+++ b/packages/core/src/storage/use-cases/index.ts
@@ -1,4 +1,5 @@
 export { BackupDatabaseUseCase } from './BackupDatabaseUseCase'
+export { CreateSignedUploadUrl } from './CreateSignedUploadUrl'
 export { VerifyFileExistsUseCase } from './VerifyFileExistsUseCase'
 export { GenerateEmbeddingsUseCase } from './GenerateEmbeddingsUseCase'
 export { SearchEmbeddingsUseCase } from './SearchEmbeddingsUseCase'

--- a/packages/core/src/storage/use-cases/tests/CreateSignedUploadUrl.test.ts
+++ b/packages/core/src/storage/use-cases/tests/CreateSignedUploadUrl.test.ts
@@ -1,0 +1,78 @@
+import { mock, type Mock } from 'ts-jest-mocker'
+
+import { SignedUploadUrl } from '#storage/domain/structures/SignedUploadUrl'
+import { FileNameAlreadyExistsError } from '#storage/errors/FileNameAlreadyExistsError'
+import type { FileStorageProvider } from '#storage/interfaces/FileStorageProvider'
+
+import { CreateSignedUploadUrl } from '../CreateSignedUploadUrl'
+
+describe('Create Signed Upload Url', () => {
+  let storageProvider: Mock<FileStorageProvider>
+  let useCase: CreateSignedUploadUrl
+
+  beforeEach(() => {
+    storageProvider = mock<FileStorageProvider>()
+    storageProvider.findFile.mockImplementation()
+    storageProvider.createSignedUploadUrl.mockImplementation()
+
+    useCase = new CreateSignedUploadUrl(storageProvider)
+  })
+
+  it('should return the signed upload url dto when the file does not exist', async () => {
+    const signedUploadUrl = SignedUploadUrl.create({
+      url: 'https://storage.stardust.dev/upload',
+      folderPath: 'images/story',
+      fileName: 'cover.png',
+    })
+
+    storageProvider.findFile.mockResolvedValue(null)
+    storageProvider.createSignedUploadUrl.mockResolvedValue(signedUploadUrl)
+
+    const response = await useCase.execute({
+      folderPath: 'story',
+      fileName: 'cover.png',
+    })
+
+    expect(storageProvider.findFile).toHaveBeenCalledTimes(1)
+    expect(storageProvider.createSignedUploadUrl).toHaveBeenCalledTimes(1)
+    expect(response).toEqual(signedUploadUrl.dto)
+  })
+
+  it('should throw when findFile returns an existing file', async () => {
+    storageProvider.findFile.mockResolvedValue(new File(['image'], 'cover.png'))
+
+    await expect(
+      useCase.execute({
+        folderPath: 'story',
+        fileName: 'cover.png',
+      }),
+    ).rejects.toThrow(FileNameAlreadyExistsError)
+
+    expect(storageProvider.createSignedUploadUrl).not.toHaveBeenCalled()
+  })
+
+  it('should convert folderPath and fileName to domain objects before calling the provider', async () => {
+    storageProvider.findFile.mockResolvedValue(null)
+    storageProvider.createSignedUploadUrl.mockResolvedValue(
+      SignedUploadUrl.create({
+        url: 'https://storage.stardust.dev/upload',
+        folderPath: 'images/story',
+        fileName: 'hero.png',
+      }),
+    )
+
+    await useCase.execute({
+      folderPath: 'story',
+      fileName: 'hero.png',
+    })
+
+    const [findFolderPath, findFileName] = storageProvider.findFile.mock.calls[0]
+    const [createFolderPath, createFileName] =
+      storageProvider.createSignedUploadUrl.mock.calls[0]
+
+    expect(findFolderPath.value).toBe('images/story')
+    expect(findFileName.value).toBe('hero.png')
+    expect(createFolderPath.value).toBe('images/story')
+    expect(createFileName.value).toBe('hero.png')
+  })
+})

--- a/packages/validation/src/modules/storage/index.ts
+++ b/packages/validation/src/modules/storage/index.ts
@@ -1,1 +1,2 @@
 export { fileStorageFolderPathSchema } from './fileStorageFolderPathSchema'
+export { signedUploadUrlSchema } from './signedUploadUrlSchema'

--- a/packages/validation/src/modules/storage/signedUploadUrlSchema.ts
+++ b/packages/validation/src/modules/storage/signedUploadUrlSchema.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod'
+
+import { stringSchema } from '../global/schemas/stringSchema'
+import { fileStorageFolderPathSchema } from './fileStorageFolderPathSchema'
+
+export const signedUploadUrlSchema = z.object({
+  folderPath: fileStorageFolderPathSchema,
+  fileName: stringSchema
+    .trim()
+    .min(1, 'Campo obrigatório')
+    .refine((value) => !['.', '..'].includes(value), {
+      message: 'Nome de arquivo inválido',
+    })
+    .refine((value) => !/[\\/]/.test(value), {
+      message: 'Nome de arquivo inválido',
+    }),
+})


### PR DESCRIPTION
## Objetivo
Migrar o fluxo de upload de imagens para emissao de URL assinada no backend e upload direto ao storage no client, reduzindo acoplamento do servidor ao trafego binario e padronizando contratos de storage entre core, server, studio e web.

## Issues relacionadas
resolve #413

## Changelog
- adiciona no core a estrutura `SignedUploadUrl`, DTO, erro de conflito de nome e use case `CreateSignedUploadUrl`
- estende interfaces de storage para suportar `createSignedUploadUrl(...)` e provider de upload assinado
- adiciona schema de validacao para payload de URL assinada
- expoe no server a rota `POST /storage/signed-upload-url` com autenticacao e validacao
- ajusta rotas de arquivos para reforco de auth e remocao via query params (`folder`, `fileName`)
- implementa emissao de signed upload URL no provider Supabase e adequa providers alternativos ao novo contrato
- cria `ProvisionContext` na studio para injetar provider client-side de upload assinado
- migra `StorageService` e widgets de imagem da studio para solicitar URL assinada e enviar arquivo direto ao Supabase
- ajusta `StorageService` da web para alinhar contrato de listagem/remocao e suporte a signed upload URL
- inclui testes de dominio, use case, controller e widgets para o fluxo de signed upload
- atualiza documentacao de arquitetura, plano e conclusao da spec

## Como testar
1. Executar `npm run test` na raiz e validar que a suite passa.
2. Executar `npm run typecheck` na raiz e validar ausencia de erros de tipagem.
3. Executar `npm run codecheck` na raiz e validar lint/format sem falhas.
4. Subir Studio e Server localmente, abrir o fluxo de selecao/upload de imagem e enviar um arquivo valido.
5. Confirmar que o client solicita `POST /storage/signed-upload-url` e realiza upload direto no storage usando a URL assinada.
6. Validar listagem e remocao de arquivos com query params (`folder` e `fileName`) apos upload.

## Observacoes
- O PR separa contratos de dominio e infraestrutura via provider dedicado para upload assinado no client.
- Houve endurecimento do proxy local de testes do Supabase para reduzir falhas intermitentes de concorrencia.
- O arquivo da spec mantem o nome atual (`signed-upload-url-migraation-spec.md`) para preservar historico desta branch.
