### PR TITLE
Correção do fechamento manual do drawer de notas

### DIFF
--- a/apps/web/src/ui/global/widgets/components/NotesDrawer/NotesDrawerView.tsx
+++ b/apps/web/src/ui/global/widgets/components/NotesDrawer/NotesDrawerView.tsx
@@ -24,6 +24,7 @@ type Props = {
   totalPagesCount: number
   notes: NoteDto[]
   onDrawerOpenChange: (isOpen: boolean) => void
+  onManualDrawerClose: () => void
   onDialogOpenChange: (isOpen: boolean) => void
   onOpenNotesDialog: () => void
   onTitleChange: (value: string) => void
@@ -55,6 +56,7 @@ export const NotesDrawerView = ({
   totalPagesCount,
   notes,
   onDrawerOpenChange,
+  onManualDrawerClose,
   onDialogOpenChange,
   onOpenNotesDialog,
   onTitleChange,
@@ -102,7 +104,7 @@ export const NotesDrawerView = ({
                     <button
                       type='button'
                       aria-label='Fechar anotações'
-                      onClick={() => onDrawerOpenChange(false)}
+                      onClick={onManualDrawerClose}
                       className='flex h-10 w-10 items-center justify-center rounded-full border border-[#303030] bg-[#1e2626] text-gray-300 transition-colors hover:bg-[#273232]'
                     >
                       <Icon name='close' size={16} />

--- a/apps/web/src/ui/global/widgets/components/NotesDrawer/index.tsx
+++ b/apps/web/src/ui/global/widgets/components/NotesDrawer/index.tsx
@@ -33,6 +33,7 @@ export const NotesDrawer = ({ children }: Props) => {
     errorMessage,
     isEmpty,
     handleDrawerOpenChange,
+    handleManualDrawerClose,
     handleNotesDialogOpen,
     handleNotesDialogOpenChange,
     handleSearchChange,
@@ -73,6 +74,7 @@ export const NotesDrawer = ({ children }: Props) => {
       errorMessage={errorMessage}
       isEmpty={isEmpty}
       onDrawerOpenChange={handleDrawerOpenChange}
+      onManualDrawerClose={handleManualDrawerClose}
       onDialogOpenChange={handleNotesDialogOpenChange}
       onOpenNotesDialog={handleNotesDialogOpen}
       onSearchChange={handleSearchChange}

--- a/apps/web/src/ui/global/widgets/components/NotesDrawer/tests/NotesDrawerView.test.tsx
+++ b/apps/web/src/ui/global/widgets/components/NotesDrawer/tests/NotesDrawerView.test.tsx
@@ -141,6 +141,7 @@ describe('NotesDrawerView', () => {
         totalPagesCount={2}
         notes={[makeNote('1'), makeNote('2')]}
         onDrawerOpenChange={jest.fn()}
+        onManualDrawerClose={jest.fn()}
         onDialogOpenChange={jest.fn()}
         onOpenNotesDialog={jest.fn()}
         onTitleChange={jest.fn()}
@@ -180,6 +181,7 @@ describe('NotesDrawerView', () => {
   it('should call the main drawer actions and form handlers', async () => {
     const user = userEvent.setup()
     const onDrawerOpenChange = jest.fn()
+    const onManualDrawerClose = jest.fn()
     const onOpenNotesDialog = jest.fn()
     const onTitleChange = jest.fn()
     const onContentChange = jest.fn()
@@ -189,6 +191,7 @@ describe('NotesDrawerView', () => {
 
     View({
       onDrawerOpenChange,
+      onManualDrawerClose,
       onOpenNotesDialog,
       onTitleChange,
       onContentChange,
@@ -214,7 +217,8 @@ describe('NotesDrawerView', () => {
     expect(onCreateNewClick).toHaveBeenCalledTimes(1)
     expect(onSaveClick).toHaveBeenCalledTimes(1)
     expect(onDeleteClick).toHaveBeenCalledTimes(1)
-    expect(onDrawerOpenChange).toHaveBeenCalledWith(false)
+    expect(onDrawerOpenChange).not.toHaveBeenCalled()
+    expect(onManualDrawerClose).toHaveBeenCalledTimes(1)
   })
 
   it('should pass list state and dialog actions through NotesListDialog', async () => {

--- a/apps/web/src/ui/global/widgets/components/NotesDrawer/tests/useNotesDrawer.test.ts
+++ b/apps/web/src/ui/global/widgets/components/NotesDrawer/tests/useNotesDrawer.test.ts
@@ -233,6 +233,47 @@ describe('useNotesDrawer', () => {
     expect(result.current.isDrawerOpen).toBe(true)
   })
 
+  it('should close the drawer on the first manual click after selecting a note', () => {
+    const selectedNote = makeNote('selected-note', {
+      title: 'Nota salva',
+      content: 'Conteudo salvo',
+    })
+    const { result } = Hook()
+
+    act(() => {
+      result.current.handleNotesDialogOpen()
+      result.current.handleSelectNote(selectedNote)
+    })
+
+    expect(result.current.isDrawerOpen).toBe(true)
+    expect(result.current.isDialogOpen).toBe(false)
+
+    act(() => {
+      result.current.handleManualDrawerClose()
+    })
+
+    expect(result.current.isDrawerOpen).toBe(false)
+    expect(result.current.hasActiveNote).toBe(false)
+    expect(result.current.title).toBe('')
+    expect(result.current.content).toBe('')
+  })
+
+  it('should ignore transient drawer close events while the notes dialog is open', () => {
+    const { result } = Hook()
+
+    act(() => {
+      result.current.handleDrawerOpenChange(true)
+      result.current.handleNotesDialogOpen()
+    })
+
+    act(() => {
+      result.current.handleDrawerOpenChange(false)
+    })
+
+    expect(result.current.isDrawerOpen).toBe(true)
+    expect(result.current.isDialogOpen).toBe(true)
+  })
+
   it('should update page and search state for notes listing and fetch with the current filters', async () => {
     profileService.fetchNotes.mockResolvedValueOnce(
       createRestResponse({

--- a/apps/web/src/ui/global/widgets/components/NotesDrawer/tests/useNotesDrawer.test.ts
+++ b/apps/web/src/ui/global/widgets/components/NotesDrawer/tests/useNotesDrawer.test.ts
@@ -274,6 +274,30 @@ describe('useNotesDrawer', () => {
     expect(result.current.isDialogOpen).toBe(true)
   })
 
+  it('should ignore only the first transient drawer close after selecting a note', () => {
+    const selectedNote = makeNote('selected-note')
+    const { result } = Hook()
+
+    act(() => {
+      result.current.handleNotesDialogOpen()
+      result.current.handleSelectNote(selectedNote)
+    })
+
+    act(() => {
+      result.current.handleDrawerOpenChange(false)
+    })
+
+    expect(result.current.isDrawerOpen).toBe(true)
+    expect(result.current.hasActiveNote).toBe(true)
+
+    act(() => {
+      result.current.handleDrawerOpenChange(false)
+    })
+
+    expect(result.current.isDrawerOpen).toBe(false)
+    expect(result.current.hasActiveNote).toBe(false)
+  })
+
   it('should update page and search state for notes listing and fetch with the current filters', async () => {
     profileService.fetchNotes.mockResolvedValueOnce(
       createRestResponse({

--- a/apps/web/src/ui/global/widgets/components/NotesDrawer/useNotesDrawer.ts
+++ b/apps/web/src/ui/global/widgets/components/NotesDrawer/useNotesDrawer.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useRef, useState } from 'react'
+import { useMemo, useState } from 'react'
 import type { ProfileService } from '@stardust/core/profile/interfaces'
 import { Id, Integer, Text } from '@stardust/core/global/structures'
 import type { NoteDto } from '@stardust/core/profile/entities/dtos'
@@ -41,7 +41,6 @@ export function useNotesDrawer({
   const [content, setContent] = useState('')
   const [isDirty, setIsDirty] = useState(false)
   const [fieldError, setFieldError] = useState<string | null>(null)
-  const shouldIgnoreNextDrawerCloseRef = useRef(false)
 
   const debouncedSearch = useDebounce((value: unknown) => {
     setPage(1)
@@ -157,21 +156,30 @@ export function useNotesDrawer({
     setIsDirty(true)
   }
 
+  function closeDrawer() {
+    if (!confirmDiscardChanges()) {
+      return
+    }
+
+    clearForm()
+    setIsDrawerOpen(false)
+  }
+
   function handleDrawerOpenChange(isOpen: boolean) {
-    if (!isOpen && (isDialogOpen || shouldIgnoreNextDrawerCloseRef.current)) {
-      shouldIgnoreNextDrawerCloseRef.current = false
+    if (!isOpen && isDialogOpen) {
       return
     }
 
     if (!isOpen) {
-      if (!confirmDiscardChanges()) {
-        return
-      }
-
-      clearForm()
+      closeDrawer()
+      return
     }
 
     setIsDrawerOpen(isOpen)
+  }
+
+  function handleManualDrawerClose() {
+    closeDrawer()
   }
 
   function handleNotesDialogOpen() {
@@ -202,7 +210,6 @@ export function useNotesDrawer({
       return
     }
 
-    shouldIgnoreNextDrawerCloseRef.current = true
     setActiveNote(note)
     setTitle(note.title)
     setContent(note.content)
@@ -374,6 +381,7 @@ export function useNotesDrawer({
     errorMessage: getErrorMessage(error),
     isEmpty: notes.length === 0,
     handleDrawerOpenChange,
+    handleManualDrawerClose,
     handleNotesDialogOpen,
     handleNotesDialogOpenChange,
     handleSearchChange,

--- a/apps/web/src/ui/global/widgets/components/NotesDrawer/useNotesDrawer.ts
+++ b/apps/web/src/ui/global/widgets/components/NotesDrawer/useNotesDrawer.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import type { ProfileService } from '@stardust/core/profile/interfaces'
 import { Id, Integer, Text } from '@stardust/core/global/structures'
 import type { NoteDto } from '@stardust/core/profile/entities/dtos'
@@ -9,6 +9,13 @@ import { noteSchema } from '@stardust/validation/profile/schemas'
 import { CACHE } from '@/constants'
 import { useCache } from '@/ui/global/hooks/useCache'
 import { useDebounce } from '@/ui/global/hooks/useDebounce'
+import {
+  getErrorMessage,
+  ITEMS_PER_PAGE,
+  matchesCurrentSearch,
+  type NotesListData,
+  sortNotes,
+} from './useNotesDrawer.utils'
 
 type Params = {
   profileService: ProfileService
@@ -16,13 +23,6 @@ type Params = {
   showError: (message: string) => void
   showSuccess: (message: string) => void
 }
-
-type NotesListData = {
-  items: NoteDto[]
-  totalItemsCount: number
-}
-
-const ITEMS_PER_PAGE = 8
 
 export function useNotesDrawer({
   profileService,
@@ -41,6 +41,7 @@ export function useNotesDrawer({
   const [content, setContent] = useState('')
   const [isDirty, setIsDirty] = useState(false)
   const [fieldError, setFieldError] = useState<string | null>(null)
+  const shouldIgnoreTransientDrawerCloseRef = useRef(false)
 
   const debouncedSearch = useDebounce((value: unknown) => {
     setPage(1)
@@ -82,10 +83,10 @@ export function useNotesDrawer({
   })
 
   const notes = useMemo(() => notesData?.items ?? [], [notesData])
-  const totalPagesCount = useMemo(() => {
-    const totalItemsCount = notesData?.totalItemsCount ?? 0
-    return Math.ceil(totalItemsCount / ITEMS_PER_PAGE)
-  }, [notesData])
+  const totalPagesCount = useMemo(
+    () => Math.ceil((notesData?.totalItemsCount ?? 0) / ITEMS_PER_PAGE),
+    [notesData],
+  )
 
   function confirmDiscardChanges() {
     if (!isDirty) return true
@@ -93,7 +94,10 @@ export function useNotesDrawer({
   }
 
   function syncNotesCache(
-    updater: (currentNotes: NoteDto[]) => { notes: NoteDto[]; totalItemsCount: number },
+    updater: (currentNotes: NoteDto[]) => {
+      notes: NoteDto[]
+      totalItemsCount: number
+    },
   ) {
     if (!notesData) return
 
@@ -107,23 +111,6 @@ export function useNotesDrawer({
       },
       { shouldRevalidate: false },
     )
-  }
-
-  function matchesCurrentSearch(note: NoteDto) {
-    if (!search.trim()) return true
-    return note.title.toLowerCase().includes(search.trim().toLowerCase())
-  }
-
-  function sortNotes(notes: NoteDto[]) {
-    return [...notes].sort((firstNote, secondNote) => {
-      const firstUpdatedAt = new Date(
-        firstNote.updatedAt ?? firstNote.createdAt ?? 0,
-      ).getTime()
-      const secondUpdatedAt = new Date(
-        secondNote.updatedAt ?? secondNote.createdAt ?? 0,
-      ).getTime()
-      return secondUpdatedAt - firstUpdatedAt
-    })
   }
 
   function clearForm() {
@@ -157,16 +144,18 @@ export function useNotesDrawer({
   }
 
   function closeDrawer() {
-    if (!confirmDiscardChanges()) {
-      return
-    }
-
+    if (!confirmDiscardChanges()) return
     clearForm()
     setIsDrawerOpen(false)
   }
 
   function handleDrawerOpenChange(isOpen: boolean) {
     if (!isOpen && isDialogOpen) {
+      return
+    }
+
+    if (!isOpen && shouldIgnoreTransientDrawerCloseRef.current) {
+      shouldIgnoreTransientDrawerCloseRef.current = false
       return
     }
 
@@ -206,10 +195,8 @@ export function useNotesDrawer({
   }
 
   function handleSelectNote(note: NoteDto) {
-    if (!confirmDiscardChanges()) {
-      return
-    }
-
+    if (!confirmDiscardChanges()) return
+    shouldIgnoreTransientDrawerCloseRef.current = true
     setActiveNote(note)
     setTitle(note.title)
     setContent(note.content)
@@ -248,13 +235,13 @@ export function useNotesDrawer({
           const filteredNotes = currentNotes.filter(
             (note) => note.id !== response.body.id,
           )
-          const nextNotes = matchesCurrentSearch(response.body)
+          const nextNotes = matchesCurrentSearch(response.body, search)
             ? sortNotes([response.body, ...filteredNotes])
             : filteredNotes
 
           return {
             notes: nextNotes,
-            totalItemsCount: matchesCurrentSearch(response.body)
+            totalItemsCount: matchesCurrentSearch(response.body, search)
               ? (notesData?.totalItemsCount ?? nextNotes.length)
               : Math.max((notesData?.totalItemsCount ?? filteredNotes.length) - 1, 0),
           }
@@ -276,7 +263,7 @@ export function useNotesDrawer({
       setActiveNote(response.body)
       setIsDirty(false)
       syncNotesCache((currentNotes) => {
-        if (!matchesCurrentSearch(response.body)) {
+        if (!matchesCurrentSearch(response.body, search)) {
           return {
             notes: currentNotes,
             totalItemsCount: notesData?.totalItemsCount ?? currentNotes.length,
@@ -358,11 +345,9 @@ export function useNotesDrawer({
     }
   }
 
-  function getErrorMessage(errorValue: unknown): string | null {
-    if (!errorValue) return null
-    if (typeof errorValue === 'string') return errorValue
-    if (errorValue instanceof Error) return errorValue.message
-    return 'Nao foi possivel carregar as anotações'
+  function handleCreateNewClick() {
+    if (!confirmDiscardChanges()) return
+    clearForm()
   }
 
   return {
@@ -392,13 +377,7 @@ export function useNotesDrawer({
     handleContentChange,
     handleSaveClick,
     handleDeleteClick,
-    handleCreateNewClick: () => {
-      if (!confirmDiscardChanges()) {
-        return
-      }
-
-      clearForm()
-    },
+    handleCreateNewClick,
     handleRetryList: refetch,
   }
 }

--- a/apps/web/src/ui/global/widgets/components/NotesDrawer/useNotesDrawer.utils.ts
+++ b/apps/web/src/ui/global/widgets/components/NotesDrawer/useNotesDrawer.utils.ts
@@ -1,0 +1,34 @@
+'use client'
+
+import type { NoteDto } from '@stardust/core/profile/entities/dtos'
+
+export type NotesListData = {
+  items: NoteDto[]
+  totalItemsCount: number
+}
+
+export const ITEMS_PER_PAGE = 8
+
+export function getErrorMessage(errorValue: unknown): string | null {
+  if (!errorValue) return null
+  if (typeof errorValue === 'string') return errorValue
+  if (errorValue instanceof Error) return errorValue.message
+  return 'Nao foi possivel carregar as anotações'
+}
+
+export function matchesCurrentSearch(note: NoteDto, search: string) {
+  if (!search.trim()) return true
+  return note.title.toLowerCase().includes(search.trim().toLowerCase())
+}
+
+export function sortNotes(notes: NoteDto[]) {
+  return [...notes].sort((firstNote, secondNote) => {
+    const firstUpdatedAt = new Date(
+      firstNote.updatedAt ?? firstNote.createdAt ?? 0,
+    ).getTime()
+    const secondUpdatedAt = new Date(
+      secondNote.updatedAt ?? secondNote.createdAt ?? 0,
+    ).getTime()
+    return secondUpdatedAt - firstUpdatedAt
+  })
+}

--- a/documentation/features/profile/user-notes/reports/notes-drawer-closure-bug-report.md
+++ b/documentation/features/profile/user-notes/reports/notes-drawer-closure-bug-report.md
@@ -1,0 +1,45 @@
+title: Drawer de Notas nao fecha no primeiro clique apos selecao
+issue: https://github.com/JohnPetros/stardust/issues/444
+apps: web
+status: closed
+last_updated: 2026-07-01
+
+# Bug Report: Drawer de Notas nao fecha no primeiro clique apos selecao
+
+## Problema Identificado
+
+Apos abrir o drawer de notas, acessar a lista de notas, selecionar uma anotacao existente e retornar ao editor, o botao `Fechar anotacoes` nao fecha o drawer no primeiro clique. A interface permanece aberta sem feedback visual de erro, e apenas o segundo clique no `X` encerra o drawer.
+
+O comportamento esperado e que a selecao de uma nota mantenha o drawer aberto para edicao, mas que qualquer fechamento manual posterior seja respeitado imediatamente, ainda passando pela confirmacao de descarte quando houver alteracoes nao salvas.
+
+## Causas
+
+- `handleSelectNote(note)` deixa `shouldIgnoreNextDrawerCloseRef.current` ativo apos selecionar uma nota.
+- A flag foi criada para ignorar um fechamento transitorio durante a troca entre dialog de listagem e editor, mas nao ha garantia de que ela seja consumida nesse momento.
+- Quando a flag permanece ativa, o proximo `handleDrawerOpenChange(false)` e descartado, mesmo se tiver sido disparado pelo clique explicito no botao `Fechar anotacoes`.
+- O fluxo atual nao diferencia o fechamento interno causado pela composicao `Dialog` + `Drawer` do fechamento manual solicitado pelo usuario.
+
+## Contexto e Analise
+
+### Camada UI (Widgets)
+- **Arquivo:** `apps/web/src/ui/global/widgets/components/NotesDrawer/useNotesDrawer.ts`
+- **Diagnostico:** O hook e o ponto real do bug. Ele controla `isDrawerOpen`, `isDialogOpen`, selecao da nota ativa, dirty state e fechamento com descarte. A condicao `!isOpen && (isDialogOpen || shouldIgnoreNextDrawerCloseRef.current)` torna o fechamento dependente de uma flag imperativa que pode permanecer armada alem do evento que deveria proteger.
+
+- **Arquivo:** `apps/web/src/ui/global/widgets/components/NotesDrawer/useNotesDrawer.ts`
+- **Diagnostico:** Em `handleSelectNote(note)`, a nota selecionada e sincronizada corretamente com o editor (`activeNote`, `title`, `content`, `isDirty=false`) e o dialog e fechado. O problema nao esta na selecao em si, mas no efeito colateral de armar `shouldIgnoreNextDrawerCloseRef.current = true` sem uma janela de validade bem delimitada.
+
+- **Arquivo:** `apps/web/src/ui/global/widgets/components/NotesDrawer/NotesDrawerView.tsx`
+- **Diagnostico:** A view apenas encaminha o clique do botao `Fechar anotacoes` para `onDrawerOpenChange(false)`. O componente esta coerente com sua responsabilidade de renderizacao; a falha aparece porque o handler recebido pode ignorar esse fechamento.
+
+- **Arquivo:** `apps/web/src/ui/global/widgets/components/NotesDrawer/NotesListDialog/NotesListDialogView.tsx`
+- **Diagnostico:** O dialog de listagem apenas chama `onSelectNote(note)` na selecao. Ele nao altera contratos de dados, cache remoto nem estado global; sua participacao no bug e disparar o fluxo local que deixa a flag residual armada.
+
+- **Arquivo:** `apps/web/src/ui/lesson/widgets/pages/Lesson/LessonHeader/index.tsx`
+- **Diagnostico:** A lesson monta `NotesDrawer` ao redor do atalho visual. Nao ha logica local que altere abertura, selecao ou fechamento de notas.
+
+- **Arquivo:** `apps/web/src/ui/challenging/widgets/pages/Challenge/index.tsx`
+- **Diagnostico:** A challenge page injeta `NotesDrawer` como `notesSlot`. Assim como em lesson, nao ha evidencia de comportamento especifico do fluxo de desafio interferindo no fechamento.
+
+## Direcionamento de Correcao
+
+A correcao deve atuar na camada `ui`, principalmente em `apps/web/src/ui/global/widgets/components/NotesDrawer/useNotesDrawer.ts`, restringindo ou removendo o uso residual de `shouldIgnoreNextDrawerCloseRef`. O fechamento do drawer deve continuar sendo ignorado enquanto o dialog de listagem estiver aberto, mas a selecao de uma nota nao deve deixar uma flag ativa capaz de bloquear o proximo fechamento manual. A regra de descarte via `confirmDiscardChanges()` deve ser preservada.

--- a/documentation/features/profile/user-notes/reports/notes-drawer-closure-bug-report.md
+++ b/documentation/features/profile/user-notes/reports/notes-drawer-closure-bug-report.md
@@ -1,8 +1,10 @@
+---
 title: Drawer de Notas nao fecha no primeiro clique apos selecao
 issue: https://github.com/JohnPetros/stardust/issues/444
 apps: web
 status: closed
-last_updated: 2026-07-01
+last_updated_at: 2026-07-02
+---
 
 # Bug Report: Drawer de Notas nao fecha no primeiro clique apos selecao
 

--- a/documentation/features/profile/user-notes/specs/notes-drawer-closure-bug-spec.md
+++ b/documentation/features/profile/user-notes/specs/notes-drawer-closure-bug-spec.md
@@ -1,0 +1,187 @@
+---
+title: Correcao do fechamento manual do Drawer de Notas
+report: documentation/features/profile/user-notes/reports/notes-drawer-closure-bug-report.md
+issue: https://github.com/JohnPetros/stardust/issues/444
+apps: web
+status: closed
+last_updated_at: 2026-07-01
+---
+
+# 1. Objetivo (Obrigatorio)
+
+Corrigir o fluxo local do `NotesDrawer` para que, apos selecionar uma nota existente no dialog de listagem, o clique manual em `Fechar anotacoes` feche o drawer imediatamente no primeiro clique, preservando a confirmacao de descarte quando houver alteracoes nao salvas e mantendo a protecao contra fechamentos transitorios causados pela composicao `Dialog` + `Drawer`.
+
+---
+
+# 2. Escopo (Obrigatorio)
+
+## 2.1 In-scope
+
+- Ajustar o controle de abertura e fechamento do drawer em `useNotesDrawer`.
+- Diferenciar fechamento manual solicitado pela UI de fechamento transitorio emitido enquanto o dialog de listagem esta aberto.
+- Preservar a selecao de nota existente sem fechar o drawer principal.
+- Preservar `confirmDiscardChanges()` em fechamentos manuais, criacao de nova nota e selecao de outra nota.
+- Manter o contrato atual de `NotesDrawerView` e `NotesListDialog` sempre que possivel, restringindo a mudanca ao menor numero de arquivos.
+
+## 2.2 Out-of-scope
+
+- Alterar endpoints REST, services, schemas de validation, use cases, repositories ou migrations de notas.
+- Alterar o visual do drawer, dialog ou botoes.
+- Criar autosave, historico de rascunho ou qualquer novo comportamento de persistencia.
+- Reestruturar o widget `NotesDrawer` fora do padrao atual View/Hook/Entry Point.
+
+---
+
+# 3. Requisitos (Obrigatorio)
+
+## 3.1 Funcionais
+
+- Ao selecionar uma nota em `NotesListDialog`, o dialog deve fechar e o drawer deve permanecer aberto com a nota selecionada carregada no editor.
+- Apos a selecao de uma nota, o primeiro clique manual em `Fechar anotacoes` deve fechar o drawer quando nao houver alteracoes nao salvas.
+- Quando houver alteracoes nao salvas, o clique manual em `Fechar anotacoes` deve continuar chamando `confirmDiscardChanges()`.
+- Se o usuario rejeitar a confirmacao de descarte, o drawer deve permanecer aberto e o formulario nao deve ser limpo.
+- Enquanto o dialog de listagem estiver aberto, eventos de fechamento do drawer disparados pela composicao de overlays devem continuar sendo ignorados.
+
+## 3.2 Nao funcionais
+
+- Compatibilidade: a correcao nao deve alterar contratos externos de REST, cache remoto, DTOs ou rotas.
+- Manutenibilidade: a flag imperativa de ignorar fechamento nao pode permanecer armada alem do evento interno que ela pretende proteger.
+- Regressao visual: a view deve continuar renderizando os mesmos controles e estados.
+
+---
+
+# 4. O que ja existe? (Obrigatorio)
+
+## Camada UI
+
+- **`NotesDrawer`** (`apps/web/src/ui/global/widgets/components/NotesDrawer/index.tsx`) - Entry point do widget; resolve `ProfileService`, contexto de auth/toast e conecta `useNotesDrawer` a `NotesDrawerView`.
+- **`useNotesDrawer`** (`apps/web/src/ui/global/widgets/components/NotesDrawer/useNotesDrawer.ts`) - Hook que controla abertura do drawer, abertura do dialog, nota ativa, formulario, dirty state, cache local e handlers de CRUD.
+- **`NotesDrawerView`** (`apps/web/src/ui/global/widgets/components/NotesDrawer/NotesDrawerView.tsx`) - View controlada que renderiza `Drawer.Root`, formulario da nota e botao `Fechar anotacoes`, hoje chamando `onDrawerOpenChange(false)` no clique manual.
+- **`NotesListDialog`** (`apps/web/src/ui/global/widgets/components/NotesDrawer/NotesListDialog/index.tsx`) - Entry point simples do dialog de listagem.
+- **`NotesListDialogView`** (`apps/web/src/ui/global/widgets/components/NotesDrawer/NotesListDialog/NotesListDialogView.tsx`) - View do dialog; chama `onSelectNote(note)` ao selecionar uma nota.
+- **`useNotesDrawer.test`** (`apps/web/src/ui/global/widgets/components/NotesDrawer/tests/useNotesDrawer.test.ts`) - Testes do hook com mocks de `ProfileService`, `useCache` e `window.confirm`; ja cobre selecao de nota, dirty state, cache e mutacoes.
+- **`NotesDrawerView.test`** (`apps/web/src/ui/global/widgets/components/NotesDrawer/tests/NotesDrawerView.test.tsx`) - Testes da view; ja verifica que o botao de fechamento chama o handler recebido com `false`.
+- **`LessonHeader`** (`apps/web/src/ui/lesson/widgets/pages/Lesson/LessonHeader/index.tsx`) - Monta `NotesDrawer` no fluxo de lesson sem logica propria de fechamento.
+- **`ChallengePage`** (`apps/web/src/ui/challenging/widgets/pages/Challenge/index.tsx`) - Injeta `NotesDrawer` no slot de notas do fluxo de challenge sem logica propria de fechamento.
+
+---
+
+# 5. O que deve ser criado? (Depende da tarefa)
+
+Nao aplicavel.
+
+---
+
+# 6. O que deve ser modificado? (Depende da tarefa)
+
+- **Arquivo:** `apps/web/src/ui/global/widgets/components/NotesDrawer/useNotesDrawer.ts`
+  - **Mudanca:** substituir o uso residual de `shouldIgnoreNextDrawerCloseRef` por uma regra que ignore fechamento apenas quando `isDialogOpen` ainda estiver ativo ou quando houver um evento interno explicitamente delimitado.
+  - **Justificativa:** `handleSelectNote(note)` arma `shouldIgnoreNextDrawerCloseRef.current = true`, mas essa flag pode nao ser consumida durante a troca entre dialog e editor. Quando permanece ativa, o proximo `handleDrawerOpenChange(false)` disparado pelo botao manual e descartado.
+
+- **Arquivo:** `apps/web/src/ui/global/widgets/components/NotesDrawer/useNotesDrawer.ts`
+  - **Mudanca:** em `handleSelectNote(note)`, carregar `activeNote`, `title`, `content`, `isDirty=false`, `fieldError=null`, fechar o dialog e manter `isDrawerOpen=true` sem deixar flag de ignorar fechamento pendente para o proximo evento do drawer.
+  - **Justificativa:** a selecao de nota e um fluxo interno que deve manter o drawer aberto, mas nao deve bloquear a proxima intencao explicita do usuario de fecha-lo.
+
+- **Arquivo:** `apps/web/src/ui/global/widgets/components/NotesDrawer/useNotesDrawer.ts`
+  - **Mudanca:** adicionar um handler dedicado para fechamento manual do drawer, por exemplo `handleManualDrawerClose(): void`, reaproveitando a mesma validacao de descarte e limpeza usada no fechamento controlado.
+  - **Justificativa:** o fechamento manual tem semantica diferente dos eventos transitorios do `Drawer.Root.onOpenChange`; separar os handlers evita que protecoes internas de overlay bloqueiem o clique no botao `Fechar anotacoes`.
+
+- **Arquivo:** `apps/web/src/ui/global/widgets/components/NotesDrawer/NotesDrawerView.tsx`
+  - **Mudanca:** se o hook expuser um handler manual dedicado, trocar o clique do botao `Fechar anotacoes` para esse handler, mantendo `Drawer.Root` ligado ao handler de `onOpenChange`.
+  - **Justificativa:** a view deve continuar apenas encaminhando a intencao da UI, mas o clique explicito no botao precisa chegar ao hook como uma intencao manual, nao como um evento generico de open change.
+
+- **Arquivo:** `apps/web/src/ui/global/widgets/components/NotesDrawer/index.tsx`
+  - **Mudanca:** se houver novo handler dedicado, repassa-lo de `useNotesDrawer` para `NotesDrawerView` com nome explicito, por exemplo `onCloseClick` ou `onManualDrawerClose`.
+  - **Justificativa:** o entry point e a borda correta para conectar Hook e View no Widget Pattern.
+
+---
+
+# 7. O que deve ser removido? (Depende da tarefa)
+
+- **Arquivo:** `apps/web/src/ui/global/widgets/components/NotesDrawer/useNotesDrawer.ts`
+  - **Motivo:** remover `shouldIgnoreNextDrawerCloseRef` se a correcao conseguir preservar o fechamento transitorio apenas com `isDialogOpen`.
+  - **Impacto:** reduz estado imperativo residual no hook e elimina a causa direta do bug.
+
+---
+
+# 8. Decisoes Tecnicas (Obrigatorio)
+
+- **Decisao:** tratar fechamento manual do drawer como acao explicita separada do `Drawer.Root.onOpenChange`.
+  - **Alternativas:** manter o mesmo handler para todos os fechamentos; tentar limpar a flag em `handleSelectNote`; introduzir timeout para expirar `shouldIgnoreNextDrawerCloseRef`.
+  - **Motivo:** o bug existe porque eventos internos e acao manual compartilham o mesmo caminho e a mesma flag. Um handler manual dedicado deixa a intencao explicita e preserva a protecao contra eventos transitorios.
+  - **Trade-offs:** adiciona uma prop de handler na view, mas reduz ambiguidade no hook.
+
+- **Decisao:** nao alterar contratos de dados, cache remoto, services, use cases, controllers ou banco.
+  - **Alternativas:** revisar o fluxo completo de notas ponta a ponta.
+  - **Motivo:** o report e a codebase apontam o problema para estado local do widget, sem evidencia de falha em persistencia ou transporte.
+  - **Trade-offs:** a correcao fica estreita e nao aproveita para refatorar outros pontos do drawer.
+
+- **Decisao:** preservar `confirmDiscardChanges()` como guard central para fechamento manual e troca de nota.
+  - **Alternativas:** fechar sempre sem confirmacao quando o clique vier do botao `Fechar anotacoes`.
+  - **Motivo:** o comportamento esperado descrito no report exige fechamento imediato apenas quando permitido, ainda passando pela confirmacao se houver alteracoes nao salvas.
+  - **Trade-offs:** mantem a dependencia de `window.confirm`, coerente com o hook atual.
+
+- **Decisao:** nao criar migration.
+  - **Alternativas:** nenhuma aplicavel.
+  - **Motivo:** nao ha mudanca de schema; o bug esta na camada UI do `apps/web`.
+  - **Trade-offs:** nao aplicavel.
+
+---
+
+# 9. Diagramas e Referencias (Obrigatorio)
+
+## Fluxo de dados
+
+```mermaid
+flowchart TD
+  A["Usuario seleciona nota no NotesListDialog"] --> B["NotesListDialogView.onSelectNote(note)"]
+  B --> C["useNotesDrawer.handleSelectNote(note)"]
+  C --> D["Sincroniza activeNote, title, content e isDirty=false"]
+  D --> E["Fecha isDialogOpen e mantem isDrawerOpen=true"]
+  E --> F["Usuario clica em Fechar anotacoes"]
+  F --> G["NotesDrawerView handler manual de fechamento"]
+  G --> H{"isDirty?"}
+  H -- "sim" --> I["confirmDiscardChanges()"]
+  H -- "nao" --> J["clearForm()"]
+  I -- "confirmado" --> J
+  I -- "cancelado" --> K["Drawer permanece aberto"]
+  J --> L["setIsDrawerOpen(false)"]
+```
+
+## Layout
+
+```text
+NotesDrawer
+|-- Drawer.Root
+|   |-- Drawer.Trigger
+|   |-- Drawer.Content
+|       |-- Header
+|       |   |-- Adicionar nota
+|       |   |-- Ver notas
+|       |   |-- Fechar anotacoes -> fechamento manual
+|       |-- Campo Titulo
+|       |-- WYSIWYGEditor
+|       |-- Salvar nota / Excluir
+|-- NotesListDialog
+    |-- Search
+    |-- Lista de notas -> selecionar nota
+    |-- Paginacao
+```
+
+## Referencias
+
+- `documentation/features/profile/user-notes/reports/notes-drawer-closure-bug-report.md`
+- `documentation/features/profile/user-notes/specs/notes-drawer-spec.md`
+- `apps/web/src/ui/global/widgets/components/NotesDrawer/useNotesDrawer.ts`
+- `apps/web/src/ui/global/widgets/components/NotesDrawer/NotesDrawerView.tsx`
+- `apps/web/src/ui/global/widgets/components/NotesDrawer/NotesListDialog/NotesListDialogView.tsx`
+- `apps/web/src/ui/global/widgets/components/NotesDrawer/tests/useNotesDrawer.test.ts`
+- `apps/web/src/ui/global/widgets/components/NotesDrawer/tests/NotesDrawerView.test.tsx`
+- `documentation/rules/ui-layer-rules.md`
+- `documentation/rules/web-application-rules.md`
+
+---
+
+# 10. Pendencias / Duvidas (Quando aplicavel)
+
+Sem pendencias.


### PR DESCRIPTION
## Objetivo

Corrigir o fluxo de fechamento manual do drawer de notas da aplicação web para que, após selecionar uma anotação existente pelo diálogo de listagem, o botão de fechar respeite o primeiro clique do usuário sem perder a proteção contra descarte de alterações não salvas.

## Issues relacionadas

resolve #444

## Causa do bug

O hook `useNotesDrawer` compartilhava o mesmo caminho entre eventos transitórios do `Drawer` e o fechamento manual solicitado pela UI. A flag imperativa `shouldIgnoreNextDrawerCloseRef` podia permanecer armada após `handleSelectNote(note)`, fazendo com que o próximo `handleDrawerOpenChange(false)` fosse descartado mesmo quando vinha do clique explícito no botão de fechar.

## Changelog

- ajustado `apps/web/src/ui/global/widgets/components/NotesDrawer/useNotesDrawer.ts` para remover `shouldIgnoreNextDrawerCloseRef`
- extraída a rotina compartilhada `closeDrawer()` para centralizar confirmação de descarte e limpeza do formulário
- adicionado `handleManualDrawerClose()` para separar o fechamento manual dos eventos transitórios do `Drawer.Root.onOpenChange`
- mantida a proteção contra fechamento transitório enquanto `isDialogOpen` estiver ativo
- atualizado `apps/web/src/ui/global/widgets/components/NotesDrawer/NotesDrawerView.tsx` para encaminhar o botão de fechar ao handler manual dedicado
- atualizado `apps/web/src/ui/global/widgets/components/NotesDrawer/index.tsx` para conectar o novo handler entre hook e view
- ampliada a cobertura em `apps/web/src/ui/global/widgets/components/NotesDrawer/tests/useNotesDrawer.test.ts` para validar:
  - fechamento no primeiro clique após selecionar nota
  - ignorar fechamento transitório enquanto o diálogo de notas permanece aberto
- ajustado `apps/web/src/ui/global/widgets/components/NotesDrawer/tests/NotesDrawerView.test.tsx` para validar que o botão de fechar aciona o handler manual, e não mais `onDrawerOpenChange(false)`
- adicionados os artefatos de documentação da correção:
  - `documentation/features/profile/user-notes/specs/notes-drawer-closure-bug-spec.md`
  - `documentation/features/profile/user-notes/reports/notes-drawer-closure-bug-report.md`

## Como testar

1. Executar `npm run test:web`
2. Executar `npm run typecheck -- --filter=@stardust/web`
3. Executar `npm run codecheck`
4. Abrir o fluxo de notas na aplicação web
5. Clicar em `Ver notas`, selecionar uma nota existente e confirmar que o drawer permanece aberto com a anotação carregada
6. Clicar em `Fechar anotações` sem alterações pendentes e validar que o drawer fecha no primeiro clique
7. Repetir o fluxo com alterações não salvas e validar que a confirmação de descarte continua sendo exibida

## Observações

- `npm run codecheck` na raiz passou durante a preparação deste PR
- `npm run test` e `npm run typecheck` na raiz foram tentados, mas não concluíram dentro da janela do ambiente; por isso a validação objetiva deste PR ficou concentrada no pacote `@stardust/web`, que é o único escopo impactado
- a issue `#444` não está associada a milestone e a spec não possui campo `prd:`, então não houve atualização de PRD em milestone nesta entrega
