### PR TITLE
Correção da centralização da última estrela desbloqueada

### DIFF
--- a/apps/web/src/ui/space/contexts/SpaceContext/lastUnlockedStarLayout.ts
+++ b/apps/web/src/ui/space/contexts/SpaceContext/lastUnlockedStarLayout.ts
@@ -1,0 +1,85 @@
+export type LastUnlockedStarLayoutMetrics = {
+  starRect: DOMRect
+  scrollContainer: HTMLElement | null
+  scrollTop: number
+  scrollHeight: number
+  clientHeight: number
+  containerRect: DOMRect | null
+}
+
+const SCROLL_CENTER_TOLERANCE_IN_PX = 4
+
+export function createLastUnlockedStarLayoutMetrics(
+  starElement: HTMLDivElement,
+  scrollContainer: HTMLElement | null,
+): LastUnlockedStarLayoutMetrics {
+  const starRect = starElement.getBoundingClientRect()
+
+  if (scrollContainer) {
+    return {
+      starRect,
+      scrollContainer,
+      scrollTop: scrollContainer.scrollTop,
+      scrollHeight: scrollContainer.scrollHeight,
+      clientHeight: scrollContainer.clientHeight,
+      containerRect: scrollContainer.getBoundingClientRect(),
+    }
+  }
+
+  return {
+    starRect,
+    scrollContainer: null,
+    scrollTop: window.scrollY,
+    scrollHeight: document.documentElement.scrollHeight,
+    clientHeight: window.innerHeight,
+    containerRect: null,
+  }
+}
+
+export function getLastUnlockedStarLayoutSnapshot(
+  layoutMetrics: LastUnlockedStarLayoutMetrics,
+) {
+  const { starRect, scrollTop, scrollHeight, clientHeight, containerRect } = layoutMetrics
+
+  return [
+    Math.round(starRect.top),
+    Math.round(starRect.bottom),
+    Math.round(starRect.height),
+    Math.round(scrollTop),
+    Math.round(scrollHeight),
+    Math.round(clientHeight),
+    Math.round(containerRect?.top ?? 0),
+    Math.round(containerRect?.bottom ?? 0),
+    Math.round(containerRect?.height ?? 0),
+  ].join(':')
+}
+
+export function isLastUnlockedStarCentered(layoutMetrics: LastUnlockedStarLayoutMetrics) {
+  const { starRect, containerRect, scrollContainer } = layoutMetrics
+  const starCenter = starRect.top + starRect.height / 2
+
+  if (scrollContainer && containerRect) {
+    const viewportCenter = containerRect.top + containerRect.height / 2
+
+    return Math.abs(starCenter - viewportCenter) <= SCROLL_CENTER_TOLERANCE_IN_PX
+  }
+
+  return Math.abs(starCenter - window.innerHeight / 2) <= SCROLL_CENTER_TOLERANCE_IN_PX
+}
+
+export function getLastUnlockedStarScrollTarget(
+  layoutMetrics: LastUnlockedStarLayoutMetrics,
+) {
+  const { starRect, scrollContainer, containerRect } = layoutMetrics
+
+  if (scrollContainer && containerRect) {
+    return (
+      scrollContainer.scrollTop +
+      (starRect.top - containerRect.top) -
+      (scrollContainer.clientHeight - starRect.height) / 2
+    )
+  }
+
+  const starTopPosition = starRect.top + window.scrollY
+  return starTopPosition - (window.innerHeight - starRect.height) / 2
+}

