### PR TITLE
Cobertura da jornada de redefinição de senha com testes de integração

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ node_modules/
 /coverage
 issue.md
 apps/web/playwright-report
+apps/web/test-results
 
 # next.js
 .next

--- a/apps/web/src/app/tests/auth/reset-password.test.ts
+++ b/apps/web/src/app/tests/auth/reset-password.test.ts
@@ -27,7 +27,7 @@ test.describe('/auth/reset-password', () => {
     confirmation: '123456',
   }
 
-  function createSessionDto(): SessionDto {
+  function fakeSessionDto(): SessionDto {
     return {
       ...SessionFaker.fakeDto(),
       accessToken: IdFaker.fake().value,
@@ -351,13 +351,23 @@ test.describe('/auth/reset-password', () => {
     page,
   }) => {
     const token = 'token-de-reset'
-    const session = createSessionDto()
+    const session = fakeSessionDto()
 
     await registerResetPasswordDefaults(page, [
       createConfirmPasswordResetSuccessRoute(session),
     ])
 
+    const confirmRequestPromise = page.waitForRequest((request) => {
+      return (
+        request.method() === 'GET' && request.url().includes(CONFIRM_PASSWORD_RESET_ROUTE)
+      )
+    })
+
     await page.goto(`${CONFIRM_PASSWORD_RESET_ROUTE}?token=${token}`)
+
+    const confirmRequest = await confirmRequestPromise
+    const confirmRequestUrl = new URL(confirmRequest.url())
+    expect(confirmRequestUrl.searchParams.get('token')).toBe(token)
 
     await expect(page).toHaveURL(new RegExp(`${RESET_PASSWORD_ROUTE}$`))
     await expectTemporaryCookies(page.context(), session)
@@ -367,7 +377,7 @@ test.describe('/auth/reset-password', () => {
     page,
   }) => {
     const token = 'token-expirado'
-    const session = createSessionDto()
+    const session = fakeSessionDto()
 
     await setTemporaryResetCookies(page.context(), session)
     await registerResetPasswordDefaults(page, [
@@ -391,7 +401,7 @@ test.describe('/auth/reset-password', () => {
   test('renders authorized reset state and opens new password dialog', async ({
     page,
   }) => {
-    await gotoAuthorizedResetPasswordPage(page, createSessionDto())
+    await gotoAuthorizedResetPasswordPage(page, fakeSessionDto())
 
     await expect(page.getByText('Você já pode redefinir sua senha 🚀!')).toBeVisible()
 
@@ -402,7 +412,7 @@ test.describe('/auth/reset-password', () => {
   })
 
   test('validates new password policy and matching confirmation', async ({ page }) => {
-    await gotoAuthorizedResetPasswordPage(page, createSessionDto())
+    await gotoAuthorizedResetPasswordPage(page, fakeSessionDto())
     await openNewPasswordDialog(page)
 
     await submitNewPasswordForm(page)
@@ -430,7 +440,7 @@ test.describe('/auth/reset-password', () => {
   test('patches new password with temporary tokens, signs out and returns to sign in from success action', async ({
     page,
   }) => {
-    await submitSuccessfulPasswordReset(page, createSessionDto())
+    await submitSuccessfulPasswordReset(page, fakeSessionDto())
 
     await page.getByRole('button', { name: 'Fazer login' }).click()
 
@@ -441,7 +451,7 @@ test.describe('/auth/reset-password', () => {
   test('returns to sign in when success dialog is closed with Escape', async ({
     page,
   }) => {
-    await submitSuccessfulPasswordReset(page, createSessionDto())
+    await submitSuccessfulPasswordReset(page, fakeSessionDto())
 
     await page.keyboard.press('Escape')
 
@@ -452,7 +462,7 @@ test.describe('/auth/reset-password', () => {
   test('returns to sign in when success dialog is closed by clicking outside', async ({
     page,
   }) => {
-    await submitSuccessfulPasswordReset(page, createSessionDto())
+    await submitSuccessfulPasswordReset(page, fakeSessionDto())
 
     await page.mouse.click(10, 10)
 
@@ -463,7 +473,7 @@ test.describe('/auth/reset-password', () => {
   test('keeps authorized flow and shows error when password reset fails', async ({
     page,
   }) => {
-    await gotoAuthorizedResetPasswordPage(page, createSessionDto(), [
+    await gotoAuthorizedResetPasswordPage(page, fakeSessionDto(), [
       {
         method: 'PATCH',
         path: '/auth/reset-password',

--- a/apps/web/src/app/tests/auth/reset-password.test.ts
+++ b/apps/web/src/app/tests/auth/reset-password.test.ts
@@ -1,0 +1,488 @@
+import { expect, test, type BrowserContext, type Page } from '@playwright/test'
+
+import type { SessionDto } from '@stardust/core/auth/structures/dtos'
+import { SessionFaker } from '../../../../../../packages/core/src/auth/domain/structures/fakers'
+import { IdFaker } from '../../../../../../packages/core/src/global/domain/structures/fakers'
+import { ServerMock } from '../shared/mocks/ServerMock'
+import type { ServerMockRoute } from '../shared/types/ServerMockRoute'
+
+const RESET_PASSWORD_ROUTE = '/auth/reset-password'
+const SIGN_IN_ROUTE = '/auth/sign-in'
+const CONFIRM_PASSWORD_RESET_ROUTE = '/api/auth/confirm-password-reset'
+const TEST_SERVER_URL = '/api/tests/server'
+const LOCAL_WEB_URL = 'http://127.0.0.1:3100'
+
+const RESET_PASSWORD_COOKIES = {
+  shouldResetPassword: '@stardust:should-reset-password',
+  accessToken: '@stardust:access-token',
+  refreshToken: '@stardust:refresh-token',
+}
+
+test.describe('/auth/reset-password', () => {
+  test.setTimeout(60000)
+
+  const validFields = {
+    email: 'reset.estelar@stardust.dev',
+    newPassword: '123456',
+    confirmation: '123456',
+  }
+
+  function createSessionDto(): SessionDto {
+    return {
+      ...SessionFaker.fakeDto(),
+      accessToken: IdFaker.fake().value,
+      refreshToken: IdFaker.fake().value,
+      durationInSeconds: 3600,
+    }
+  }
+
+  function createAuthAccountFallbackRoute(): ServerMockRoute {
+    return {
+      method: 'GET',
+      path: '/auth/account',
+      status: 401,
+      body: {
+        title: 'Unauthorized',
+        message: 'Não autorizado.',
+      },
+    }
+  }
+
+  function createRequestPasswordResetSuccessRoute(): ServerMockRoute {
+    return {
+      method: 'POST',
+      path: '/auth/request-password-reset',
+      status: 200,
+      body: null,
+    }
+  }
+
+  function createConfirmPasswordResetSuccessRoute(session: SessionDto): ServerMockRoute {
+    return {
+      method: 'POST',
+      path: '/auth/confirm-password-reset',
+      status: 200,
+      body: session,
+    }
+  }
+
+  function createResetPasswordSuccessRoute(): ServerMockRoute {
+    return {
+      method: 'PATCH',
+      path: '/auth/reset-password',
+      status: 200,
+      body: null,
+    }
+  }
+
+  function createSignOutSuccessRoute(): ServerMockRoute {
+    return {
+      method: 'DELETE',
+      path: '/auth/sign-out',
+      status: 200,
+      body: null,
+    }
+  }
+
+  function createRefreshSessionUnauthorizedRoute(): ServerMockRoute {
+    return {
+      method: 'POST',
+      path: '/auth/refresh-session',
+      status: 401,
+      body: {
+        title: 'Unauthorized',
+        message: 'Não autorizado.',
+      },
+    }
+  }
+
+  async function registerResetPasswordDefaults(
+    page: Page,
+    routes: ServerMockRoute[] = [],
+  ) {
+    await ServerMock(page).reset()
+    await ServerMock(page).register([
+      ...routes,
+      createAuthAccountFallbackRoute(),
+      createRequestPasswordResetSuccessRoute(),
+      createResetPasswordSuccessRoute(),
+      createSignOutSuccessRoute(),
+      createRefreshSessionUnauthorizedRoute(),
+    ])
+  }
+
+  async function setCookie(
+    context: BrowserContext,
+    cookie: { name: string; value: string; maxAge?: number },
+  ) {
+    await context.addCookies([
+      {
+        name: cookie.name,
+        value: cookie.value,
+        url: LOCAL_WEB_URL,
+        httpOnly: true,
+        sameSite: 'Lax',
+        expires: Math.floor(Date.now() / 1000) + (cookie.maxAge ?? 900),
+      },
+    ])
+  }
+
+  async function setTemporaryResetCookies(context: BrowserContext, session: SessionDto) {
+    await Promise.all([
+      setCookie(context, {
+        name: RESET_PASSWORD_COOKIES.shouldResetPassword,
+        value: 'true',
+      }),
+      setCookie(context, {
+        name: RESET_PASSWORD_COOKIES.accessToken,
+        value: session.accessToken,
+      }),
+      setCookie(context, {
+        name: RESET_PASSWORD_COOKIES.refreshToken,
+        value: session.refreshToken,
+      }),
+    ])
+  }
+
+  async function getTemporaryResetCookies(context: BrowserContext) {
+    const cookies = await context.cookies(LOCAL_WEB_URL)
+
+    return {
+      shouldResetPassword: cookies.find(
+        (cookie) => cookie.name === RESET_PASSWORD_COOKIES.shouldResetPassword,
+      )?.value,
+      accessToken: cookies.find(
+        (cookie) => cookie.name === RESET_PASSWORD_COOKIES.accessToken,
+      )?.value,
+      refreshToken: cookies.find(
+        (cookie) => cookie.name === RESET_PASSWORD_COOKIES.refreshToken,
+      )?.value,
+    }
+  }
+
+  async function expectTemporaryCookies(context: BrowserContext, session: SessionDto) {
+    await expect
+      .poll(async () => await getTemporaryResetCookies(context))
+      .toEqual({
+        shouldResetPassword: 'true',
+        accessToken: session.accessToken,
+        refreshToken: session.refreshToken,
+      })
+  }
+
+  async function expectTemporaryPermissionCleared(context: BrowserContext) {
+    await expect
+      .poll(async () => (await getTemporaryResetCookies(context)).shouldResetPassword)
+      .toBeUndefined()
+  }
+
+  async function expectTemporaryCookiesCleared(context: BrowserContext) {
+    await expect
+      .poll(async () => await getTemporaryResetCookies(context))
+      .toEqual({
+        shouldResetPassword: undefined,
+        accessToken: undefined,
+        refreshToken: undefined,
+      })
+  }
+
+  async function gotoResetPasswordPage(page: Page, routes: ServerMockRoute[] = []) {
+    await registerResetPasswordDefaults(page, routes)
+    await page.goto(RESET_PASSWORD_ROUTE)
+  }
+
+  async function gotoAuthorizedResetPasswordPage(
+    page: Page,
+    session: SessionDto,
+    routes: ServerMockRoute[] = [],
+  ) {
+    await setTemporaryResetCookies(page.context(), session)
+    await gotoResetPasswordPage(page, routes)
+  }
+
+  async function fillResetRequestEmail(page: Page, email: string) {
+    await page.getByTestId('email-input').fill(email)
+    await expect(page.getByTestId('email-input')).toHaveValue(email)
+  }
+
+  async function openNewPasswordDialog(page: Page) {
+    await page.getByTestId('open-reset-password-dialog-button').click()
+    await expect(
+      page.getByRole('heading', { name: 'Insira sua nova senha' }),
+    ).toBeVisible()
+  }
+
+  async function fillNewPasswordForm(
+    page: Page,
+    fields: { newPassword: string; confirmation: string },
+  ) {
+    await page.getByTestId('new-password-input').fill(fields.newPassword)
+    await page.getByTestId('new-password-confirmation-input').fill(fields.confirmation)
+  }
+
+  async function submitNewPasswordForm(page: Page) {
+    await page.getByTestId('reset-password-submit-button').click()
+  }
+
+  async function submitSuccessfulPasswordReset(page: Page, session: SessionDto) {
+    await gotoAuthorizedResetPasswordPage(page, session)
+    await openNewPasswordDialog(page)
+    await fillNewPasswordForm(page, validFields)
+
+    const resetPasswordRequestPromise = page.waitForRequest((request) => {
+      return (
+        request.method() === 'PATCH' &&
+        request.url().endsWith(`${TEST_SERVER_URL}/auth/reset-password`)
+      )
+    })
+    const signOutResponsePromise = page.waitForResponse((response) => {
+      return (
+        response.request().method() === 'DELETE' &&
+        response.url().endsWith(`${TEST_SERVER_URL}/auth/sign-out`)
+      )
+    })
+
+    await submitNewPasswordForm(page)
+
+    const resetPasswordRequest = await resetPasswordRequestPromise
+    await signOutResponsePromise
+
+    expect(resetPasswordRequest.postDataJSON()).toEqual({
+      newPassword: validFields.newPassword,
+      accessToken: session.accessToken,
+      refreshToken: session.refreshToken,
+    })
+
+    await expect(
+      page.getByRole('alertdialog', {
+        name: 'Você redefiniu sua senha com sucesso!',
+      }),
+    ).toBeVisible()
+  }
+
+  test.afterEach(async ({ page }) => {
+    await ServerMock(page).reset()
+  })
+
+  test('renders reset request form without temporary permission', async ({ page }) => {
+    await gotoResetPasswordPage(page)
+
+    await expect(page.getByRole('heading', { name: 'Redefina sua senha' })).toBeVisible()
+    await expect(page.getByLabel('E-mail')).toBeVisible()
+    await expect(page.getByPlaceholder('seu@email.com')).toBeVisible()
+    await expect(page.getByTestId('submit-button')).toHaveText('Enviar e-mail')
+    await expect(page.getByTestId('sign-in-link')).toHaveAttribute('href', SIGN_IN_ROUTE)
+  })
+
+  test('validates email before requesting password reset', async ({ page }) => {
+    await gotoResetPasswordPage(page)
+
+    let requestPasswordResetRequestsCount = 0
+    page.on('request', (request) => {
+      if (
+        request.method() === 'POST' &&
+        request.url().endsWith(`${TEST_SERVER_URL}/auth/request-password-reset`)
+      ) {
+        requestPasswordResetRequestsCount += 1
+      }
+    })
+
+    await fillResetRequestEmail(page, 'email-invalido')
+    await page.getByTestId('submit-button').click()
+
+    await expect(page.getByText('Informe um e-mail válido')).toBeVisible()
+    expect(requestPasswordResetRequestsCount).toBe(0)
+  })
+
+  test('posts email and shows generic success message', async ({ page }) => {
+    await gotoResetPasswordPage(page)
+    await fillResetRequestEmail(page, validFields.email)
+
+    const requestPasswordResetRequestPromise = page.waitForRequest((request) => {
+      return (
+        request.method() === 'POST' &&
+        request.url().endsWith(`${TEST_SERVER_URL}/auth/request-password-reset`)
+      )
+    })
+    const requestPasswordResetResponsePromise = page.waitForResponse((response) => {
+      return (
+        response.request().method() === 'POST' &&
+        response.url().endsWith(`${TEST_SERVER_URL}/auth/request-password-reset`)
+      )
+    })
+
+    await page.getByTestId('submit-button').click()
+
+    const requestPasswordResetRequest = await requestPasswordResetRequestPromise
+    await requestPasswordResetResponsePromise
+
+    expect(requestPasswordResetRequest.postDataJSON()).toEqual({
+      email: validFields.email,
+    })
+    await expect(
+      page.getByText(
+        'Enviamos um e-mail para você redefinir sua senha (se seu e-mail estiver cadastrado, claro)',
+      ),
+    ).toBeVisible()
+  })
+
+  test('shows request error when password reset request fails', async ({ page }) => {
+    await gotoResetPasswordPage(page, [
+      {
+        method: 'POST',
+        path: '/auth/request-password-reset',
+        status: 500,
+        body: {
+          title: 'Request password reset error',
+          message: 'Falha ao solicitar redefinição',
+        },
+      },
+    ])
+    await fillResetRequestEmail(page, validFields.email)
+
+    await page.getByTestId('submit-button').click()
+
+    await expect(
+      page.getByText('Erro ao enviar e-mail de redefinição de senha'),
+    ).toBeVisible()
+  })
+
+  test('confirms reset token, stores temporary cookies and redirects to reset page', async ({
+    page,
+  }) => {
+    const token = 'token-de-reset'
+    const session = createSessionDto()
+
+    await registerResetPasswordDefaults(page, [
+      createConfirmPasswordResetSuccessRoute(session),
+    ])
+
+    await page.goto(`${CONFIRM_PASSWORD_RESET_ROUTE}?token=${token}`)
+
+    await expect(page).toHaveURL(new RegExp(`${RESET_PASSWORD_ROUTE}$`))
+    await expectTemporaryCookies(page.context(), session)
+  })
+
+  test('removes temporary permission and redirects to sign in when token confirmation fails', async ({
+    page,
+  }) => {
+    const token = 'token-expirado'
+    const session = createSessionDto()
+
+    await setTemporaryResetCookies(page.context(), session)
+    await registerResetPasswordDefaults(page, [
+      {
+        method: 'POST',
+        path: '/auth/confirm-password-reset',
+        status: 401,
+        body: {
+          title: 'Confirm password reset error',
+          message: 'Invalid or expired token',
+        },
+      },
+    ])
+
+    await page.goto(`${CONFIRM_PASSWORD_RESET_ROUTE}?token=${token}`)
+
+    await expect(page).toHaveURL(/\/auth\/sign-in\?error=invalid-or-expired-token$/)
+    await expectTemporaryPermissionCleared(page.context())
+  })
+
+  test('renders authorized reset state and opens new password dialog', async ({
+    page,
+  }) => {
+    await gotoAuthorizedResetPasswordPage(page, createSessionDto())
+
+    await expect(page.getByText('Você já pode redefinir sua senha 🚀!')).toBeVisible()
+
+    await openNewPasswordDialog(page)
+
+    await expect(page.getByTestId('new-password-input')).toBeVisible()
+    await expect(page.getByTestId('new-password-confirmation-input')).toBeVisible()
+  })
+
+  test('validates new password policy and matching confirmation', async ({ page }) => {
+    await gotoAuthorizedResetPasswordPage(page, createSessionDto())
+    await openNewPasswordDialog(page)
+
+    await submitNewPasswordForm(page)
+    await expect(
+      page.getByText('Sua senha deve conter pelo menos 6 caracteres'),
+    ).toBeVisible()
+
+    await fillNewPasswordForm(page, {
+      newPassword: '123',
+      confirmation: '123',
+    })
+    await submitNewPasswordForm(page)
+    await expect(
+      page.getByText('Sua senha deve conter pelo menos 6 caracteres'),
+    ).toBeVisible()
+
+    await fillNewPasswordForm(page, {
+      newPassword: validFields.newPassword,
+      confirmation: '654321',
+    })
+    await submitNewPasswordForm(page)
+    await expect(page.getByText('as senhas devem ser iguais')).toBeVisible()
+  })
+
+  test('patches new password with temporary tokens, signs out and returns to sign in from success action', async ({
+    page,
+  }) => {
+    await submitSuccessfulPasswordReset(page, createSessionDto())
+
+    await page.getByRole('button', { name: 'Fazer login' }).click()
+
+    await expect(page).toHaveURL(new RegExp(`${SIGN_IN_ROUTE}$`))
+    await expectTemporaryCookiesCleared(page.context())
+  })
+
+  test('returns to sign in when success dialog is closed with Escape', async ({
+    page,
+  }) => {
+    await submitSuccessfulPasswordReset(page, createSessionDto())
+
+    await page.keyboard.press('Escape')
+
+    await expect(page).toHaveURL(new RegExp(`${SIGN_IN_ROUTE}$`))
+    await expectTemporaryCookiesCleared(page.context())
+  })
+
+  test('returns to sign in when success dialog is closed by clicking outside', async ({
+    page,
+  }) => {
+    await submitSuccessfulPasswordReset(page, createSessionDto())
+
+    await page.mouse.click(10, 10)
+
+    await expect(page).toHaveURL(new RegExp(`${SIGN_IN_ROUTE}$`))
+    await expectTemporaryCookiesCleared(page.context())
+  })
+
+  test('keeps authorized flow and shows error when password reset fails', async ({
+    page,
+  }) => {
+    await gotoAuthorizedResetPasswordPage(page, createSessionDto(), [
+      {
+        method: 'PATCH',
+        path: '/auth/reset-password',
+        status: 400,
+        body: {
+          title: 'Reset password error',
+          message: 'Senha recusada',
+        },
+      },
+    ])
+    await openNewPasswordDialog(page)
+    await fillNewPasswordForm(page, validFields)
+
+    await submitNewPasswordForm(page)
+
+    await expect(
+      page.getByText('Erro de redefinição, escolha outra senha', { exact: true }),
+    ).toBeVisible()
+    await expect(page).toHaveURL(new RegExp(`${RESET_PASSWORD_ROUTE}$`))
+    await expect(page.getByText('Você já pode redefinir sua senha 🚀!')).toBeVisible()
+  })
+})

--- a/apps/web/src/app/tests/auth/sign-in.test.ts
+++ b/apps/web/src/app/tests/auth/sign-in.test.ts
@@ -143,6 +143,12 @@ test.describe('/auth/sign-in', () => {
       },
       ...createSignInSuccessRoutes(account, session),
       {
+        method: 'POST',
+        path: '/auth/refresh-session',
+        status: 200,
+        body: session,
+      },
+      {
         method: 'GET',
         path: '/profile/achievements',
         status: 200,

--- a/apps/web/src/ui/auth/widgets/pages/ResetPassword/ResetPasswordFormDialog/index.tsx
+++ b/apps/web/src/ui/auth/widgets/pages/ResetPassword/ResetPasswordFormDialog/index.tsx
@@ -27,7 +27,12 @@ export const ResetPasswordFormDialog = ({
   const alertDialogRef = useRef<AlertDialogRef | null>(null)
   const { authService } = useRestContext()
   const { errors, isSubmitting, register, handleSubmit, handleOpenChange } =
-    useResetPasswordFormDialog(authService, alertDialogRef, onNewPasswordSubmit)
+    useResetPasswordFormDialog(
+      authService,
+      alertDialogRef,
+      onNewPasswordSubmit,
+      onPasswordReset,
+    )
 
   return (
     <>
@@ -41,8 +46,9 @@ export const ResetPasswordFormDialog = ({
           </p>
         }
         shouldPlayAudio={false}
+        shouldCloseOnInteractOutside
         onOpenChange={handleOpenChange}
-        action={<Button onClick={onPasswordReset}>Fazer login</Button>}
+        action={<Button>Fazer login</Button>}
       />
       <Dialog.Container>
         <Dialog.Content>
@@ -51,6 +57,7 @@ export const ResetPasswordFormDialog = ({
           <form className='mt-3'>
             <div>
               <Input
+                testId='new-password-input'
                 label='Nova senha'
                 type='password'
                 icon='lock'
@@ -62,6 +69,7 @@ export const ResetPasswordFormDialog = ({
             </div>
             <div className='mt-6'>
               <Input
+                testId='new-password-confirmation-input'
                 label='Confirme sua nova senha'
                 type='password'
                 icon='lock'
@@ -70,7 +78,12 @@ export const ResetPasswordFormDialog = ({
                 placeholder='********'
               />
             </div>
-            <Button onClick={handleSubmit} isLoading={isSubmitting} className='mt-8'>
+            <Button
+              onClick={handleSubmit}
+              isLoading={isSubmitting}
+              className='mt-8'
+              testId='reset-password-submit-button'
+            >
               Redefinir senha
             </Button>
           </form>

--- a/apps/web/src/ui/auth/widgets/pages/ResetPassword/ResetPasswordFormDialog/tests/ResetPasswordFormDialog.test.tsx
+++ b/apps/web/src/ui/auth/widgets/pages/ResetPassword/ResetPasswordFormDialog/tests/ResetPasswordFormDialog.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { RestResponse } from '@stardust/core/global/responses'
+
+import { ResetPasswordFormDialog } from '..'
+import { useRestContext } from '@/ui/global/hooks/useRestContext'
+
+jest.mock('@/ui/global/hooks/useRestContext', () => ({
+  useRestContext: jest.fn(),
+}))
+
+jest.mock('@/ui/global/widgets/components/AlertDialog', () => ({
+  AlertDialog: () => null,
+}))
+
+jest.mock('@/ui/global/contexts/ToastContext', () => ({
+  useToastContext: () => ({
+    showError: jest.fn(),
+    showSuccess: jest.fn(),
+    show: jest.fn(),
+  }),
+}))
+
+jest.mock('@/ui/global/hooks/useNavigationProvider', () => ({
+  useNavigationProvider: () => ({
+    goTo: jest.fn(),
+  }),
+}))
+
+describe('ResetPasswordFormDialog', () => {
+  const resetPassword = jest.fn()
+  const signOut = jest.fn()
+
+  beforeEach(() => {
+    jest.mocked(useRestContext).mockReturnValue({
+      authService: {
+        resetPassword,
+        signOut,
+      },
+    } as never)
+    resetPassword.mockResolvedValue(new RestResponse())
+    signOut.mockResolvedValue(new RestResponse())
+  })
+
+  async function Widget() {
+    const user = userEvent.setup()
+
+    render(
+      <ResetPasswordFormDialog
+        onNewPasswordSubmit={jest.fn()}
+        onPasswordReset={jest.fn()}
+      >
+        <button type='button'>Redefinir senha</button>
+      </ResetPasswordFormDialog>,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Redefinir senha' }))
+  }
+
+  it('should expose stable selectors when new password dialog opens', async () => {
+    await Widget()
+
+    expect(screen.getByRole('heading', { name: 'Insira sua nova senha' })).toBeVisible()
+    expect(screen.getByTestId('new-password-input')).toBeVisible()
+    expect(screen.getByTestId('new-password-confirmation-input')).toBeVisible()
+    expect(screen.getByTestId('reset-password-submit-button')).toBeVisible()
+  })
+})

--- a/apps/web/src/ui/auth/widgets/pages/ResetPassword/ResetPasswordFormDialog/tests/ResetPasswordFormDialog.test.tsx
+++ b/apps/web/src/ui/auth/widgets/pages/ResetPassword/ResetPasswordFormDialog/tests/ResetPasswordFormDialog.test.tsx
@@ -61,9 +61,9 @@ describe('ResetPasswordFormDialog', () => {
   it('should expose stable selectors when new password dialog opens', async () => {
     await Widget()
 
-    expect(screen.getByRole('heading', { name: 'Insira sua nova senha' })).toBeVisible()
-    expect(screen.getByTestId('new-password-input')).toBeVisible()
-    expect(screen.getByTestId('new-password-confirmation-input')).toBeVisible()
-    expect(screen.getByTestId('reset-password-submit-button')).toBeVisible()
+    expect(screen.getByRole('heading', { name: 'Insira sua nova senha' })).toBeInTheDocument()
+    expect(screen.getByTestId('new-password-input')).toBeInTheDocument()
+    expect(screen.getByTestId('new-password-confirmation-input')).toBeInTheDocument()
+    expect(screen.getByTestId('reset-password-submit-button')).toBeInTheDocument()
   })
 })

--- a/apps/web/src/ui/auth/widgets/pages/ResetPassword/ResetPasswordFormDialog/tests/ResetPasswordFormDialog.test.tsx
+++ b/apps/web/src/ui/auth/widgets/pages/ResetPassword/ResetPasswordFormDialog/tests/ResetPasswordFormDialog.test.tsx
@@ -61,7 +61,9 @@ describe('ResetPasswordFormDialog', () => {
   it('should expose stable selectors when new password dialog opens', async () => {
     await Widget()
 
-    expect(screen.getByRole('heading', { name: 'Insira sua nova senha' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Insira sua nova senha' }),
+    ).toBeInTheDocument()
     expect(screen.getByTestId('new-password-input')).toBeInTheDocument()
     expect(screen.getByTestId('new-password-confirmation-input')).toBeInTheDocument()
     expect(screen.getByTestId('reset-password-submit-button')).toBeInTheDocument()

--- a/apps/web/src/ui/auth/widgets/pages/ResetPassword/ResetPasswordFormDialog/useResetPasswordFormDialog.ts
+++ b/apps/web/src/ui/auth/widgets/pages/ResetPassword/ResetPasswordFormDialog/useResetPasswordFormDialog.ts
@@ -10,9 +10,7 @@ import { Password } from '@stardust/core/auth/structures'
 import { Text } from '@stardust/core/global/structures'
 import type { AuthService } from '@stardust/core/auth/interfaces'
 
-import { ROUTES } from '@/constants'
 import { useToastContext } from '@/ui/global/contexts/ToastContext'
-import { useNavigationProvider } from '@/ui/global/hooks/useNavigationProvider'
 import type { AlertDialogRef } from '@/ui/global/widgets/components/AlertDialog/types'
 
 const resetPasswordFormSchema = z
@@ -34,6 +32,7 @@ export function useResetPasswordFormDialog(
     accessToken: string | null
     refreshToken: string | null
   }>,
+  onPasswordReset: () => Promise<void>,
 ) {
   const {
     register,
@@ -44,10 +43,9 @@ export function useResetPasswordFormDialog(
   })
   const [isSubmitting, setIsSubmitting] = useState(false)
   const toast = useToastContext()
-  const router = useNavigationProvider()
 
-  function handleOpenChange(isOpen: boolean) {
-    if (!isOpen) router.goTo(ROUTES.auth.signIn)
+  async function handleOpenChange(isOpen: boolean) {
+    if (!isOpen) await onPasswordReset()
   }
 
   async function handleFormSubmit({ password }: ResetPasswordFormFields) {

--- a/apps/web/src/ui/auth/widgets/pages/ResetPassword/ResetPasswordPageView.tsx
+++ b/apps/web/src/ui/auth/widgets/pages/ResetPassword/ResetPasswordPageView.tsx
@@ -41,33 +41,40 @@ export const ResetPasswordPageView = ({
               onNewPasswordSubmit={onNewPasswordSubmit}
               onPasswordReset={onPasswordReset}
             >
-              <Button className='w-full'>Redefinir senha</Button>
+              <Button className='w-full' testId='open-reset-password-dialog-button'>
+                Redefinir senha
+              </Button>
             </ResetPasswordFormDialog>
           }
         />
       ) : (
         <AnimatedForm>
-          <h1 className='text-2xl font-semibold text-gray-100'>Redefina sua senha</h1>
-          <p className='text-sm text-gray-300'>
-            Digite seu e-mail de cadastro e nós enviaremos um link para você redefinir sua
-            senha.
-          </p>
-          <Input
-            label='E-mail'
-            type='email'
-            icon='mail'
-            value={email}
-            onChange={({ currentTarget }) => onEmailChange(currentTarget.value)}
-            errorMessage={errorMessage}
-            placeholder='seu@email.com'
-            autoFocus
-            className='w-[100rem]'
-          />
-          <Button onClick={onEmailSubmit} isLoading={isLoading}>
-            Enviar e-mail
-          </Button>
-          <div className='w-max self-center'>
-            <Link href={ROUTES.auth.signIn}>Já tem uma conta? Faça login</Link>
+          <div data-testid='reset-password-request-form' className='contents'>
+            <h1 className='text-2xl font-semibold text-gray-100'>Redefina sua senha</h1>
+            <p className='text-sm text-gray-300'>
+              Digite seu e-mail de cadastro e nós enviaremos um link para você redefinir
+              sua senha.
+            </p>
+            <Input
+              testId='email-input'
+              label='E-mail'
+              type='email'
+              icon='mail'
+              value={email}
+              onChange={({ currentTarget }) => onEmailChange(currentTarget.value)}
+              errorMessage={errorMessage}
+              placeholder='seu@email.com'
+              autoFocus
+              className='w-[100rem]'
+            />
+            <Button onClick={onEmailSubmit} isLoading={isLoading} testId='submit-button'>
+              Enviar e-mail
+            </Button>
+            <div className='w-max self-center'>
+              <Link href={ROUTES.auth.signIn} testId='sign-in-link'>
+                Já tem uma conta? Faça login
+              </Link>
+            </div>
           </div>
         </AnimatedForm>
       )}

--- a/apps/web/src/ui/auth/widgets/pages/ResetPassword/tests/ResetPasswordPageView.test.tsx
+++ b/apps/web/src/ui/auth/widgets/pages/ResetPassword/tests/ResetPasswordPageView.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+
+import { ROUTES } from '@/constants'
+import { ResetPasswordPageView } from '../ResetPasswordPageView'
+
+jest.mock('@/ui/auth/widgets/pages/ResetPassword/AnimatedForm', () => ({
+  AnimatedForm: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+jest.mock('@/ui/auth/widgets/pages/ResetPassword/ResetPasswordFormDialog', () => ({
+  ResetPasswordFormDialog: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+}))
+
+describe('ResetPasswordPageView', () => {
+  function View(params?: { canResetPassword?: boolean }) {
+    render(
+      <ResetPasswordPageView
+        canResetPassword={params?.canResetPassword ?? false}
+        isLoading={false}
+        email=''
+        errorMessage=''
+        onEmailChange={jest.fn()}
+        onEmailSubmit={jest.fn()}
+        onNewPasswordSubmit={jest.fn()}
+        onPasswordReset={jest.fn()}
+      />,
+    )
+  }
+
+  it('should render reset password request form selectors and sign in link', () => {
+    View()
+
+    expect(screen.getByTestId('reset-password-request-form')).toBeVisible()
+    expect(screen.getByTestId('email-input')).toBeVisible()
+    expect(screen.getByTestId('submit-button')).toBeVisible()
+    expect(screen.getByTestId('sign-in-link')).toHaveAttribute('href', ROUTES.auth.signIn)
+  })
+})

--- a/apps/web/src/ui/auth/widgets/pages/ResetPassword/useResetPassword.ts
+++ b/apps/web/src/ui/auth/widgets/pages/ResetPassword/useResetPassword.ts
@@ -65,7 +65,7 @@ export function useResetPassword(
         10,
       )
     } catch (error) {
-      if (error instanceof ValidationError) setErrorMessage(error.message)
+      if (error instanceof ValidationError) setErrorMessage('Informe um e-mail válido')
     } finally {
       setIsLoading(false)
     }

--- a/apps/web/src/ui/global/widgets/components/AlertDialog/index.tsx
+++ b/apps/web/src/ui/global/widgets/components/AlertDialog/index.tsx
@@ -18,6 +18,7 @@ type AlertDialogProps = {
   children?: ReactNode
   shouldPlayAudio?: boolean
   shouldForceMount?: boolean
+  shouldCloseOnInteractOutside?: boolean
   onOpenChange?: (isOpen: boolean) => void
 }
 
@@ -31,6 +32,7 @@ const AlertDialogComponent = (
     children: trigger,
     shouldPlayAudio = true,
     shouldForceMount = false,
+    shouldCloseOnInteractOutside = false,
     onOpenChange,
   }: AlertDialogProps,
   ref: ForwardedRef<AlertDialogRef>,
@@ -49,7 +51,12 @@ const AlertDialogComponent = (
     <Hydration>
       <AlertDialog.Root open={isOpen} onOpenChange={handleOpenChange}>
         <AlertDialog.Portal container={isRendered ? containerRef.current : null}>
-          <AlertDialog.Overlay className='fixed inset-0 z-[1000] overflow-y-auto bg-black bg-opacity-50' />
+          <AlertDialog.Overlay
+            className='fixed inset-0 z-[1000] overflow-y-auto bg-black bg-opacity-50'
+            onClick={
+              shouldCloseOnInteractOutside ? () => handleOpenChange(false) : undefined
+            }
+          />
           <AlertDialog.Content
             forceMount={shouldForceMount ? true : undefined}
             className='fixed left-1/2 top-1/2 z-[1100] max-h-screen w-full max-w-lg -translate-x-1/2 -translate-y-1/2 p-6'

--- a/documentation/features/auth/reset-password/plans/reset-password-integration-tests-plan.md
+++ b/documentation/features/auth/reset-password/plans/reset-password-integration-tests-plan.md
@@ -1,0 +1,99 @@
+spec: specs/reset-password-integration-tests-spec.md
+
+## Pendencias (quando aplicavel)
+
+Sem pendencias.
+
+
+## Tabela de Dependencias de Fases
+
+| Fase | Objetivo | Depende de | Pode rodar em paralelo com |
+| --- | --- | --- | --- |
+| F1 | Confirmar o reuso dos contratos existentes de `core` e `validation` sem criar ou modificar artefatos nessas camadas | - | - |
+| F3 | Implementar a suite Playwright de reset password no `web` e os ajustes minimos de UI necessarios para locators estaveis | F1 | - |
+
+> **Estratégia de paralelismo:** sempre comece pelo core (domínio, structures e use cases). Nesta spec, F1 apenas consolida o contrato ja existente (`SessionDto`, `emailSchema`, `passwordSchema` e contratos REST atuais), sem gerar novos artefatos. Com isso validado, F3 executa toda a implementacao no `web`.
+
+
+## Tabela de Dependencias de Tarefas
+
+| Tarefa | Depende de | Libera | Camada |
+| --- | --- | --- | --- |
+| T3.1 | - | T3.2, T3.3 | web |
+| T3.2 | T3.1 | T3.2t, T3.3 | ui |
+| T3.2t | T3.2 | - | ui |
+| T3.3 | T3.1, T3.2 | T3.4, T3.5 | web |
+| T3.4 | T3.3 | T3.4t, T3.5 | ui |
+| T3.4t | T3.4 | - | ui |
+| T3.5 | T3.3, T3.4 | - | web |
+
+
+## F1 — Core: Domínio, Structures e Use Cases
+
+**Objetivo:** Validar que a jornada reutiliza contratos existentes de dominio e validacao (`SessionDto`, `emailSchema`, `passwordSchema`) sem exigir novos artefatos em `packages/core` ou `packages/validation`. Essa fase formaliza que o contrato consumido pela suite Playwright ja existe e desbloqueia a implementacao integral em `web`.
+
+### Tarefas
+
+- [x] Nenhuma tarefa de implementacao nesta fase. A spec declara explicitamente que nao ha criacao, modificacao ou remocao de artefatos em `core`, `validation` ou `server`.
+
+
+## F3 — Web: UI e Integração
+
+**Objetivo:** Implementar a cobertura Playwright da jornada publicada de reset password no `web`, reutilizando `ServerMock(page)` e a infraestrutura test-only existente, e introduzir somente os ajustes minimos de UI necessarios para locators estaveis.
+
+### Tarefas
+
+- [x] **T3.1** — criar a base da suite Playwright com helpers locais e cenarios da solicitacao de e-mail
+  - **Ref:** spec §5 — App Web (Testes de Rotas Playwright) e spec §5 — App Web (Playwright Cookie Helpers)
+  - **Tipo:** `criar`
+  - **Arquivo:** `apps/web/src/app/tests/auth/reset-password.test.ts` (novo)
+  - **Depende de:** -
+  - **Resultado observavel:** `reset-password.test.ts` registra defaults em `/api/tests/server`, navega para `/auth/reset-password` sem permissao temporaria e verifica formulario inicial, validacao de e-mail invalido sem request e `POST /auth/request-password-reset` com payload `{ email }`
+  - **Camada:** `web`
+  - **Rules:** `documentation/rules/web-app-routes-testing-rules.md`
+
+- [x] **T3.2** — adicionar seletores estaveis ao estado inicial da pagina de reset password
+  - **Ref:** spec §6 — `ResetPasswordPageView.tsx`
+  - **Tipo:** `modificar`
+  - **Arquivo:** `apps/web/src/ui/auth/widgets/pages/ResetPassword/ResetPasswordPageView.tsx`
+  - **Depende de:** T3.1
+  - **Resultado observavel:** `ResetPasswordPageView` expõe `testId` para formulario inicial, input de e-mail, CTA de envio e link de login, permitindo distinguir os elementos publicos exigidos pela suite
+  - **Camada:** `ui`
+
+- [x] **T3.2t** — testar os seletores e links do estado inicial de reset password
+  - **Depende de:** T3.2
+  - **Resultado observavel:** testes de `ResetPasswordPageView` passando, cobrindo renderizacao do formulario inicial, exposicao dos `testId` esperados e link `Já tem uma conta? Faça login` apontando para `/auth/sign-in`
+  - **Camada:** `ui`
+  - **Rules:** `documentation/rules/widget-tests-rules.md`
+
+- [x] **T3.3** — expandir a suite Playwright para confirmacao de token e acesso autorizado por cookies temporarios
+  - **Ref:** spec §5 — App Web (Testes de Rotas Playwright) e spec §5 — App Web (Playwright Cookie Helpers)
+  - **Tipo:** `modificar`
+  - **Arquivo:** `apps/web/src/app/tests/auth/reset-password.test.ts`
+  - **Depende de:** T3.1, T3.2
+  - **Resultado observavel:** `reset-password.test.ts` chama `POST /auth/confirm-password-reset` com `{ token }`, verifica criacao e limpeza dos cookies temporarios via `BrowserContext`, valida redirects para `/auth/reset-password` e `/auth/sign-in?error=<slug>` e renderiza o estado autorizado com abertura do dialog de nova senha
+  - **Camada:** `web`
+  - **Rules:** `documentation/rules/web-app-routes-testing-rules.md`
+
+- [x] **T3.4** — adicionar seletores estaveis ao dialog de nova senha e ao submit interno
+  - **Ref:** spec §6 — `ResetPasswordFormDialog/index.tsx`
+  - **Tipo:** `modificar`
+  - **Arquivo:** `apps/web/src/ui/auth/widgets/pages/ResetPassword/ResetPasswordFormDialog/index.tsx`
+  - **Depende de:** T3.3
+  - **Resultado observavel:** `ResetPasswordFormDialog` expõe `testId` opcionais para campo `Nova senha`, campo `Confirme sua nova senha` e botao de submit do dialog, diferenciando o CTA que abre o modal do CTA que envia a redefinicao
+  - **Camada:** `ui`
+
+- [x] **T3.4t** — testar os seletores e a abertura do dialog de redefinicao
+  - **Depende de:** T3.4
+  - **Resultado observavel:** testes de `ResetPasswordFormDialog` passando, cobrindo abertura do dialog `Insira sua nova senha`, exposicao dos `testId` dos campos de senha e presenca do botao interno `Redefinir senha`
+  - **Camada:** `ui`
+  - **Rules:** `documentation/rules/widget-tests-rules.md`
+
+- [x] **T3.5** — concluir a suite Playwright com cenarios de redefinicao, sucesso final e falha
+  - **Ref:** spec §5 — App Web (Testes de Rotas Playwright) e spec §3.1 — Funcionais
+  - **Tipo:** `modificar`
+  - **Arquivo:** `apps/web/src/app/tests/auth/reset-password.test.ts`
+  - **Depende de:** T3.3, T3.4
+  - **Resultado observavel:** `reset-password.test.ts` valida politica minima e confirmacao divergente no dialog, envia `PATCH /auth/reset-password` com `{ newPassword, accessToken, refreshToken }`, confirma `DELETE /auth/sign-out`, verifica mensagem de sucesso com retorno para `/auth/sign-in` por botao, `Escape` e clique fora, e mantem o fluxo autorizado com erro `Erro de redefinição, escolha outra senha` quando o reset falha
+  - **Camada:** `web`
+  - **Rules:** `documentation/rules/web-app-routes-testing-rules.md`

--- a/documentation/features/auth/reset-password/specs/reset-password-integration-tests-spec.md
+++ b/documentation/features/auth/reset-password/specs/reset-password-integration-tests-spec.md
@@ -1,0 +1,325 @@
+---
+title: Testes de Integracao do Fluxo de Redefinicao de Senha Web
+prd: https://github.com/JohnPetros/stardust/milestone/36
+issue: https://github.com/JohnPetros/stardust/issues/428
+apps: web
+status: closed
+last_updated_at: 2026-06-23
+---
+
+# 1. Objetivo
+
+Criar a cobertura Playwright da jornada publicada de redefinicao de senha no `web`, cobrindo a solicitacao do e-mail em `/auth/reset-password`, o retorno do link em `/api/auth/confirm-password-reset?token=...`, o acesso condicionado por cookies temporarios, a definicao da nova senha, o encerramento da sessao temporaria e o retorno final para `/auth/sign-in`. A implementacao deve reutilizar a infraestrutura test-only existente de `/api/tests/server`, preservar os contratos REST atuais e nao depender do backend real.
+
+---
+
+# 2. Escopo
+
+## 2.1 In-scope
+
+- Criar a suite Playwright `apps/web/src/app/tests/auth/reset-password.test.ts`.
+- Validar `/auth/reset-password` sem `COOKIES.shouldResetPassword.key`, renderizando o formulario inicial de solicitacao.
+- Validar label `E-mail`, placeholder `seu@email.com`, CTA `Enviar e-mail` e link `Já tem uma conta? Faça login` apontando para `/auth/sign-in`.
+- Validar erro de e-mail invalido antes de qualquer request para `/api/tests/server/auth/request-password-reset`.
+- Registrar `POST /auth/request-password-reset` via `ServerMock(page)` e validar o payload `{ email }`.
+- Validar toast de sucesso generico e toast/feedback de erro para falha de solicitacao.
+- Validar `/api/auth/confirm-password-reset?token=<token>` com sucesso, incluindo request fake para `POST /auth/confirm-password-reset`, redirecionamento para `/auth/reset-password` e criacao dos cookies `shouldResetPassword`, `accessToken` e `refreshToken`.
+- Validar falha da confirmacao, removendo `shouldResetPassword` e redirecionando para `/auth/sign-in?error=<slug>`.
+- Validar `/auth/reset-password` com permissao temporaria ativa, exibindo o estado autorizado e abrindo o dialog de nova senha.
+- Validar obrigatoriedade, politica global de senha e confirmacao divergente no dialog.
+- Validar `PATCH /auth/reset-password` com `{ newPassword, accessToken, refreshToken }` obtidos dos cookies temporarios.
+- Validar que o sucesso em `PATCH /auth/reset-password` chama `DELETE /auth/sign-out`, exibe a mensagem de sucesso e permite retornar para `/auth/sign-in` pelo botao `Fazer login`, por `Escape` ou por clique fora do dialog.
+- Validar que falha em `PATCH /auth/reset-password` mantem o usuario no fluxo autorizado e exibe `Erro de redefinição, escolha outra senha`.
+
+## 2.2 Out-of-scope
+
+- Criar ou alterar endpoints reais no `apps/server`.
+- Alterar contratos de `AuthService`, `ConfirmPasswordResetController`, `NextApiRestClient` ou `ServerMock`.
+- Criar migrations, tabelas, policies, grants ou seeds.
+- Testar envio real de e-mail.
+- Testar token real do provedor de autenticacao.
+- Cobrir login automatico apos redefinicao.
+- Exibir detalhes da politica de senha alem das mensagens ja fornecidas pelos schemas compartilhados.
+- Criar testes unitarios adicionais para widgets ou controllers que ja possuem cobertura equivalente, salvo lacuna necessaria descoberta durante a implementacao.
+
+---
+
+# 3. Requisitos
+
+## 3.1 Funcionais
+
+- A rota `/auth/reset-password` deve exibir o formulario de e-mail quando nao houver permissao temporaria de redefinicao.
+- O formulario deve rejeitar e-mail invalido sem request para o backend fake.
+- Um e-mail valido deve chamar `POST /auth/request-password-reset` com `{ email }`.
+- Sucesso na solicitacao deve exibir a mensagem generica `Enviamos um e-mail para você redefinir sua senha (se seu e-mail estiver cadastrado, claro)`.
+- Falha na solicitacao deve exibir `Erro ao enviar e-mail de redefinição de senha`.
+- A rota `/api/auth/confirm-password-reset` deve ler `token` da query string e chamar `POST /auth/confirm-password-reset` com `{ token }`.
+- Sucesso na confirmacao deve criar `shouldResetPassword`, `accessToken` e `refreshToken`, redirecionando para `/auth/reset-password`.
+- Falha na confirmacao deve remover `shouldResetPassword` e redirecionar para `/auth/sign-in?error=<slug>`.
+- Com permissao temporaria ativa, `/auth/reset-password` deve exibir `Você já pode redefinir sua senha 🚀!`.
+- O CTA `Redefinir senha` deve abrir o dialog `Insira sua nova senha`.
+- O dialog deve validar `Nova senha`, `Confirme sua nova senha`, senha minima global e igualdade entre senha e confirmacao.
+- Redefinicao bem-sucedida deve chamar `PATCH /auth/reset-password` com a nova senha e os tokens temporarios, chamar `DELETE /auth/sign-out`, exibir `Você redefiniu sua senha com sucesso!` e redirecionar para `/auth/sign-in` ao clicar em `Fazer login`, pressionar `Escape` ou clicar fora do dialog.
+- Falha na redefinicao deve manter o usuario no estado autorizado e exibir `Erro de redefinição, escolha outra senha`.
+
+## 3.2 Nao funcionais
+
+- Isolamento: a suite deve usar `NEXT_PUBLIC_STARDUST_SERVER_URL=http://127.0.0.1:3100/api/tests/server`, sem trafegar para o backend real.
+- Confiabilidade: cada teste deve registrar suas rotas fake antes de navegar para a rota sob teste e deve limpar `ServerMock(page)` no `afterEach`.
+- Confiabilidade: cookies HTTP-only devem ser preparados e verificados por `page.context().addCookies(...)` e `page.context().cookies(...)`, nao por `page.evaluate(...)`.
+- Estabilidade: sincronizar requests relevantes com `page.waitForRequest(...)` e `page.waitForResponse(...)`, evitando `waitForTimeout`.
+- Observabilidade: assertions devem usar `getByRole`, `getByLabel`, `getByPlaceholder`, textos publicos ou `getByTestId` apenas quando os componentes ja expuserem seletor estavel ou quando uma modificacao minima for documentada nesta spec.
+- Seguranca: a infraestrutura `/api/tests/server` deve continuar protegida por `MODE=testing`.
+
+---
+
+# 4. O que ja existe?
+
+## App Web (Testes de Rotas)
+
+- **SignInIntegrationSuite** (`apps/web/src/app/tests/auth/sign-in.test.ts`) - suite Playwright existente com helpers locais, `ServerMock(page)`, fakers do core, `afterEach` de limpeza e sincronizacao por request/response.
+- **SignUpIntegrationSuite** (`apps/web/src/app/tests/auth/sign-up.test.ts`) - referencia de fluxo auth com `ServerMock(page).registerSuccessDefaults(...)`, locators Playwright e reset de mocks ao final de cada cenario.
+- **ServerMock** (`apps/web/src/app/tests/shared/mocks/ServerMock.ts`) - helper test-only para registrar e limpar rotas fake em `/api/tests/server`.
+- **ServerMockRegistry** (`apps/web/src/app/tests/shared/mocks/ServerMockRegistry.ts`) - registry temporario em `/tmp/stardust/stardust-web-server-mock-routes.json`.
+- **ServerMockRoute** (`apps/web/src/app/tests/shared/types/ServerMockRoute.ts`) - contrato serializavel `{ method, path, query, status, delayInMs, body, headers }`.
+- **TestServerRegistryRoute** (`apps/web/src/app/api/tests/server/route.ts`) - route handler test-only para healthcheck, registro e limpeza das rotas fake.
+- **TestServerCatchAllRoute** (`apps/web/src/app/api/tests/server/[...path]/route.ts`) - route handler test-only que responde requests fake por metodo, path e query.
+- **PlaywrightConfig** (`apps/web/playwright.config.ts`) - configura `baseURL` em `http://127.0.0.1:3100`, `MODE=testing`, `NEXT_PUBLIC_STARDUST_SERVER_URL` para `/api/tests/server`, `testDir: './src/app/tests'` e `workers: 1`.
+
+## Next.js App
+
+- **ResetPasswordRoute** (`apps/web/src/app/auth/reset-password/page.tsx`) - entrada App Router que le `COOKIES.shouldResetPassword.key` via `cookieActions.getCookie(...)` e renderiza `ResetPasswordPage`.
+- **ConfirmPasswordResetRoute** (`apps/web/src/app/api/auth/confirm-password-reset/route.ts`) - rota API que valida `queryParams.token`, instancia `NextApiRestClient`, `AuthService` e `ConfirmPasswordResetController`.
+- **ServerProviders** (`apps/web/src/ui/global/widgets/layouts/Root/ServerProviders/index.tsx`) - composition root server-side que chama `AuthService.fetchAccount()` antes de renderizar a pagina, exigindo `GET /auth/account` registrado no mock server.
+- **ROUTES** (`apps/web/src/constants/routes.ts`) - contem `/auth/reset-password`, `/auth/sign-in` e `/api/auth/confirm-password-reset`.
+- **COOKIES** (`apps/web/src/constants/cookies.ts`) - define `@stardust:should-reset-password`, `@stardust:access-token`, `@stardust:refresh-token` e a duracao de 15 minutos da permissao temporaria.
+
+## UI
+
+- **ResetPasswordPage** (`apps/web/src/ui/auth/widgets/pages/ResetPassword/index.tsx`) - entry point cliente que injeta `authService`, `profileService`, `getCookie`, `deleteCookie` e delega para `useResetPassword`.
+- **useResetPassword** (`apps/web/src/ui/auth/widgets/pages/ResetPassword/useResetPassword.ts`) - controla e-mail, loading, erro de solicitacao, leitura dos tokens temporarios e limpeza final dos cookies antes de navegar para `/auth/sign-in`.
+- **ResetPasswordPageView** (`apps/web/src/ui/auth/widgets/pages/ResetPassword/ResetPasswordPageView.tsx`) - alterna entre formulario inicial e estado autorizado conforme `canResetPassword`.
+- **ResetPasswordFormDialog** (`apps/web/src/ui/auth/widgets/pages/ResetPassword/ResetPasswordFormDialog/index.tsx`) - renderiza dialog de nova senha e alert dialog de sucesso com acao `Fazer login`.
+- **useResetPasswordFormDialog** (`apps/web/src/ui/auth/widgets/pages/ResetPassword/ResetPasswordFormDialog/useResetPasswordFormDialog.ts`) - usa `react-hook-form`, `zodResolver`, `passwordSchema`, `stringSchema`, comparacao de senhas, `authService.resetPassword(...)`, `authService.signOut()` e redirecionamento ao fechar o dialog de sucesso.
+- **Input** (`apps/web/src/ui/global/widgets/components/Input/index.tsx`) - componente com `aria-label` derivado de `label`, `placeholder`, `errorMessage` e suporte opcional a `testId`.
+- **Button** (`apps/web/src/ui/global/widgets/components/Button/index.tsx`) - componente de botao com estado `isLoading` e suporte opcional a `testId`.
+- **AuthLink** (`apps/web/src/ui/auth/widgets/components/Link/LinkView.tsx`) - link auth com suporte opcional a `testId`.
+- **Toast** (`apps/web/src/ui/global/contexts/ToastContext/Toast/ToastView.tsx`) - feedback visual de sucesso/erro usado pelas mensagens de solicitacao e redefinicao.
+
+## REST / Controllers
+
+- **AuthService** (`apps/web/src/rest/services/AuthService.ts`) - service web com `requestPasswordReset`, `confirmPasswordReset`, `resetPassword` e `signOut`.
+- **ConfirmPasswordResetController** (`apps/web/src/rest/controllers/auth/ConfirmPasswordResetController.ts`) - confirma token, grava cookies temporarios e redireciona para reset password ou login com erro.
+- **ConfirmPasswordResetControllerTest** (`apps/web/src/rest/controllers/auth/tests/ConfirmPasswordResetController.test.ts`) - cobertura unitária existente para chamada do token, cookies e redirects do controller.
+- **NextApiRestClient** (`apps/web/src/rest/next/NextApiRestClient.ts`) - adapter REST server-side de API route, usando `CLIENT_ENV.stardustServerUrl` e authorization por header ou cookie.
+- **NextRestClient** (`apps/web/src/rest/next/NextRestClient.ts`) - adapter REST usado pelo client e pelo server, incluindo `patch`, `post`, `delete` e refresh de sessao em erros.
+- **NextHttp** (`apps/web/src/rest/next/NextHttp.ts`) - adapter HTTP que aplica cookies acumulados em responses de redirect.
+
+## Validation / Core
+
+- **emailSchema** (`packages/validation/src/modules/global/schemas/emailSchema.ts`) - mensagem `Informe um e-mail válido`.
+- **passwordSchema** (`packages/validation/src/modules/global/schemas/passwordSchema.ts`) - senha minima de 6 caracteres com mensagem `Sua senha deve conter pelo menos 6 caracteres`.
+- **SessionDto** (`packages/core/src/auth/domain/structures/dtos/SessionDto.ts`) - contrato `{ account, accessToken, refreshToken, durationInSeconds }` retornado por confirmacao de reset.
+- **SessionFaker** (`packages/core/src/auth/domain/structures/fakers/SessionFaker.ts`) - faker de `SessionDto` para montar responses compativeis.
+- **AccountsFaker** (`packages/core/src/auth/domain/entities/fakers/AccountsFaker.ts`) - faker de `AccountDto` usado por `SessionFaker` e suites auth existentes.
+- **IdFaker** (`packages/core/src/global/domain/structures/fakers`) - faker de ids usado nas suites auth existentes.
+
+---
+
+# 5. O que deve ser criado?
+
+## App Web (Testes de Rotas Playwright)
+
+- **Localizacao:** `apps/web/src/app/tests/auth/reset-password.test.ts` **(novo arquivo)**
+- **Runner:** `@playwright/test`
+- **Dependencias:** `test`, `expect`, `type BrowserContext`, `type Page`; `SessionFaker` ou fixture local aderente a `SessionDto`; `IdFaker`; `ServerMock`; `type ServerMockRoute`.
+- **Request/Response:** a suite registra rotas fake para `GET /auth/account`, `POST /auth/request-password-reset`, `POST /auth/confirm-password-reset`, `PATCH /auth/reset-password` e `DELETE /auth/sign-out`.
+- **Constantes locais:** nomes de cookies derivados dos contratos atuais (`@stardust:should-reset-password`, `@stardust:access-token`, `@stardust:refresh-token`) ou import direto de `@/constants/cookies`; evitar import do barrel `@/constants` em Playwright.
+- **Helpers locais:**
+  - `createSessionDto(): SessionDto` - cria uma sessao temporaria deterministica para o fluxo de confirmacao.
+  - `createAuthAccountFallbackRoute(): ServerMockRoute` - registra `GET /auth/account` como usuario anonimo ou erro controlado, suficiente para `ServerProviders`.
+  - `registerResetPasswordDefaults(page: Page, routes?: ServerMockRoute[]): Promise<void>` - limpa e registra defaults minimos para a rota atual.
+  - `setTemporaryResetCookies(context: BrowserContext, session: SessionDto): Promise<void>` - cria `shouldResetPassword`, `accessToken` e `refreshToken` para `127.0.0.1`.
+  - `getTemporaryResetCookies(context: BrowserContext): Promise<Record<string, string | undefined>>` - le cookies relevantes do contexto Playwright.
+  - `gotoResetPasswordPage(page: Page, routes?: ServerMockRoute[]): Promise<void>` - registra mocks e navega para `/auth/reset-password`.
+  - `gotoAuthorizedResetPasswordPage(page: Page, session: SessionDto, routes?: ServerMockRoute[]): Promise<void>` - prepara cookies temporarios e navega para `/auth/reset-password`.
+  - `fillResetRequestEmail(page: Page, email: string): Promise<void>` - preenche o campo `E-mail`.
+  - `openNewPasswordDialog(page: Page): Promise<void>` - clica no CTA `Redefinir senha` e aguarda o dialog `Insira sua nova senha`.
+  - `fillNewPasswordForm(page: Page, fields: { newPassword: string; confirmation: string }): Promise<void>` - preenche `Nova senha` e `Confirme sua nova senha`.
+  - `submitNewPasswordForm(page: Page): Promise<void>` - clica no botao `Redefinir senha` do dialog.
+- **Cenarios da suite:**
+  - `test('renders reset request form without temporary permission', ...)`
+  - `test('validates email before requesting password reset', ...)`
+  - `test('posts email and shows generic success message', ...)`
+  - `test('shows request error when password reset request fails', ...)`
+  - `test('confirms reset token, stores temporary cookies and redirects to reset page', ...)`
+  - `test('removes temporary permission and redirects to sign in when token confirmation fails', ...)`
+  - `test('renders authorized reset state and opens new password dialog', ...)`
+  - `test('validates new password policy and matching confirmation', ...)`
+  - `test('patches new password with temporary tokens, signs out and returns to sign in from success action', ...)`
+  - `test('returns to sign in when success dialog is closed with Escape', ...)`
+  - `test('returns to sign in when success dialog is closed by clicking outside', ...)`
+  - `test('keeps authorized flow and shows error when password reset fails', ...)`
+
+## App Web (Playwright Cookie Helpers)
+
+- **Localizacao:** mesmo arquivo `apps/web/src/app/tests/auth/reset-password.test.ts` **(novo arquivo)**
+- **Responsabilidade:** isolar a montagem dos cookies HTTP-only usados pelos cenarios autorizados.
+- **Metodos:**
+  - `setCookie(context: BrowserContext, cookie: { name: string; value: string; maxAge?: number }): Promise<void>` - adiciona cookie em `http://127.0.0.1:3100`.
+  - `expectTemporaryCookies(context: BrowserContext, session: SessionDto): Promise<void>` - valida `shouldResetPassword=true`, `accessToken=session.accessToken` e `refreshToken=session.refreshToken`.
+  - `expectTemporaryCookiesCleared(context: BrowserContext): Promise<void>` - valida ausencia ou expiracao dos cookies temporarios apos falha/finalizacao.
+
+---
+
+# 6. O que deve ser modificado?
+
+- **Arquivo:** `apps/web/src/ui/auth/widgets/pages/ResetPassword/ResetPasswordPageView.tsx`
+  - **Mudanca:** adicionar `testId` nos pontos onde locators por role/label nao forem suficientes: formulario inicial (`reset-password-request-form`), input de e-mail (`email-input`), CTA de envio (`submit-button`) e link de login (`sign-in-link`).
+  - **Justificativa:** `Input`, `Button` e `Link` ja suportam `testId`; o padrao existe em `SignInForm` e `SignUpPageView`, e reduz ambiguidade entre o CTA inicial e o CTA homonimo dentro do dialog.
+
+- **Arquivo:** `apps/web/src/ui/auth/widgets/pages/ResetPassword/ResetPasswordFormDialog/index.tsx`
+  - **Mudanca:** adicionar `testId` opcionais aos campos de nova senha (`new-password-input`, `new-password-confirmation-input`) e ao botao de submit do dialog (`reset-password-submit-button`) caso os locators por label/role fiquem ambiguos durante a implementacao.
+  - **Justificativa:** os componentes globais ja aceitam `testId`, e a suite precisa diferenciar o botao `Redefinir senha` que abre o dialog do botao que submete a nova senha.
+
+Se a implementacao conseguir cobrir todos os cenarios com `getByRole`, `getByLabel`, `getByPlaceholder` e textos publicos sem ambiguidade, estas modificacoes devem ser omitidas.
+
+---
+
+# 7. O que deve ser removido?
+
+Nao aplicavel.
+
+---
+
+# 8. Decisoes Tecnicas
+
+- **Decisao:** criar uma unica suite Playwright em `apps/web/src/app/tests/auth/reset-password.test.ts`.
+  - **Alternativas:** distribuir parte da cobertura em testes unitarios de widget/controller.
+  - **Motivo:** o issue pede a jornada publicada ao usuario, envolvendo SSR, API route, cookies HTTP-only, hidratacao, REST client-side e redirects reais.
+  - **Trade-offs:** a suite fica mais longa, mas valida o contrato de ponta a ponta dentro da borda `web`.
+
+- **Decisao:** usar `ServerMock(page)` e `/api/tests/server` em vez de `page.route(...)`.
+  - **Alternativas:** interceptar requests no browser com Playwright.
+  - **Motivo:** a codebase ja tem boundary test-only canonico que atende requests server-side e client-side, inclusive a chamada de `NextApiRestClient` em `/api/auth/confirm-password-reset`.
+  - **Trade-offs:** exige registrar `GET /auth/account` para o `ServerProviders`, mas evita backend real.
+
+- **Decisao:** validar cookies temporarios pelo `BrowserContext`.
+  - **Alternativas:** expor cookies por JS no browser.
+  - **Motivo:** `NextCall` e `NextHttp` gravam cookies HTTP-only; JS client-side nao deve le-los diretamente. Playwright consegue preparar e inspecionar cookies no contexto do navegador.
+  - **Trade-offs:** helpers de cookie precisam conhecer `baseURL` e dominio local.
+
+- **Decisao:** preferir locators acessiveis e textos publicos, adicionando `testId` apenas em pontos ambiguos.
+  - **Alternativas:** adicionar `testId` em todos os elementos da pagina.
+  - **Motivo:** a pagina ja expoe labels, placeholders e textos de produto suficientes para a maior parte das assertions; os `testId` devem seguir o padrao existente apenas para estabilizar interacoes repetidas.
+  - **Trade-offs:** alguns testes ficam mais proximos do texto de UI, mas isso e aceitavel porque o issue exige validar a jornada publicada.
+
+- **Decisao:** manter `ConfirmPasswordResetController.test.ts` sem alteracoes obrigatorias.
+  - **Alternativas:** duplicar as assertions de cookies no teste unitario.
+  - **Motivo:** o controller ja cobre token, cookies e redirects; o novo valor esta em validar a rota API real com `NextHttp`, `NextApiRestClient`, `ServerMock` e redirects observaveis.
+  - **Trade-offs:** se a rota API tiver comportamento diferente do controller, a suite Playwright deve revelar sem exigir novo teste unitario.
+
+- **Decisao:** nao criar migration.
+  - **Alternativas:** nao aplicavel.
+  - **Motivo:** a feature nao altera schema, tabela, indice, view, constraint, grant ou RLS.
+  - **Trade-offs:** nenhum.
+
+- **Decisao:** nao criar contratos novos em `core`, `validation` ou `server`.
+  - **Alternativas:** adicionar DTOs/helpers compartilhados para os testes.
+  - **Motivo:** `SessionDto`, `AuthService`, `emailSchema`, `passwordSchema` e `ServerMockRoute` ja fornecem os contratos necessarios.
+  - **Trade-offs:** a suite Playwright mantem alguns helpers locais, como as suites auth existentes.
+
+---
+
+# 9. Diagramas e Referencias
+
+- **Fluxo de dados:**
+
+```mermaid
+sequenceDiagram
+  participant Test as reset-password.test.ts
+  participant Mock as /api/tests/server
+  participant Page as /auth/reset-password
+  participant UI as ResetPasswordPage
+  participant API as /api/auth/confirm-password-reset
+  participant Controller as ConfirmPasswordResetController
+  participant REST as AuthService
+
+  Test->>Mock: register GET /auth/account
+  Test->>Page: goto('/auth/reset-password')
+  Page->>UI: canResetPassword=false
+  UI->>REST: POST /auth/request-password-reset { email }
+  REST->>Mock: /auth/request-password-reset
+  Mock-->>UI: null ou erro
+  Test->>Mock: register POST /auth/confirm-password-reset
+  Test->>API: goto('/api/auth/confirm-password-reset?token=...')
+  API->>Controller: handle(http)
+  Controller->>REST: confirmPasswordReset(token)
+  REST->>Mock: POST /auth/confirm-password-reset
+  Mock-->>Controller: SessionDto ou erro
+  Controller-->>API: set/delete cookies + redirect
+  API-->>Page: /auth/reset-password ou /auth/sign-in?error=...
+  Test->>Page: goto com cookies temporarios
+  Page->>UI: canResetPassword=true
+  UI->>REST: PATCH /auth/reset-password { newPassword, accessToken, refreshToken }
+  REST->>Mock: /auth/reset-password
+  UI->>REST: DELETE /auth/sign-out
+  REST->>Mock: /auth/sign-out
+  UI-->>Page: sucesso + retorno para /auth/sign-in
+```
+
+- **Fluxo cross-app:** nao aplicavel. A cobertura executa somente `apps/web`; o backend e substituido por route handlers test-only da propria app em `/api/tests/server`.
+
+- **Layout:**
+
+```text
+/auth/reset-password sem permissao
+`- ResetPasswordPage
+   |- h1: Redefina sua senha
+   |- input: E-mail / seu@email.com
+   |- button: Enviar e-mail
+   `- link: Já tem uma conta? Faça login -> /auth/sign-in
+
+/auth/reset-password com permissao
+`- ResetPasswordPage
+   |- AppMessage: Você já pode redefinir sua senha
+   `- button: Redefinir senha
+      `- Dialog: Insira sua nova senha
+         |- input: Nova senha
+         |- input: Confirme sua nova senha
+         `- button: Redefinir senha
+            `- AlertDialog: Voce redefiniu sua senha com sucesso!
+               `- button: Fazer login
+```
+
+- **Referencias:**
+  - `apps/web/src/app/tests/auth/sign-in.test.ts`
+  - `apps/web/src/app/tests/auth/sign-up.test.ts`
+  - `apps/web/src/app/tests/shared/mocks/ServerMock.ts`
+  - `apps/web/src/app/tests/shared/mocks/ServerMockRegistry.ts`
+  - `apps/web/src/app/tests/shared/types/ServerMockRoute.ts`
+  - `apps/web/src/app/api/tests/server/route.ts`
+  - `apps/web/src/app/api/tests/server/[...path]/route.ts`
+  - `apps/web/playwright.config.ts`
+  - `apps/web/src/app/auth/reset-password/page.tsx`
+  - `apps/web/src/app/api/auth/confirm-password-reset/route.ts`
+  - `apps/web/src/ui/auth/widgets/pages/ResetPassword/index.tsx`
+  - `apps/web/src/ui/auth/widgets/pages/ResetPassword/useResetPassword.ts`
+  - `apps/web/src/ui/auth/widgets/pages/ResetPassword/ResetPasswordPageView.tsx`
+  - `apps/web/src/ui/auth/widgets/pages/ResetPassword/ResetPasswordFormDialog/index.tsx`
+  - `apps/web/src/ui/auth/widgets/pages/ResetPassword/ResetPasswordFormDialog/useResetPasswordFormDialog.ts`
+  - `apps/web/src/rest/controllers/auth/ConfirmPasswordResetController.ts`
+  - `apps/web/src/rest/controllers/auth/tests/ConfirmPasswordResetController.test.ts`
+  - `apps/web/src/rest/services/AuthService.ts`
+  - `apps/web/src/constants/cookies.ts`
+  - `apps/web/src/constants/routes.ts`
+  - `packages/validation/src/modules/global/schemas/emailSchema.ts`
+  - `packages/validation/src/modules/global/schemas/passwordSchema.ts`
+  - `packages/core/src/auth/domain/structures/dtos/SessionDto.ts`
+  - `packages/core/src/auth/domain/structures/fakers/SessionFaker.ts`
+
+---
+
+# 10. Pendencias / Duvidas
+
+Sem pendencias.

--- a/documentation/prompts/conclude-spec-prompt.md
+++ b/documentation/prompts/conclude-spec-prompt.md
@@ -257,3 +257,19 @@ dependências externas — tudo que o revisor precisa saber antes de aprovar>
 - [ ] Architecture atualizado (se aplicável)
 - [ ] Rules atualizadas (se aplicável)
 ```
+
+---
+
+## Fase 4 — Commit e Pull Request
+
+Esta fase só deve ser executada após a Fase 3 estar completa e o checklist final sem pendências.
+
+**4.1 Commit das alterações**
+
+Execute o skill `/commit-code` para commitar todas as alterações da implementação. O skill agrupa os arquivos por responsabilidade semântica e cria os commits com mensagens padronizadas.
+
+> Atenção: apenas arquivos relacionados à spec atual devem ser commitados. Alterações pré-existentes de outras features não devem entrar neste PR.
+
+**4.2 Criação do Pull Request**
+
+Após os commits, execute o skill `/create-pr` para abrir o PR com título e descrição padronizados, usando o resumo de conclusão gerado na Fase 3 como base para o body.

--- a/documentation/prompts/resolve-pr-pendencies-prompt.md
+++ b/documentation/prompts/resolve-pr-pendencies-prompt.md
@@ -1,11 +1,11 @@
 ---
-description: Prompt para resolver conversas pendentes de um pull request com analise, implementacao e fechamento de threads via gh CLI.
+description: Prompt para resolver conversas pendentes e erros de CI/CD de um pull request com analise, implementacao e fechamento de threads via gh CLI.
 ---
 
-# Prompt: Resolver Conversas de PR
+# Prompt: Resolver Pendências de PR
 
 **Objetivo Principal:**
-Analisar, implementar e resolver todas as conversas **não resolvidas** em um Pull Request (PR) específico do GitHub. O foco é garantir que todos os pontos de melhoria, correções de bugs e sugestões de design levantadas pelos revisores sejam devidamente endereçados no código, respeitando os padrões e a arquitetura do projeto.
+Analisar, implementar e resolver todas as conversas **não resolvidas** e **erros de GitHub Actions** em um Pull Request (PR) específico do GitHub. O foco é garantir que todos os pontos de melhoria, correções de bugs, sugestões de design levantadas pelos revisores e falhas de CI/CD sejam devidamente endereçados no código, respeitando os padrões e a arquitetura do projeto.
 
 **Entrada:**
 - **Link do PR:** URL completa do Pull Request no GitHub (ex: `https://github.com/owner/repo/pull/123`).
@@ -67,23 +67,53 @@ Filtre apenas os nós onde `isResolved: false` e `isOutdated: false`. Esses são
 
 ---
 
-### 3. Triagem das Threads
+### 3. Verificação de Erros do GitHub Actions
 
-Classifique cada thread não resolvida em uma das categorias:
+Verifique o status dos checks (CI/CD) associados ao PR:
+
+```bash
+gh pr checks <pull_number> --repo <owner>/<repo>
+```
+
+Se houver checks com status **fail**, obtenha os logs do workflow com falha:
+
+```bash
+# Listar os runs associados ao PR
+gh run list --repo <owner>/<repo> --branch <head_branch> --status failure --limit 5 --json databaseId,name,conclusion,event
+
+# Obter os logs detalhados do run com falha
+gh run view <run_id> --repo <owner>/<repo> --log-failed
+```
+
+> **Dica:** O `--log-failed` retorna apenas os logs dos steps que falharam, facilitando a análise. Se o output for muito grande, foque nos últimos 100 linhas do step com falha.
+
+Para cada falha identificada, extraia:
+- **Workflow e job** que falhou.
+- **Mensagem de erro** principal.
+- **Arquivo e linha** afetados (quando disponível no log).
+- **Causa raiz** provável.
+
+---
+
+### 4. Triagem das Threads e Erros de CI
+
+Classifique cada thread não resolvida **e cada erro de CI** em uma das categorias:
 
 | Categoria | Critério | Ação |
 |---|---|---|
-| **Implementar** | Correção de código, ajuste de padrão, bug apontado | Implementar autonomamente |
-| **Escalar** | Mudança arquitetural, decisão de design, conflito com Spec/PRD | Consultar o usuário antes de agir |
-| **Ignorar** | Comentário meramente informativo, já endereçado no código | Pular |
+| **Implementar** | Correção de código, ajuste de padrão, bug apontado, erro de lint/type/test no CI | Implementar autonomamente |
+| **Escalar** | Mudança arquitetural, decisão de design, conflito com Spec/PRD, falha de CI relacionada a infra/config de workflow | Consultar o usuário antes de agir |
+| **Ignorar** | Comentário meramente informativo, já endereçado no código, falha de CI transiente (timeout de rede, flaky test já conhecido) | Pular |
 
-> **Regra de escalada:** Qualquer comentário que implique mudança de arquitetura, remoção de funcionalidade ou conflito com o PRD/Spec associado deve ser **escalado** — nunca implementado de forma autônoma.
+> **Regra de escalada:** Qualquer comentário ou erro de CI que implique mudança de arquitetura, remoção de funcionalidade, alteração de configuração de workflow/infra ou conflito com o PRD/Spec associado deve ser **escalado** — nunca implementado de forma autônoma.
+
+> **Erros de CI:** Erros de typecheck, lint, testes unitários/integração e build são tratados como itens **Implementar**. Erros de configuração de workflow (permissões, secrets, versão de runner) são **Escalar**.
 
 Apresente a lista classificada ao usuário antes de avançar caso haja itens na categoria **Escalar**.
 
 ---
 
-### 4. Implementação
+### 5. Implementação
 
 Para cada thread categorizada como **Implementar**:
 
@@ -104,7 +134,7 @@ Para cada thread categorizada como **Escalar**:
 
 ---
 
-### 5. Validação das Alterações
+### 6. Validação das Alterações
 
 Após implementar todas as correções:
 
@@ -118,7 +148,7 @@ Corrija eventuais erros antes de prosseguir. Verifique também se as alteraçõe
 
 ---
 
-### 6. Fechamento das Threads
+### 7. Fechamento das Threads
 
 Resolva cada thread implementada via GraphQL API:
 
@@ -138,7 +168,7 @@ mutation {
 
 ---
 
-### 7. Atualização da Documentação
+### 8. Atualização da Documentação
 
 Localize o documento de Spec ou Bug Report associado à branch do PR (`documentation/features/.../specs/...`) e, se as alterações implementadas afetarem o escopo documentado:
 
@@ -158,13 +188,20 @@ gh pr view <pull_number> --repo <owner>/<repo> --json title,headRefName,body,fil
 
 # Threads de revisão (filtrando não resolvidas e não outdated)
 gh api graphql -f query='{ repository(owner:"<owner>", name:"<repo>") { pullRequest(number:<pull_number>) { reviewThreads(first:50) { nodes { id isResolved isOutdated comments(first:1) { nodes { path body author { login } } } } } } } }'
+
+# Status dos checks de CI/CD
+gh pr checks <pull_number> --repo <owner>/<repo>
+
+# Logs de workflows com falha (se houver)
+gh run list --repo <owner>/<repo> --branch <head_branch> --status failure --limit 5 --json databaseId,name,conclusion
+gh run view <run_id> --repo <owner>/<repo> --log-failed
 ```
 
 ### Passo 2 — Diagnóstico e Triagem
 
-Para cada thread não resolvida, identifique e classifique:
+Para cada thread não resolvida e cada erro de CI, identifique e classifique:
 - Arquivo afetado e linhas envolvidas.
-- Problema descrito pelo revisor.
+- Problema descrito pelo revisor ou mensagem de erro do CI.
 - Solução proposta.
 - Categoria: **Implementar**, **Escalar** ou **Ignorar**.
 
@@ -190,14 +227,17 @@ Relate o progresso com o seguinte formato:
 ```
 ## Resumo de Resolucoes
 
-### Implementadas
+### Conversas Implementadas
 - [x] `caminho/do/arquivo.ts` — [descricao da mudanca realizada]
 
+### Erros de CI Corrigidos
+- [x] `workflow/job` — [descricao do erro e da correcao aplicada]
+
 ### Aguardando decisao
-- [ ] `caminho/do/arquivo.ts` — [comentario do revisor] -> [motivo da escalada]
+- [ ] `caminho/do/arquivo.ts` — [comentario do revisor ou erro de CI] -> [motivo da escalada]
 
 ### Ignoradas
-- `caminho/do/arquivo.ts` — thread meramente informativa / ja enderecada
+- `caminho/do/arquivo.ts` — thread meramente informativa / ja enderecada / falha transiente de CI
 ```
 
 ### Passo 6 — Atualização da Documentação


### PR DESCRIPTION
## Objetivo

Adicionar cobertura Playwright da jornada completa de redefinição de senha no `apps/web`, validando o fluxo de ponta a ponta: solicitação de e-mail, confirmação de token via API route, acesso condicionado por cookies temporários, definição da nova senha e retorno para login.

## Issues relacionadas

resolve #428

## Changelog

**Testes de integração (Playwright):**
- `apps/web/src/app/tests/auth/reset-password.test.ts` — nova suite com 12 cenários cobrindo todos os requisitos funcionais da spec
- `apps/web/src/app/tests/auth/sign-in.test.ts` — adicionada rota mock `POST /auth/refresh-session` para estabilizar suite existente

**Testes de widget:**
- `apps/web/src/ui/auth/widgets/pages/ResetPassword/tests/ResetPasswordPageView.test.tsx` — cobertura de seletores e link do estado inicial
- `apps/web/src/ui/auth/widgets/pages/ResetPassword/ResetPasswordFormDialog/tests/ResetPasswordFormDialog.test.tsx` — cobertura de seletores do dialog de nova senha

**Ajustes de UI para seletores estáveis:**
- `ResetPasswordPageView.tsx` — adicionados `testId` em formulário (`reset-password-request-form`), input de e-mail (`email-input`), botão de envio (`submit-button`) e link de login (`sign-in-link`)
- `ResetPasswordFormDialog/index.tsx` — adicionados `testId` em campos de senha (`new-password-input`, `new-password-confirmation-input`) e botão de submit do dialog (`reset-password-submit-button`); botão de abertura do dialog recebeu `open-reset-password-dialog-button`
- `AlertDialog/index.tsx` — nova prop `shouldCloseOnInteractOutside` para suportar fechamento por clique no overlay
- `useResetPasswordFormDialog.ts` — refatorado para receber `onPasswordReset` como callback, removendo acoplamento direto ao router
- `useResetPassword.ts` — mensagem de erro de validação de e-mail fixada como string literal consistente com `emailSchema`

**Config:**
- `.gitignore` — adicionado `apps/web/test-results` para ignorar artefatos de falha do Playwright

**Documentação:**
- `documentation/features/auth/reset-password/specs/reset-password-integration-tests-spec.md` — spec fechada (`status: closed`)
- `documentation/features/auth/reset-password/plans/reset-password-integration-tests-plan.md` — plano de implementação

## Como testar

1. Certifique-se de que o servidor Next.js está rodando em modo `testing` (`MODE=testing`): `cd apps/web && npm run dev`
2. Execute a suite Playwright: `cd apps/web && npx playwright test src/app/tests/auth/reset-password.test.ts`
3. Para rodar todos os testes unitários do `web`: `npm run test:web`
4. Para validar a cobertura dos widgets novos: os testes de `ResetPasswordPageView.test.tsx` e `ResetPasswordFormDialog.test.tsx` rodam embutidos no `npm run test:web`

## Observações

- A prop `shouldCloseOnInteractOutside` no `AlertDialog` usa `onClick` no `Overlay` do Radix — o Radix AlertDialog bloqueia `onInteractOutside` por design; o `onClick` no overlay é o workaround necessário para suportar fechamento por clique fora.
- A suite usa `ServerMock(page)` e `/api/tests/server` (boundary test-only canônico) em vez de `page.route()`, garantindo que as chamadas server-side de `NextApiRestClient` também sejam interceptadas.
- Cookies HTTP-only são manipulados exclusivamente via `BrowserContext` (não JS no browser), conforme requisito não funcional da spec.
- `test.setTimeout(60000)` na suite Playwright cobre os cenários de confirmação de token que envolvem redirect server-side.