--- a/apps/web/src/ui/space/contexts/SpaceContext/tests/useSpaceContextProvider.test.ts
+++ b/apps/web/src/ui/space/contexts/SpaceContext/tests/useSpaceContextProvider.test.ts
@@ -33,9 +33,14 @@ describe('useSpaceContextProvider', () => {
   }
 
   beforeEach(() => {
+    jest.useFakeTimers()
     jest.clearAllMocks()
     jest.restoreAllMocks()
     document.body.innerHTML = ''
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
   })
 
   it('should return null as last unlocked star id when user is null', () => {
@@ -205,6 +210,109 @@ describe('useSpaceContextProvider', () => {
       top: 240,
       behavior: 'smooth',
     })
+  })
+
+  it('should retry centering when layout keeps shifting after the first scroll', () => {
+    const planets = PlanetsFaker.fakeMany(1)
+    const user = UsersFaker.fake()
+    const starElement = document.createElement('div')
+    const scrollContainer = document.createElement('section')
+    const containerScrollTo = jest.fn(({ top }: { top: number }) => {
+      scrollContainer.scrollTop = top
+    })
+
+    scrollContainer.style.overflowY = 'auto'
+    Object.defineProperty(scrollContainer, 'clientHeight', {
+      value: 200,
+      configurable: true,
+    })
+    Object.defineProperty(scrollContainer, 'scrollHeight', {
+      value: 800,
+      configurable: true,
+    })
+    Object.defineProperty(scrollContainer, 'scrollTop', {
+      value: 120,
+      configurable: true,
+      writable: true,
+    })
+    Object.defineProperty(scrollContainer, 'scrollTo', {
+      value: containerScrollTo,
+      configurable: true,
+    })
+
+    scrollContainer.appendChild(starElement)
+    document.body.appendChild(scrollContainer)
+
+    jest
+      .spyOn(scrollContainer, 'getBoundingClientRect')
+      .mockReturnValue(createRect({ top: 100, bottom: 300, height: 200 }))
+    jest
+      .spyOn(starElement, 'getBoundingClientRect')
+      .mockReturnValueOnce(createRect({ top: 320, bottom: 360, height: 40 }))
+      .mockReturnValueOnce(createRect({ top: 260, bottom: 300, height: 40 }))
+      .mockReturnValueOnce(createRect({ top: 260, bottom: 300, height: 40 }))
+      .mockReturnValue(createRect({ top: 180, bottom: 220, height: 40 }))
+
+    const { result } = renderHook(() => useSpaceContextProvider(planets, user))
+
+    setLastUnlockedStarRef(result.current.lastUnlockedStarRef, starElement)
+
+    act(() => {
+      result.current.scrollIntoLastUnlockedStar()
+    })
+
+    expect(containerScrollTo).toHaveBeenNthCalledWith(1, {
+      top: 260,
+      behavior: 'smooth',
+    })
+
+    act(() => {
+      jest.advanceTimersByTime(150)
+    })
+
+    expect(containerScrollTo).toHaveBeenNthCalledWith(2, {
+      top: 260,
+      behavior: 'smooth',
+    })
+  })
+
+  it('should expose a layout snapshot based on the resolved scroll container', () => {
+    const planets = PlanetsFaker.fakeMany(1)
+    const user = UsersFaker.fake()
+    const starElement = document.createElement('div')
+    const scrollContainer = document.createElement('section')
+
+    scrollContainer.style.overflowY = 'auto'
+    Object.defineProperty(scrollContainer, 'scrollHeight', {
+      value: 1800,
+      configurable: true,
+    })
+    Object.defineProperty(scrollContainer, 'clientHeight', {
+      value: 320,
+      configurable: true,
+    })
+    Object.defineProperty(scrollContainer, 'scrollTop', {
+      value: 480,
+      configurable: true,
+    })
+
+    scrollContainer.appendChild(starElement)
+    document.body.appendChild(scrollContainer)
+
+    jest
+      .spyOn(starElement, 'getBoundingClientRect')
+      .mockReturnValue(createRect({ top: 640, bottom: 720, height: 80 }))
+    jest
+      .spyOn(scrollContainer, 'getBoundingClientRect')
+      .mockReturnValue(createRect({ top: 100, bottom: 420, height: 320 }))
+
+    const { result } = renderHook(() => useSpaceContextProvider(planets, user))
+
+    setLastUnlockedStarRef(result.current.lastUnlockedStarRef, starElement)
+
+    expect(result.current.getLastUnlockedStarLayoutSnapshot()).toBe(
+      '640:720:80:480:1800:320:100:420:320',
+    )
   })
 
   it('should track scroll position on container after user refetch', () => {

--- a/apps/web/src/ui/space/contexts/SpaceContext/tests/useSpaceContextProvider.test.ts
+++ b/apps/web/src/ui/space/contexts/SpaceContext/tests/useSpaceContextProvider.test.ts
@@ -217,9 +217,12 @@ describe('useSpaceContextProvider', () => {
     const user = UsersFaker.fake()
     const starElement = document.createElement('div')
     const scrollContainer = document.createElement('section')
+    let isRecentering = false
+    let recenterLayoutReads = 0
     const containerScrollTo = jest.fn(({ top }: { top: number }) => {
       scrollContainer.scrollTop = top
     })
+    jest.spyOn(window, 'requestAnimationFrame').mockReturnValue(1)
 
     scrollContainer.style.overflowY = 'auto'
     Object.defineProperty(scrollContainer, 'clientHeight', {
@@ -246,16 +249,29 @@ describe('useSpaceContextProvider', () => {
     jest
       .spyOn(scrollContainer, 'getBoundingClientRect')
       .mockReturnValue(createRect({ top: 100, bottom: 300, height: 200 }))
-    jest
-      .spyOn(starElement, 'getBoundingClientRect')
-      .mockReturnValueOnce(createRect({ top: 320, bottom: 360, height: 40 }))
-      .mockReturnValueOnce(createRect({ top: 260, bottom: 300, height: 40 }))
-      .mockReturnValueOnce(createRect({ top: 260, bottom: 300, height: 40 }))
-      .mockReturnValue(createRect({ top: 180, bottom: 220, height: 40 }))
+    jest.spyOn(starElement, 'getBoundingClientRect').mockImplementation(() => {
+      if (!isRecentering) {
+        return createRect({ top: 180, bottom: 220, height: 40 })
+      }
+
+      recenterLayoutReads += 1
+
+      if (recenterLayoutReads === 1) {
+        return createRect({ top: 320, bottom: 360, height: 40 })
+      }
+
+      if (recenterLayoutReads === 2) {
+        return createRect({ top: 260, bottom: 300, height: 40 })
+      }
+
+      return createRect({ top: 180, bottom: 220, height: 40 })
+    })
 
     const { result } = renderHook(() => useSpaceContextProvider(planets, user))
 
     setLastUnlockedStarRef(result.current.lastUnlockedStarRef, starElement)
+    containerScrollTo.mockClear()
+    isRecentering = true
 
     act(() => {
       result.current.scrollIntoLastUnlockedStar()

--- a/apps/web/src/ui/space/contexts/SpaceContext/types/SpaceContextValue.ts
+++ b/apps/web/src/ui/space/contexts/SpaceContext/types/SpaceContextValue.ts
@@ -7,6 +7,7 @@ export type SpaceContextValue = {
   lastUnlockedStarId: string | null
   lastUnlockedStarRef: RefObject<HTMLDivElement | null>
   lastUnlockedStarPosition: LastUnlockedStarViewPortPosition
+  getLastUnlockedStarLayoutSnapshot: () => string | null
   scrollIntoLastUnlockedStar: () => void
   setLastUnlockedStarPosition: (
     viewPortposition: LastUnlockedStarViewPortPosition,

--- a/apps/web/src/ui/space/contexts/SpaceContext/useSpaceContextProvider.ts
+++ b/apps/web/src/ui/space/contexts/SpaceContext/useSpaceContextProvider.ts
@@ -5,6 +5,19 @@ import type { Planet } from '@stardust/core/space/entities'
 
 import type { LastUnlockedStarViewPortPosition } from './types'
 
+type LastUnlockedStarLayoutMetrics = {
+  starRect: DOMRect
+  scrollContainer: HTMLElement | null
+  scrollTop: number
+  scrollHeight: number
+  clientHeight: number
+  containerRect: DOMRect | null
+}
+
+const MAX_SCROLL_RECENTER_ATTEMPTS = 6
+const SCROLL_RECENTER_DELAY_IN_MS = 150
+const SCROLL_CENTER_TOLERANCE_IN_PX = 4
+
 export function useSpaceContextProvider(planets: Planet[], user: User | null) {
   const [lastUnlockedStarPosition, setLastUnlockedStarPosition] =
     useState<LastUnlockedStarViewPortPosition>('above')
@@ -77,6 +90,91 @@ export function useSpaceContextProvider(planets: Planet[], user: User | null) {
     return null
   }, [])
 
+  const getLastUnlockedStarLayoutMetrics = useCallback(() => {
+    const starElement = lastUnlockedStarRef.current
+
+    if (!starElement) {
+      return null
+    }
+
+    const starRect = starElement.getBoundingClientRect()
+    const scrollContainer = resolveScrollContainer()
+
+    if (scrollContainer) {
+      return {
+        starRect,
+        scrollContainer,
+        scrollTop: scrollContainer.scrollTop,
+        scrollHeight: scrollContainer.scrollHeight,
+        clientHeight: scrollContainer.clientHeight,
+        containerRect: scrollContainer.getBoundingClientRect(),
+      }
+    }
+
+    return {
+      starRect,
+      scrollContainer: null,
+      scrollTop: window.scrollY,
+      scrollHeight: document.documentElement.scrollHeight,
+      clientHeight: window.innerHeight,
+      containerRect: null,
+    }
+  }, [resolveScrollContainer])
+
+  const getLastUnlockedStarLayoutSnapshot = useCallback(() => {
+    const layoutMetrics = getLastUnlockedStarLayoutMetrics()
+
+    if (!layoutMetrics) {
+      return null
+    }
+
+    const { starRect, scrollTop, scrollHeight, clientHeight, containerRect } =
+      layoutMetrics
+
+    return [
+      Math.round(starRect.top),
+      Math.round(starRect.bottom),
+      Math.round(starRect.height),
+      Math.round(scrollTop),
+      Math.round(scrollHeight),
+      Math.round(clientHeight),
+      Math.round(containerRect?.top ?? 0),
+      Math.round(containerRect?.bottom ?? 0),
+      Math.round(containerRect?.height ?? 0),
+    ].join(':')
+  }, [getLastUnlockedStarLayoutMetrics])
+
+  const isLastUnlockedStarCentered = useCallback(
+    (layoutMetrics: LastUnlockedStarLayoutMetrics) => {
+      const { starRect, containerRect, scrollContainer } = layoutMetrics
+      const starCenter = starRect.top + starRect.height / 2
+      const viewportCenter = scrollContainer
+        ? containerRect!.top + containerRect!.height / 2
+        : window.innerHeight / 2
+
+      return Math.abs(starCenter - viewportCenter) <= SCROLL_CENTER_TOLERANCE_IN_PX
+    },
+    [],
+  )
+
+  const getLastUnlockedStarScrollTarget = useCallback(
+    (layoutMetrics: LastUnlockedStarLayoutMetrics) => {
+      const { starRect, scrollContainer, containerRect } = layoutMetrics
+
+      if (scrollContainer && containerRect) {
+        return (
+          scrollContainer.scrollTop +
+          (starRect.top - containerRect.top) -
+          (scrollContainer.clientHeight - starRect.height) / 2
+        )
+      }
+
+      const starTopPosition = starRect.top + window.scrollY
+      return starTopPosition - (window.innerHeight - starRect.height) / 2
+    },
+    [],
+  )
+
   const handleScroll = useCallback(() => {
     const starRect = lastUnlockedStarRef.current?.getBoundingClientRect()
 
@@ -115,39 +213,46 @@ export function useSpaceContextProvider(planets: Planet[], user: User | null) {
   }, [resolveScrollContainer])
 
   const scrollIntoLastUnlockedStar = useCallback(() => {
-    const starElement = lastUnlockedStarRef.current
+    function recenterLastUnlockedStar(remainingAttempts: number) {
+      const layoutMetrics = getLastUnlockedStarLayoutMetrics()
 
-    if (!starElement) return
+      if (!layoutMetrics) return
 
-    const starRect = starElement.getBoundingClientRect()
+      const nextScrollTop = getLastUnlockedStarScrollTarget(layoutMetrics)
 
-    if (!starRect) return
+      if (layoutMetrics.scrollContainer) {
+        layoutMetrics.scrollContainer.scrollTo({
+          top: nextScrollTop,
+          behavior: 'smooth',
+        })
+      } else {
+        window.scrollTo({
+          top: nextScrollTop,
+          behavior: 'smooth',
+        })
+      }
 
-    const scrollContainer = resolveScrollContainer()
+      if (remainingAttempts <= 0) {
+        return
+      }
 
-    if (scrollContainer) {
-      const containerRect = scrollContainer.getBoundingClientRect()
-      const starPositionWithinContainer =
-        scrollContainer.scrollTop +
-        (starRect.top - containerRect.top) -
-        (scrollContainer.clientHeight - starRect.height) / 2
+      window.setTimeout(() => {
+        const nextLayoutMetrics = getLastUnlockedStarLayoutMetrics()
 
-      scrollContainer.scrollTo({
-        top: starPositionWithinContainer,
-        behavior: 'smooth',
-      })
+        if (!nextLayoutMetrics || isLastUnlockedStarCentered(nextLayoutMetrics)) {
+          return
+        }
 
-      return
+        recenterLastUnlockedStar(remainingAttempts - 1)
+      }, SCROLL_RECENTER_DELAY_IN_MS)
     }
 
-    const starTopPosition = starRect.top + window.scrollY
-    const starPosition = starTopPosition - (window.innerHeight - starRect.height) / 2
-
-    window.scrollTo({
-      top: starPosition,
-      behavior: 'smooth',
-    })
-  }, [resolveScrollContainer])
+    recenterLastUnlockedStar(MAX_SCROLL_RECENTER_ATTEMPTS)
+  }, [
+    getLastUnlockedStarLayoutMetrics,
+    getLastUnlockedStarScrollTarget,
+    isLastUnlockedStarCentered,
+  ])
 
   useEffect(() => {
     const targets: Array<HTMLElement | Window> = []
@@ -196,10 +301,17 @@ export function useSpaceContextProvider(planets: Planet[], user: User | null) {
       lastUnlockedStarId,
       lastUnlockedStarRef,
       lastUnlockedStarPosition,
+      getLastUnlockedStarLayoutSnapshot,
       scrollIntoLastUnlockedStar,
       setLastUnlockedStarPosition,
     }
-  }, [planets, lastUnlockedStarId, lastUnlockedStarPosition, scrollIntoLastUnlockedStar])
+  }, [
+    planets,
+    lastUnlockedStarId,
+    lastUnlockedStarPosition,
+    getLastUnlockedStarLayoutSnapshot,
+    scrollIntoLastUnlockedStar,
+  ])
 
   return spaceContextValue
 }

--- a/apps/web/src/ui/space/contexts/SpaceContext/useSpaceContextProvider.ts
+++ b/apps/web/src/ui/space/contexts/SpaceContext/useSpaceContextProvider.ts
@@ -3,20 +3,16 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { User } from '@stardust/core/profile/entities'
 import type { Planet } from '@stardust/core/space/entities'
 
+import {
+  createLastUnlockedStarLayoutMetrics,
+  getLastUnlockedStarLayoutSnapshot,
+  getLastUnlockedStarScrollTarget,
+  isLastUnlockedStarCentered,
+} from './lastUnlockedStarLayout'
 import type { LastUnlockedStarViewPortPosition } from './types'
-
-type LastUnlockedStarLayoutMetrics = {
-  starRect: DOMRect
-  scrollContainer: HTMLElement | null
-  scrollTop: number
-  scrollHeight: number
-  clientHeight: number
-  containerRect: DOMRect | null
-}
 
 const MAX_SCROLL_RECENTER_ATTEMPTS = 6
 const SCROLL_RECENTER_DELAY_IN_MS = 150
-const SCROLL_CENTER_TOLERANCE_IN_PX = 4
 
 export function useSpaceContextProvider(planets: Planet[], user: User | null) {
   const [lastUnlockedStarPosition, setLastUnlockedStarPosition] =
@@ -97,83 +93,18 @@ export function useSpaceContextProvider(planets: Planet[], user: User | null) {
       return null
     }
 
-    const starRect = starElement.getBoundingClientRect()
-    const scrollContainer = resolveScrollContainer()
-
-    if (scrollContainer) {
-      return {
-        starRect,
-        scrollContainer,
-        scrollTop: scrollContainer.scrollTop,
-        scrollHeight: scrollContainer.scrollHeight,
-        clientHeight: scrollContainer.clientHeight,
-        containerRect: scrollContainer.getBoundingClientRect(),
-      }
-    }
-
-    return {
-      starRect,
-      scrollContainer: null,
-      scrollTop: window.scrollY,
-      scrollHeight: document.documentElement.scrollHeight,
-      clientHeight: window.innerHeight,
-      containerRect: null,
-    }
+    return createLastUnlockedStarLayoutMetrics(starElement, resolveScrollContainer())
   }, [resolveScrollContainer])
 
-  const getLastUnlockedStarLayoutSnapshot = useCallback(() => {
+  const handleGetLastUnlockedStarLayoutSnapshot = useCallback(() => {
     const layoutMetrics = getLastUnlockedStarLayoutMetrics()
 
     if (!layoutMetrics) {
       return null
     }
 
-    const { starRect, scrollTop, scrollHeight, clientHeight, containerRect } =
-      layoutMetrics
-
-    return [
-      Math.round(starRect.top),
-      Math.round(starRect.bottom),
-      Math.round(starRect.height),
-      Math.round(scrollTop),
-      Math.round(scrollHeight),
-      Math.round(clientHeight),
-      Math.round(containerRect?.top ?? 0),
-      Math.round(containerRect?.bottom ?? 0),
-      Math.round(containerRect?.height ?? 0),
-    ].join(':')
+    return getLastUnlockedStarLayoutSnapshot(layoutMetrics)
   }, [getLastUnlockedStarLayoutMetrics])
-
-  const isLastUnlockedStarCentered = useCallback(
-    (layoutMetrics: LastUnlockedStarLayoutMetrics) => {
-      const { starRect, containerRect, scrollContainer } = layoutMetrics
-      const starCenter = starRect.top + starRect.height / 2
-      const viewportCenter = scrollContainer
-        ? containerRect!.top + containerRect!.height / 2
-        : window.innerHeight / 2
-
-      return Math.abs(starCenter - viewportCenter) <= SCROLL_CENTER_TOLERANCE_IN_PX
-    },
-    [],
-  )
-
-  const getLastUnlockedStarScrollTarget = useCallback(
-    (layoutMetrics: LastUnlockedStarLayoutMetrics) => {
-      const { starRect, scrollContainer, containerRect } = layoutMetrics
-
-      if (scrollContainer && containerRect) {
-        return (
-          scrollContainer.scrollTop +
-          (starRect.top - containerRect.top) -
-          (scrollContainer.clientHeight - starRect.height) / 2
-        )
-      }
-
-      const starTopPosition = starRect.top + window.scrollY
-      return starTopPosition - (window.innerHeight - starRect.height) / 2
-    },
-    [],
-  )
 
   const handleScroll = useCallback(() => {
     const starRect = lastUnlockedStarRef.current?.getBoundingClientRect()
@@ -248,11 +179,7 @@ export function useSpaceContextProvider(planets: Planet[], user: User | null) {
     }
 
     recenterLastUnlockedStar(MAX_SCROLL_RECENTER_ATTEMPTS)
-  }, [
-    getLastUnlockedStarLayoutMetrics,
-    getLastUnlockedStarScrollTarget,
-    isLastUnlockedStarCentered,
-  ])
+  }, [getLastUnlockedStarLayoutMetrics])
 
   useEffect(() => {
     const targets: Array<HTMLElement | Window> = []
@@ -301,7 +228,7 @@ export function useSpaceContextProvider(planets: Planet[], user: User | null) {
       lastUnlockedStarId,
       lastUnlockedStarRef,
       lastUnlockedStarPosition,
-      getLastUnlockedStarLayoutSnapshot,
+      getLastUnlockedStarLayoutSnapshot: handleGetLastUnlockedStarLayoutSnapshot,
       scrollIntoLastUnlockedStar,
       setLastUnlockedStarPosition,
     }
@@ -309,7 +236,7 @@ export function useSpaceContextProvider(planets: Planet[], user: User | null) {
     planets,
     lastUnlockedStarId,
     lastUnlockedStarPosition,
-    getLastUnlockedStarLayoutSnapshot,
+    handleGetLastUnlockedStarLayoutSnapshot,
     scrollIntoLastUnlockedStar,
   ])
 

--- a/apps/web/src/ui/space/widgets/pages/Space/Planet/Star/index.tsx
+++ b/apps/web/src/ui/space/widgets/pages/Space/Planet/Star/index.tsx
@@ -24,6 +24,7 @@ export const Star = ({ id, name, number, slug }: StarProps) => {
     lastUnlockedStarId,
     lastUnlockedStarRef,
     lastUnlockedStarPosition,
+    getLastUnlockedStarLayoutSnapshot,
     scrollIntoLastUnlockedStar,
     setLastUnlockedStarPosition,
   } = useSpaceContext()
@@ -37,6 +38,7 @@ export const Star = ({ id, name, number, slug }: StarProps) => {
     challengingService,
     lastUnlockedStarRef,
     lastUnlockedStarPosition,
+    getLastUnlockedStarLayoutSnapshot,
     scrollIntoLastUnlockedStar,
     setLastUnlockedStarPosition,
   })

--- a/apps/web/src/ui/space/widgets/pages/Space/Planet/Star/tests/useStar.test.ts
+++ b/apps/web/src/ui/space/widgets/pages/Space/Planet/Star/tests/useStar.test.ts
@@ -27,9 +27,9 @@ describe('useStar', () => {
   let goTo: jest.Mock
   let scrollIntoLastUnlockedStar: jest.Mock
   let setLastUnlockedStarPosition: jest.Mock
+  let getLastUnlockedStarLayoutSnapshot: jest.Mock
   let starAnimationRef: React.RefObject<AnimationRef | null>
   let lastUnlockedStarPosition: 'above' | 'in' | 'bellow'
-  let getBoundingClientRectMock: jest.SpyInstance
 
   const star = ChallengesFaker.fake()
   const starId = IdFaker.fake()
@@ -46,6 +46,7 @@ describe('useStar', () => {
         challengingService,
         lastUnlockedStarRef,
         lastUnlockedStarPosition,
+        getLastUnlockedStarLayoutSnapshot,
         scrollIntoLastUnlockedStar,
         setLastUnlockedStarPosition,
       }),
@@ -60,10 +61,10 @@ describe('useStar', () => {
     goTo = jest.fn()
     scrollIntoLastUnlockedStar = jest.fn()
     setLastUnlockedStarPosition = jest.fn()
+    getLastUnlockedStarLayoutSnapshot = jest
+      .fn()
+      .mockReturnValue('300:380:80:0:1200:900:0:0:0')
     lastUnlockedStarPosition = 'in'
-    getBoundingClientRectMock = jest
-      .spyOn(lastUnlockedStarRef.current, 'getBoundingClientRect')
-      .mockReturnValue({ top: 300, height: 80 } as DOMRect)
     starAnimationRef = {
       current: {
         restart: jest.fn(),
@@ -157,10 +158,10 @@ describe('useStar', () => {
   })
 
   it('should wait for layout to stabilize before scrolling into last unlocked star', () => {
-    getBoundingClientRectMock
-      .mockReturnValueOnce({ top: 300, height: 80 } as DOMRect)
-      .mockReturnValueOnce({ top: 420, height: 80 } as DOMRect)
-      .mockReturnValue({ top: 420, height: 80 } as DOMRect)
+    getLastUnlockedStarLayoutSnapshot
+      .mockReturnValueOnce('300:380:80:0:1200:900:0:0:0')
+      .mockReturnValueOnce('420:500:80:0:1200:900:0:0:0')
+      .mockReturnValue('420:500:80:0:1200:900:0:0:0')
 
     Hook(true)
 
@@ -184,6 +185,18 @@ describe('useStar', () => {
 
     act(() => {
       jest.advanceTimersByTime(3000)
+    })
+
+    expect(scrollIntoLastUnlockedStar).not.toHaveBeenCalled()
+  })
+
+  it('should stop waiting when snapshot is unavailable', () => {
+    getLastUnlockedStarLayoutSnapshot.mockReturnValue(null)
+
+    Hook(true)
+
+    act(() => {
+      jest.advanceTimersByTime(500)
     })
 
     expect(scrollIntoLastUnlockedStar).not.toHaveBeenCalled()

--- a/apps/web/src/ui/space/widgets/pages/Space/Planet/Star/useStar.ts
+++ b/apps/web/src/ui/space/widgets/pages/Space/Planet/Star/useStar.ts
@@ -17,6 +17,7 @@ type Params = {
   challengingService: ChallengingService
   lastUnlockedStarRef: RefObject<HTMLDivElement | null>
   lastUnlockedStarPosition: LastUnlockedStarViewPortPosition
+  getLastUnlockedStarLayoutSnapshot: () => string | null
   scrollIntoLastUnlockedStar: () => void
   setLastUnlockedStarPosition: (position: LastUnlockedStarViewPortPosition) => void
 }
@@ -29,6 +30,7 @@ export function useStar({
   challengingService,
   lastUnlockedStarRef,
   lastUnlockedStarPosition,
+  getLastUnlockedStarLayoutSnapshot,
   scrollIntoLastUnlockedStar,
   setLastUnlockedStarPosition,
 }: Params) {
@@ -37,31 +39,15 @@ export function useStar({
   const navigationProvider = useNavigationProvider()
   const isInView = lastUnlockedStarPosition === 'in'
 
-  function getLayoutSnapshot() {
-    const starElement = lastUnlockedStarRef.current
-
-    if (!starElement) {
-      return null
-    }
-
-    const starRect = starElement.getBoundingClientRect()
-
-    return [
-      Math.round(starRect.top),
-      Math.round(starRect.height),
-      document.documentElement.scrollHeight,
-    ].join(':')
-  }
-
   async function handleStarNavigation() {
-    const reponse = await challengingService.fetchChallengeByStarId(starId)
+    const response = await challengingService.fetchChallengeByStarId(starId)
 
-    if (reponse.isFailure) {
+    if (response.isFailure) {
       navigationProvider.goTo(ROUTES.lesson.star(starSlug.value))
       return
     }
 
-    const challenge = reponse.body
+    const challenge = response.body
     if (challenge.slug)
       navigationProvider.goTo(ROUTES.challenging.challenges.challenge(challenge.slug))
   }
@@ -87,14 +73,14 @@ export function useStar({
     if (isLastUnlockedStar && lastUnlockedStarRef.current && isFirstScroll.current) {
       let attempts = 0
       let stableIterations = 0
-      let previousSnapshot = getLayoutSnapshot()
+      let previousSnapshot = getLastUnlockedStarLayoutSnapshot()
 
       const waitForStableLayout = () => {
         if (!lastUnlockedStarRef.current || !isFirstScroll.current) {
           return
         }
 
-        const currentSnapshot = getLayoutSnapshot()
+        const currentSnapshot = getLastUnlockedStarLayoutSnapshot()
 
         if (!currentSnapshot) {
           return
@@ -122,7 +108,12 @@ export function useStar({
     }
 
     return () => window.clearTimeout(timeout)
-  }, [isLastUnlockedStar, lastUnlockedStarRef, scrollIntoLastUnlockedStar])
+  }, [
+    getLastUnlockedStarLayoutSnapshot,
+    isLastUnlockedStar,
+    lastUnlockedStarRef,
+    scrollIntoLastUnlockedStar,
+  ])
 
   return {
     lastUnlockedStarRef,

--- a/documentation/features/space/space-page/bug-reports/last-unloocked-star-scroll-bug-report.md
+++ b/documentation/features/space/space-page/bug-reports/last-unloocked-star-scroll-bug-report.md
@@ -1,0 +1,52 @@
+---
+title: Centralizacao da ultima estrela desbloqueada para antes do destino
+issue: https://github.com/JohnPetros/stardust/issues/445
+apps: web
+status: closed
+last_updated_at: 2026-07-02
+---
+
+# Bug Report: Centralizacao da ultima estrela desbloqueada para antes do destino
+
+## Problema Identificado
+
+Ao carregar `/space`, a navegacao assistida tenta levar o usuario ate a ultima estrela desbloqueada, mas o scroll pode parar algumas estrelas antes do destino real. O mesmo risco afeta o FAB "Ir ate a ultima estrela desbloqueada", que deve recentralizar a jornada no progresso atual do usuario, mas pode usar uma medicao ainda inconsistente do layout.
+
+## Causas
+
+- Estabilizacao de layout possivelmente concluida cedo demais antes da posicao final da estrela e da altura efetiva do container rolavel estarem confiaveis.
+- Calculo de centralizacao dependente de `getBoundingClientRect()` no momento do disparo, sem uma garantia forte de que assets, animacoes e dimensoes da Space Page ja terminaram de alterar o layout.
+- Estado visual do FAB pode ser atualizado como `in` com base na medicao corrente, mesmo quando o auto-scroll inicial terminou antes da ultima estrela desbloqueada.
+
+## Contexto e Análise
+
+### Camada UI (Contexts)
+
+- **Arquivo:** `apps/web/src/ui/space/contexts/SpaceContext/useSpaceContextProvider.ts`
+- **Diagnóstico:** O contexto identifica `lastUnlockedStarId` percorrendo planetas e estrelas em ordem reversa, mantem `lastUnlockedStarRef`, resolve o container rolavel e executa `scrollIntoLastUnlockedStar()`. Fato encontrado no codigo: a centralizacao usa a posicao atual de `lastUnlockedStarRef.current.getBoundingClientRect()` contra o container resolvido no momento do scroll. Hipotese do bug: se esse metodo for chamado antes do layout final da Space Page estabilizar, o `top` calculado fica defasado e o scroll centraliza uma posicao anterior a estrela correta.
+
+### Camada UI (Widgets)
+
+- **Arquivo:** `apps/web/src/ui/space/widgets/pages/Space/Planet/Star/useStar.ts`
+- **Diagnóstico:** O hook da estrela dispara o auto-scroll inicial apenas uma vez quando `isLastUnlockedStar` e a ref DOM existem. Fato encontrado no codigo: `getLayoutSnapshot()` considera `starRect.top`, `starRect.height` e `document.documentElement.scrollHeight`, exigindo duas iteracoes estaveis ou no maximo 30 tentativas antes de chamar `scrollIntoLastUnlockedStar()`. Hipotese do bug: esse snapshot pode nao representar a altura ou estabilidade real do container interno usado pela Space Page, permitindo que a espera termine enquanto imagens, animacoes ou o proprio container rolavel ainda mudam.
+
+- **Arquivo:** `apps/web/src/ui/space/widgets/pages/Space/Planet/Star/index.tsx`
+- **Diagnóstico:** O entry point da estrela compara `lastUnlockedStarId` com o id da estrela renderizada e passa `lastUnlockedStarRef`, `lastUnlockedStarPosition` e `scrollIntoLastUnlockedStar()` para `useStar`. Esse arquivo confirma que apenas a estrela considerada ultima desbloqueada ancora a ref usada pelas medicoes; portanto, o sintoma nao indica, por si so, falha na selecao da estrela, mas sim no momento e na confiabilidade da medicao usada para rolar ate ela.
+
+- **Arquivo:** `apps/web/src/ui/space/widgets/pages/Space/Planet/Star/StarView.tsx`
+- **Diagnóstico:** A ref da ultima estrela desbloqueada e anexada ao wrapper externo do item de estrela. O elemento medido inclui conteudo visual que pode ser afetado por imagens e animacoes, reforcando a necessidade de aguardar estabilidade real antes de calcular o scroll.
+
+- **Arquivo:** `apps/web/src/ui/space/widgets/pages/Space/index.tsx`
+- **Diagnóstico:** A pagina renderiza o FAB com `isVisible={lastUnlockedStarPosition !== 'in'}` e reaproveita `scrollIntoLastUnlockedStar()` para a recentralizacao manual. Se `lastUnlockedStarPosition` for atualizado com base em uma medicao antecipada ou divergente, a UI pode esconder o FAB ou indicar estado correto mesmo com a estrela alvo fora da posicao esperada.
+
+### Camada Next.js App (Pages, Layouts)
+
+- **Arquivo:** `apps/web/src/app/(home)/space/page.tsx`
+- **Diagnóstico:** A rota `/space` carrega os planetas via `SpaceService.fetchPlanets()` e renderiza `SpaceProvider` com `SpacePage`. Nao ha evidencia neste ponto de erro no carregamento dos dados da trilha; a falha descrita acontece depois da renderizacao, na coordenacao de scroll da UI.
+
+- **Arquivo:** `apps/web/src/ui/reporting/widgets/layouts/FeedbackLayout/FeedbackLayoutView.tsx`
+- **Diagnóstico:** O conteudo autenticado roda dentro de um container interno com `overflow-auto`. Esse layout confirma que a Space Page depende de medicoes relativas ao container rolavel real, nao apenas ao documento global. A correcao anterior ja passou a resolver esse container; o bug atual indica que o tempo de medicao e estabilizacao ainda pode ser insuficiente.
+
+## Direcionamento de Correção
+
+A correcao deve atuar na camada `ui`, principalmente em `apps/web/src/ui/space/widgets/pages/Space/Planet/Star/useStar.ts` e `apps/web/src/ui/space/contexts/SpaceContext/useSpaceContextProvider.ts`, fortalecendo o criterio de estabilidade antes do auto-scroll inicial e garantindo que a centralizacao manual pelo FAB sempre use uma medicao atual do mesmo container rolavel real. Nao ha evidencia de necessidade de alterar contratos REST, dados do core ou mapeamentos de banco.

--- a/documentation/features/space/space-page/specs/last-unloocked-star-scroll-bug-spec.md
+++ b/documentation/features/space/space-page/specs/last-unloocked-star-scroll-bug-spec.md
@@ -1,0 +1,178 @@
+---
+title: Centralizacao confiavel da ultima estrela desbloqueada
+report: documentation/features/space/space-page/bug-reports/last-unloocked-star-scroll-bug-report.md
+issue: https://github.com/JohnPetros/stardust/issues/445
+apps: web
+status: closed
+last_updated_at: 2026-07-02
+---
+
+# Spec: Centralizacao confiavel da ultima estrela desbloqueada
+
+## 1. Objetivo
+
+Corrigir a navegacao assistida da Space Page para que o auto-scroll inicial e o FAB "Ir ate a ultima estrela desbloqueada" centralizem a estrela correta usando medicoes atuais do mesmo container rolavel real da pagina. A entrega deve fortalecer a estabilizacao de layout antes do primeiro scroll e manter a recentralizacao manual baseada em uma medicao fresca, sem alterar contratos REST, dados de dominio, banco de dados ou rota Next.js.
+
+## 2. Escopo
+
+### 2.1 In-scope
+
+- Ajustar a estabilizacao de layout usada antes do auto-scroll inicial da ultima estrela desbloqueada.
+- Garantir que o snapshot de estabilidade considere o container rolavel resolvido pela Space Page, nao apenas `document.documentElement.scrollHeight`.
+- Garantir que `scrollIntoLastUnlockedStar()` sempre calcule a centralizacao a partir do container rolavel atual e da posicao atual da estrela.
+- Preservar o comportamento do FAB, mantendo a acao manual como chamada ao mesmo fluxo de scroll confiavel.
+
+### 2.2 Out-of-scope
+
+- Alterar a regra que identifica `lastUnlockedStarId`.
+- Alterar a estrutura visual da Space Page, planetas, estrelas, animacoes ou FAB.
+- Alterar `SpaceService.fetchPlanets()`, contratos REST, entidades do core ou DTOs.
+- Criar migrations, repositories, mappers ou schemas de validacao.
+- Incluir testes automatizados nesta spec.
+
+## 3. Requisitos
+
+### 3.1 Funcionais
+
+- Ao carregar `/space`, a pagina deve rolar ate a ultima estrela desbloqueada somente depois que a posicao da estrela e as dimensoes do container rolavel estiverem estaveis.
+- O FAB deve recentralizar a ultima estrela desbloqueada usando uma medicao feita no momento do clique.
+- O estado `lastUnlockedStarPosition` deve continuar refletindo se a estrela esta acima, visivel ou abaixo do viewport do container rolavel.
+- Se nenhum container rolavel interno for encontrado, o fallback de scroll pela janela deve continuar funcionando.
+
+### 3.2 Nao funcionais
+
+- A espera de estabilizacao deve continuar finita para evitar loop permanente em telas com animacoes continuas.
+- A correcao deve evitar listeners globais extras alem dos ja usados para `window` e container rolavel.
+- A solucao deve manter a separacao do Widget Pattern: entry points resolvem dependencias, hooks orquestram UI, views renderizam.
+
+## 4. O que ja existe?
+
+### UI (Contexts)
+
+**useSpaceContextProvider** (`apps/web/src/ui/space/contexts/SpaceContext/useSpaceContextProvider.ts`) — calcula `lastUnlockedStarId`, mantem `lastUnlockedStarRef`, resolve o container rolavel, atualiza `lastUnlockedStarPosition` e executa `scrollIntoLastUnlockedStar()`.
+
+**SpaceContextValue** (`apps/web/src/ui/space/contexts/SpaceContext/types/SpaceContextValue.ts`) — contrato consumido pelos widgets da Space Page, incluindo `lastUnlockedStarId`, `lastUnlockedStarRef`, `lastUnlockedStarPosition`, `scrollIntoLastUnlockedStar` e `setLastUnlockedStarPosition`.
+
+**useSpaceContext** (`apps/web/src/ui/space/hooks/useSpaceContext.ts`) — hook de consumo do contexto da Space Page.
+
+### UI (Widgets)
+
+**SpacePage** (`apps/web/src/ui/space/widgets/pages/Space/index.tsx`) — renderiza planetas, estrelas e o FAB; consome `lastUnlockedStarPosition` para exibir ou esconder o FAB.
+
+**useSpacePage** (`apps/web/src/ui/space/widgets/pages/Space/useSpacePage.ts`) — encaminha o clique do FAB para `scrollIntoLastUnlockedStar()`.
+
+**Star** (`apps/web/src/ui/space/widgets/pages/Space/Planet/Star/index.tsx`) — identifica se a estrela renderizada e a ultima desbloqueada e conecta `useStar` com o contexto.
+
+**useStar** (`apps/web/src/ui/space/widgets/pages/Space/Planet/Star/useStar.ts`) — dispara o auto-scroll inicial uma vez e hoje aguarda estabilidade com base em `starRect.top`, `starRect.height` e `document.documentElement.scrollHeight`.
+
+**StarView** (`apps/web/src/ui/space/widgets/pages/Space/Planet/Star/StarView.tsx`) — anexa `lastUnlockedStarRef` ao wrapper externo da ultima estrela desbloqueada.
+
+### Next.js App (Pages, Layouts)
+
+**Space Route** (`apps/web/src/app/(home)/space/page.tsx`) — carrega planetas via `SpaceService.fetchPlanets()` e renderiza `SpaceProvider` com `SpacePage`.
+
+**FeedbackLayoutView** (`apps/web/src/ui/reporting/widgets/layouts/FeedbackLayout/FeedbackLayoutView.tsx`) — envolve rotas autenticadas em um container interno `div.flex-1.overflow-auto`, que e o container rolavel real para `/space`.
+
+## 5. O que deve ser criado?
+
+Nao aplicavel.
+
+## 6. O que deve ser modificado?
+
+- **Arquivo:** `apps/web/src/ui/space/contexts/SpaceContext/useSpaceContextProvider.ts`
+- **Mudanca:** concentrar a medicao de layout da ultima estrela no contexto, reaproveitando `resolveScrollContainer()` para produzir um snapshot que inclua `starRect.top`, `starRect.bottom`, `starRect.height`, dimensoes do container (`scrollTop`, `scrollHeight`, `clientHeight`) e `containerRect` quando houver container interno; no fallback, usar dados da janela/documento.
+- **Justificativa:** o contexto ja e a fonte do container rolavel e do scroll; manter a medicao ali elimina a divergencia atual entre espera de estabilidade baseada no documento e centralizacao baseada no container interno.
+
+- **Arquivo:** `apps/web/src/ui/space/contexts/SpaceContext/useSpaceContextProvider.ts`
+- **Mudanca:** garantir que `scrollIntoLastUnlockedStar()` sempre resolva novamente o container e leia `getBoundingClientRect()` imediatamente antes de calcular o destino, sem depender de snapshots anteriores nem do estado visual do FAB.
+- **Justificativa:** a recentralizacao manual pelo FAB precisa refletir o layout no momento do clique.
+
+- **Arquivo:** `apps/web/src/ui/space/contexts/SpaceContext/types/SpaceContextValue.ts`
+- **Mudanca:** adicionar ao contrato do contexto uma funcao de leitura de snapshot de layout, por exemplo `getLastUnlockedStarLayoutSnapshot(): string | null`.
+- **Justificativa:** `useStar` precisa aguardar estabilidade sem duplicar a logica de descoberta do container rolavel.
+
+- **Arquivo:** `apps/web/src/ui/space/widgets/pages/Space/Planet/Star/useStar.ts`
+- **Mudanca:** substituir `getLayoutSnapshot()` local pela funcao recebida do contexto e manter o disparo unico do auto-scroll quando o snapshot ficar estavel por iteracoes consecutivas ou quando o limite de tentativas for atingido.
+- **Justificativa:** o hook da estrela continua responsavel pelo timing do primeiro scroll, mas deixa a medicao para o contexto que conhece o container real.
+
+- **Arquivo:** `apps/web/src/ui/space/widgets/pages/Space/Planet/Star/index.tsx`
+- **Mudanca:** consumir `getLastUnlockedStarLayoutSnapshot` de `useSpaceContext()` e repassar para `useStar`.
+- **Justificativa:** o entry point do widget e a borda correta para conectar contexto e hook, conforme o Widget Pattern.
+
+## 7. O que deve ser removido?
+
+- **Arquivo:** `apps/web/src/ui/space/widgets/pages/Space/Planet/Star/useStar.ts`
+- **Motivo:** remover a funcao local `getLayoutSnapshot()` baseada em `document.documentElement.scrollHeight`.
+- **Impacto:** a espera do auto-scroll inicial passa a usar o snapshot do contexto; nao ha alteracao esperada em navegacao de estrela, audio ou animacao.
+
+## 8. Decisoes Tecnicas
+
+- **Decisao:** centralizar a medicao de layout em `useSpaceContextProvider`.
+- **Alternativas:** manter a medicao em `useStar`; criar um hook global de scroll; criar um utilitario isolado.
+- **Motivo:** `useSpaceContextProvider` ja possui `lastUnlockedStarRef`, `resolveScrollContainer()` e `scrollIntoLastUnlockedStar()`, portanto e o ponto com mais evidencia na codebase para evitar duplicacao.
+- **Trade-offs:** aumenta levemente o contrato do contexto, mas remove a divergencia entre estabilizacao e scroll.
+
+- **Decisao:** manter a espera finita por tentativas consecutivas estaveis.
+- **Alternativas:** aguardar eventos de imagens/animacoes; usar `ResizeObserver`; rolar imediatamente.
+- **Motivo:** o codigo atual ja usa uma espera finita e o bug report pede fortalecer o criterio, nao trocar o mecanismo inteiro.
+- **Trade-offs:** uma tela com mudancas tardias ainda pode atingir o limite, mas o snapshot mais completo reduz a chance de encerrar cedo.
+
+- **Decisao:** nao alterar a rota `/space` nem `FeedbackLayoutView`.
+- **Alternativas:** expor uma ref explicita do container rolavel pelo layout; alterar a estrutura do container da pagina.
+- **Motivo:** o contexto ja descobre o ancestral com `overflowY` rolavel, e o report nao indica falha estrutural na rota ou no layout.
+- **Trade-offs:** a solucao continua dependente da descoberta por ancestral rolavel, mas preserva o acoplamento atual.
+
+- **Decisao:** nao criar migration.
+- **Alternativas:** nenhuma aplicavel.
+- **Motivo:** o problema esta restrito a medicao e scroll de UI.
+- **Trade-offs:** nao aplicavel.
+
+## 9. Diagramas e Referencias
+
+### Fluxo de dados
+
+```mermaid
+flowchart TD
+  Page["apps/web/src/app/(home)/space/page.tsx"] --> Provider["SpaceProvider"]
+  Provider --> Context["useSpaceContextProvider"]
+  Context --> SpacePage["SpacePage"]
+  SpacePage --> Planet["Planet"]
+  Planet --> Star["Star"]
+  Star --> UseStar["useStar"]
+  UseStar --> Snapshot["getLastUnlockedStarLayoutSnapshot()"]
+  Snapshot --> Context
+  UseStar --> Scroll["scrollIntoLastUnlockedStar()"]
+  Scroll --> Container["FeedbackLayout overflow-auto container"]
+  SpacePage --> Fab["Fab"]
+  Fab --> Scroll
+```
+
+### Layout
+
+```text
+FeedbackLayoutView
+└─ div.flex-1.overflow-auto
+   └─ SpaceProvider
+      └─ SpacePage
+         ├─ Particles
+         ├─ ul
+         │  └─ Planet
+         │     └─ Star
+         │        └─ StarView wrapper ref=lastUnlockedStarRef
+         └─ Fab
+```
+
+### Referencias
+
+- `apps/web/src/ui/space/contexts/SpaceContext/useSpaceContextProvider.ts`
+- `apps/web/src/ui/space/contexts/SpaceContext/types/SpaceContextValue.ts`
+- `apps/web/src/ui/space/widgets/pages/Space/Planet/Star/useStar.ts`
+- `apps/web/src/ui/space/widgets/pages/Space/Planet/Star/index.tsx`
+- `apps/web/src/ui/space/widgets/pages/Space/Planet/Star/StarView.tsx`
+- `apps/web/src/ui/space/widgets/pages/Space/index.tsx`
+- `apps/web/src/ui/reporting/widgets/layouts/FeedbackLayout/FeedbackLayoutView.tsx`
+- `apps/web/src/app/(home)/space/page.tsx`
+
+## 10. Pendencias / Duvidas
+
+Sem pendencias.


### PR DESCRIPTION
## Objetivo

Corrigir a navegacao assistida da Space Page para que o auto-scroll inicial e o FAB de recentralizacao usem medicoes consistentes do container rolavel real, evitando parar antes da ultima estrela desbloqueada.

## Issues relacionadas

resolve #445

## Causa do bug

A estabilizacao inicial do layout era decidida dentro de `useStar` com um snapshot baseado em `document.documentElement.scrollHeight`, enquanto a centralizacao efetiva usava o container rolavel interno resolvido pelo contexto. Essa divergencia permitia concluir a espera cedo demais e calcular o scroll com uma medicao ainda instavel.

## Changelog

- adiciona `getLastUnlockedStarLayoutSnapshot()` ao contrato de `SpaceContextValue`
- centraliza em `useSpaceContextProvider` a coleta de metricas da estrela e do container rolavel
- atualiza `scrollIntoLastUnlockedStar()` para recalcular o alvo com medicao fresca e tentar recentralizacao finita apos layout shifts
- remove o snapshot local de `useStar` e passa a consumir o snapshot exposto pelo contexto
- ajusta o entry point de `Star` para injetar a nova dependencia do contexto no hook
- amplia a cobertura de testes de `useSpaceContextProvider` e `useStar` para snapshot do container, retry de recentralizacao e interrupcao quando o snapshot fica indisponivel
- adiciona a spec e o bug report fechados para documentar a entrega

## Como testar

1. Abrir `/space` autenticado com progresso em multiplas estrelas e confirmar que o carregamento inicial centraliza a ultima estrela desbloqueada.
2. Rolar a pagina para cima ou para baixo e usar o FAB de recentralizacao para confirmar que o scroll volta para a mesma estrela correta.
3. Executar `npx jest src/ui/space/contexts/SpaceContext/tests/useSpaceContextProvider.test.ts src/ui/space/widgets/pages/Space/Planet/Star/tests/useStar.test.ts --runInBand` em `apps/web`.
4. Executar `npm run typecheck` em `apps/web`.
5. Executar `npm run codecheck` na raiz do projeto.

## Observações

- A correcao ficou restrita a camada UI e nao altera contratos REST, dados de dominio, banco ou rotas.
- `npm run test` e `npm run typecheck` na raiz chegaram a ficar em execucao ate timeout no ambiente local, sem falha explicita registrada durante a validacao da spec.
- A issue `#445` estava sem milestone no GitHub na data da conclusao, entao nao houve atualizacao de PRD em milestone.
