### PR TITLE
Configuração do Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,57 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Sao_Paulo"
+    open-pull-requests-limit: 5
+    versioning-strategy: "increase-if-necessary"
+    commit-message:
+      prefix: "📦 deps"
+    groups:
+      npm-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:30"
+      timezone: "America/Sao_Paulo"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "📦 deps"
+    groups:
+      github-actions-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "docker-compose"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "10:00"
+      timezone: "America/Sao_Paulo"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "📦 deps"
+    groups:
+      docker-compose-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/core-package-ci.yaml
+++ b/.github/workflows/core-package-ci.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
     paths:
+      - ".github/workflows/**"
+      - "package.json"
+      - "package-lock.json"
       - "packages/core/**"
       - "scripts/quality-gate/**"
 

--- a/.github/workflows/server-app-ci.yaml
+++ b/.github/workflows/server-app-ci.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
     paths:
+      - ".github/workflows/**"
+      - "package.json"
+      - "package-lock.json"
       - "apps/server/**"
       - "packages/core/**"
       - "packages/validation/**"

--- a/.github/workflows/studio-app-ci.yaml
+++ b/.github/workflows/studio-app-ci.yaml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
     paths:
+      - ".github/workflows/**"
+      - "package.json"
+      - "package-lock.json"
       - "apps/studio/**"
       - "packages/core/**"
       - "packages/validation/**"
-      - "package-lock.json"
       - "scripts/quality-gate/**"
 
 permissions:

--- a/.github/workflows/web-app-ci.yaml
+++ b/.github/workflows/web-app-ci.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
     paths:
+      - ".github/workflows/**"
+      - "package.json"
+      - "package-lock.json"
       - "apps/web/**"
       - "packages/core/**"
       - "packages/validation/**"

--- a/.gitignore
+++ b/.gitignore
@@ -89,7 +89,6 @@ google-key-file.json
 .serena/
 .opencode/
 opencode.json
-.mcp.json
 CLAUDE.md
 GEMINI.md
 prompt.md
@@ -99,9 +98,10 @@ documentation/issue.md
 # Ai Content
 .context/
 
-# Serena MCP
-.serena
-
+# MCPs
+.serena/
+.mcp.json
+.playwright-mcp
 
 # Terminal Paste Image folder
 .cp-images/

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -2,9 +2,7 @@
   "name": "@stardust/server",
   "main": "dist/main.js",
   "scripts": {
-    "dev:server": "tsx watch --env-file .env.development src/main.ts",
-    "dev:queue": "npx inngest-cli@latest dev --no-discovery -u http://localhost:3333/inngest",
-    "dev": "npm-run-all --parallel dev:server dev:queue",
+    "dev": "tsx watch --env-file .env.development src/main.ts",
     "codecheck": "npm run lint && npm run format",
     "lint": "biome lint src --diagnostic-level=error",
     "format": "biome format src --write",
@@ -52,7 +50,6 @@
     "@types/supertest": "^7.2.0",
     "jest": "^29.7.0",
     "jest-environment-node": "^29.7.0",
-    "npm-run-all": "^4.1.5",
     "supabase": "^2.98.2",
     "supertest": "^7.2.2",
     "ts-jest": "^29.4.4",

--- a/apps/server/src/database/supabase/mappers/forum/SupabaseCommentMapper.ts
+++ b/apps/server/src/database/supabase/mappers/forum/SupabaseCommentMapper.ts
@@ -1,6 +1,5 @@
 import { Comment } from '@stardust/core/forum/entities'
 import type { CommentDto } from '@stardust/core/forum/entities/dtos'
-import { Datetime } from '@stardust/core/global/libs'
 import type { SupabaseComment } from '../../types'
 
 export class SupabaseCommentMapper {

--- a/apps/server/src/database/supabase/types/SupabaseTier.ts
+++ b/apps/server/src/database/supabase/types/SupabaseTier.ts
@@ -1,4 +1,3 @@
 import type { Database } from './Database'
-import type { SupabaseUser } from './SupabaseUser'
 
 export type SupabaseTier = Database['public']['Tables']['tiers']['Row']

--- a/apps/server/src/provision/analytics/posthog/PostHogAnalyticsReportingProvider.ts
+++ b/apps/server/src/provision/analytics/posthog/PostHogAnalyticsReportingProvider.ts
@@ -2,7 +2,7 @@ import type { AnalyticsReportingProvider } from '@stardust/core/analytics/interf
 import type { RestClient } from '@stardust/core/global/interfaces'
 import { HTTP_HEADERS } from '@stardust/core/global/constants'
 import { AppError } from '@stardust/core/global/errors'
-import { Integer } from '@stardust/core/global/structures'
+import type { Integer } from '@stardust/core/global/structures'
 import type { DailyActiveUsersDto } from '@stardust/core/profile/entities/dtos'
 
 import { ENV } from '@/constants'

--- a/apps/server/src/provision/storage/DropboxStorageProvider.ts
+++ b/apps/server/src/provision/storage/DropboxStorageProvider.ts
@@ -1,5 +1,3 @@
-import fs from 'node:fs/promises'
-
 import { Dropbox } from 'dropbox'
 
 import { AppError } from '@stardust/core/global/errors'

--- a/apps/server/src/provision/tts/open-router-eleven-labs/OpenRouterElevenLabsTtsProvider.ts
+++ b/apps/server/src/provision/tts/open-router-eleven-labs/OpenRouterElevenLabsTtsProvider.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto'
 
 import { HTTP_HEADERS } from '@stardust/core/global/constants'
 import { AppError } from '@stardust/core/global/errors'
-import { Text } from '@stardust/core/global/structures'
+import type { Text } from '@stardust/core/global/structures'
 import type { AudioVoice } from '@stardust/core/lesson/structures'
 import type { TtsProvider } from '@stardust/core/lesson/interfaces'
 

--- a/apps/server/src/queue/inngest/functions/ProfileFunctions.ts
+++ b/apps/server/src/queue/inngest/functions/ProfileFunctions.ts
@@ -1,26 +1,13 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 
-import {
-  RankingLosersDefinedEvent,
-  RankingWinnersDefinedEvent,
-} from '@stardust/core/ranking/events'
 import { ShopItemsAcquiredByDefaultEvent } from '@stardust/core/shop/events'
 import type { EventPayload } from '@stardust/core/global/types'
 
-import {
-  ObserveStreakBreakJob,
-  ResetWeekStatusForAllUsersJob,
-  UpdateTierForRankingWinnersJob,
-  UpdateTierForRankingLosersJob,
-  CreateUserJob,
-  UpdateSpaceForAllUsersJob,
-} from '@/queue/jobs/profile'
+import { ObserveStreakBreakJob, CreateUserJob } from '@/queue/jobs/profile'
 import { SupabaseUsersRepository } from '@/database'
 import { InngestAmqp } from '../InngestAmqp'
 import { InngestBroker } from '../InngestBroker'
-import { InngestFunctions } from './InngestFunctions'
-import { SpaceOrderChangedEvent } from '@stardust/core/space/events'
-import { eventType } from './InngestFunctions'
+import { InngestFunctions, eventType } from './InngestFunctions'
 import z from 'zod'
 import { emailSchema, idSchema, nameSchema } from '@stardust/validation/global/schemas'
 

--- a/apps/server/src/rest/controllers/auth/api-keys/CreateApiKeyController.ts
+++ b/apps/server/src/rest/controllers/auth/api-keys/CreateApiKeyController.ts
@@ -1,6 +1,6 @@
-import {
-  type ApiKeySecretProvider,
-  type ApiKeysRepository,
+import type {
+  ApiKeySecretProvider,
+  ApiKeysRepository,
 } from '@stardust/core/auth/interfaces'
 import { CreateApiKeyUseCase } from '@stardust/core/auth/use-cases'
 import type { Controller, Http } from '@stardust/core/global/interfaces'

--- a/apps/server/src/rest/controllers/forum/comments/PostChallengeCommentController.ts
+++ b/apps/server/src/rest/controllers/forum/comments/PostChallengeCommentController.ts
@@ -1,4 +1,3 @@
-import type { CommentDto } from '@stardust/core/forum/entities/dtos'
 import type { CommentsRepository } from '@stardust/core/forum/interfaces'
 import { PostChallengeCommentUseCase } from '@stardust/core/forum/use-cases'
 import type { Controller, Http } from '@stardust/core/global/interfaces'

--- a/apps/server/src/rest/controllers/forum/comments/PostSolutionCommentController.ts
+++ b/apps/server/src/rest/controllers/forum/comments/PostSolutionCommentController.ts
@@ -1,4 +1,3 @@
-import type { CommentDto } from '@stardust/core/forum/entities/dtos'
 import type { CommentsRepository } from '@stardust/core/forum/interfaces'
 import { PostSolutionCommentUseCase } from '@stardust/core/forum/use-cases'
 import type { Controller, Http } from '@stardust/core/global/interfaces'

--- a/apps/server/src/rest/controllers/forum/comments/ReplyCommentController.ts
+++ b/apps/server/src/rest/controllers/forum/comments/ReplyCommentController.ts
@@ -1,4 +1,3 @@
-import type { CommentDto } from '@stardust/core/forum/entities/dtos'
 import type { CommentsRepository } from '@stardust/core/forum/interfaces'
 import { ReplyCommentUseCase } from '@stardust/core/forum/use-cases'
 import type { Controller, Http } from '@stardust/core/global/interfaces'

--- a/apps/server/src/rest/controllers/forum/comments/tests/PostChallengeCommentController.test.ts
+++ b/apps/server/src/rest/controllers/forum/comments/tests/PostChallengeCommentController.test.ts
@@ -1,0 +1,67 @@
+import { mock, type Mock } from 'ts-jest-mocker'
+
+import type { Http } from '@stardust/core/global/interfaces'
+import type { RestResponse } from '@stardust/core/global/responses'
+import type { CommentsRepository } from '@stardust/core/forum/interfaces'
+import { PostChallengeCommentUseCase } from '@stardust/core/forum/use-cases'
+
+import { PostChallengeCommentController } from '../PostChallengeCommentController'
+
+type Schema = {
+  routeParams: {
+    challengeId: string
+  }
+  body: {
+    content: string
+  }
+}
+
+describe('Post Challenge Comment Controller', () => {
+  let http: Mock<Http<Schema>>
+  let repository: Mock<CommentsRepository>
+  let controller: PostChallengeCommentController
+
+  beforeEach(() => {
+    jest.restoreAllMocks()
+    http = mock()
+    repository = mock()
+    controller = new PostChallengeCommentController(repository)
+  })
+
+  it('should post challenge comment with route params, body and account data', async () => {
+    const body = { content: 'Novo comentario' }
+    const account = {
+      id: '550e8400-e29b-41d4-a716-446655440000',
+      email: 'user@test.com',
+      name: 'User',
+      isAuthenticated: true,
+    }
+    const response = { id: 'comment-id' }
+    const restResponse = mock<RestResponse>()
+
+    http.getRouteParams.mockReturnValue({ challengeId: 'challenge-id' })
+    http.getBody.mockResolvedValue(body)
+    http.getAccount.mockResolvedValue(account)
+    http.statusCreated.mockReturnValue(http)
+    http.send.mockReturnValue(restResponse)
+
+    const executeSpy = jest
+      .spyOn(PostChallengeCommentUseCase.prototype, 'execute')
+      .mockResolvedValue(response as never)
+
+    const result = await controller.handle(http)
+
+    expect(executeSpy).toHaveBeenCalledWith({
+      challengeId: 'challenge-id',
+      commentDto: {
+        content: body.content,
+        author: {
+          id: account.id,
+        },
+      },
+    })
+    expect(http.statusCreated).toHaveBeenCalledTimes(1)
+    expect(http.send).toHaveBeenCalledWith(response)
+    expect(result).toBe(restResponse)
+  })
+})

--- a/apps/server/src/rest/controllers/profile/users/tests/VerifyUserAbsenceController.test.ts
+++ b/apps/server/src/rest/controllers/profile/users/tests/VerifyUserAbsenceController.test.ts
@@ -1,0 +1,63 @@
+import { mock, type Mock } from 'ts-jest-mocker'
+
+import type { AuthService } from '@stardust/core/auth/interfaces'
+import type { AccountDto } from '@stardust/core/auth/entities/dtos'
+import type { Http } from '@stardust/core/global/interfaces'
+import type { RestResponse } from '@stardust/core/global/responses'
+import { RestResponse as CoreRestResponse } from '@stardust/core/global/responses'
+import { ConflictError } from '@stardust/core/global/errors'
+import type { UsersRepository } from '@stardust/core/profile/interfaces'
+
+import { VerifyUserAbsenceController } from '../VerifyUserAbsenceController'
+
+describe('Verify User Absence Controller', () => {
+  let http: Mock<Http>
+  let authService: Mock<AuthService>
+  let usersRepository: Mock<UsersRepository>
+  let controller: VerifyUserAbsenceController
+
+  beforeEach(() => {
+    jest.restoreAllMocks()
+    http = mock()
+    authService = mock()
+    usersRepository = mock()
+    controller = new VerifyUserAbsenceController(authService, usersRepository)
+  })
+
+  it('should pass when account has no related user profile', async () => {
+    const restResponse = mock<RestResponse>()
+    const account: AccountDto = {
+      id: '550e8400-e29b-41d4-a716-446655440000',
+      email: 'user@test.com',
+      name: 'User',
+      isAuthenticated: true,
+    }
+
+    authService.fetchAccount.mockResolvedValue(new CoreRestResponse({ body: account }))
+    usersRepository.findById.mockResolvedValue(null)
+    http.pass.mockResolvedValue(restResponse)
+
+    const result = await controller.handle(http)
+
+    expect(usersRepository.findById).toHaveBeenCalledTimes(1)
+    expect(http.pass).toHaveBeenCalledTimes(1)
+    expect(result).toBe(restResponse)
+  })
+
+  it('should throw ConflictError when account already has a profile', async () => {
+    const account: AccountDto = {
+      id: '550e8400-e29b-41d4-a716-446655440000',
+      email: 'user@test.com',
+      name: 'User',
+      isAuthenticated: true,
+    }
+
+    authService.fetchAccount.mockResolvedValue(new CoreRestResponse({ body: account }))
+    usersRepository.findById.mockResolvedValue({ id: { value: 'user-id' } } as never)
+
+    await expect(controller.handle(http)).rejects.toThrow(
+      new ConflictError('Perfil já existe para esta conta'),
+    )
+    expect(http.pass).not.toHaveBeenCalled()
+  })
+})

--- a/apps/server/src/tests/routes/space/stars/EditStarAvailabilityRoute.test.ts
+++ b/apps/server/src/tests/routes/space/stars/EditStarAvailabilityRoute.test.ts
@@ -2,7 +2,6 @@ import request from 'supertest'
 
 import { HTTP_STATUS_CODE } from '@stardust/core/global/constants'
 import { AuthError, NotGodAccountError } from '@stardust/core/global/errors'
-import { Id } from '@stardust/core/global/structures'
 
 import { ENV } from '@/constants'
 import { AuthFixture } from '@/tests/fixtures/AuthFixture'

--- a/apps/web/src/ui/global/widgets/components/WYSIWYGEditor/useWYSIWYGEditor.ts
+++ b/apps/web/src/ui/global/widgets/components/WYSIWYGEditor/useWYSIWYGEditor.ts
@@ -262,7 +262,7 @@ export function useWYSIWYGEditor({ value, disabled = false, onChange }: Params) 
     const currentContent = getMarkdown(editor).trim()
 
     if (nextContent !== currentContent) {
-      setMarkdownContent(editor, value)
+      scheduleSetMarkdownContent(editor, value)
     }
   }, [value, editor])
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,14 @@
 services:
+  inngest:
+    image: inngest/inngest:v1.19.4
+    container_name: stardust-inngest
+    command: inngest dev -u http://host.docker.internal:3333/inngest --no-discovery
+    ports:
+      - "8288:8288"
+      - "8289:8289"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
   redis:
     image: redis:7-alpine
     container_name: stardust-redis

--- a/documentation/features/space/space-page/prd.md
+++ b/documentation/features/space/space-page/prd.md
@@ -1,1 +1,0 @@
-https://github.com/JohnPetros/stardust/milestone/11

--- a/documentation/prompts/create-bug-report-prompt.md
+++ b/documentation/prompts/create-bug-report-prompt.md
@@ -11,15 +11,14 @@ Transformar um esboço ou relato informal de um erro em um **Bug Report profissi
 O bug report deve:
 - Explicar **o que está quebrado**
 - Indicar **onde e por que provavelmente está quebrado**
-- Sugerir **como corrigir**, respeitando a arquitetura do projeto
+- Indicar um **direcionamento de correção** curto, sem detalhar implementação como Spec
 
 O resultado desta tarefa é **sempre um único arquivo Markdown** contendo apenas o **Bug Report**.
 
-Quando o bug exigir planejamento de correção formal, a **Spec de correção** deve ser criada em **fluxo separado**, consumindo o bug report como insumo e seguindo `documentation/prompts/create-spec-prompt.md`.
+Este prompt **não cria Spec de correção**. Quando uma Spec for necessária, ela deve ser solicitada e executada em outro fluxo, usando `documentation/prompts/create-spec-prompt.md`.
 
-> A Spec derivada de Bug Report **não faz parte da mesma entrega** e **não deve coexistir no mesmo arquivo**.
 > O papel desta tarefa termina quando o bug report estiver salvo, claro e acionável.
-> A criação da Spec acontece depois, em arquivo próprio dentro de `specs/`.
+> Não crie, edite nem antecipe arquivo em `specs/` durante a execução deste prompt.
 
 ---
 
@@ -69,20 +68,21 @@ Quando o bug exigir planejamento de correção formal, a **Spec de correção** 
   - `web` — Pages e Layouts Next.js
   - `studio` — Pages e Layouts React Router
 
-### 4. Plano de Correção
+### 4. Direcionamento de Correção
 
-- Proponha uma solução técnica **incremental e segura**, separada por camadas.
-- O plano deve ser claro o suficiente para servir como base de implementação.
+- Inclua apenas uma orientação técnica breve sobre onde a correção provavelmente deve atuar.
+- Não detalhe fases, tarefas, assinaturas, novos arquivos ou lista estruturada de implementação.
+- Não use seções do tipo **O que já existe**, **O que deve ser criado**, **O que deve ser modificado** ou **O que deve ser removido**; isso pertence à Spec.
+- O direcionamento deve ajudar a próxima etapa, mas não substituir a Spec.
 
-### 5. Encaminhamento para Spec de Correção
+### 5. Encerramento
 
-Após salvar o Bug Report, o agente deve deixar explícito se o próximo passo recomendado é criar uma Spec de correção em fluxo separado.
+Após salvar o Bug Report, encerre a tarefa informando o arquivo criado ou atualizado.
 
-- A criação da Spec **não acontece nesta tarefa**.
-- O **esboço da tarefa** da futura Spec é o próprio Bug Report gerado.
-- O **PRD de referência** da futura Spec é a milestone do GitHub da feature afetada.
-- As seções **O que já existe**, **O que deve ser criado**, **O que deve ser modificado** e **O que deve ser removido** do bug report devem facilitar a criação posterior da Spec, sem duplicá-la.
-- Quando a correção exigir Spec formal, ela deve ser salva separadamente em `documentation/features/{dominio}/specs/{nome-descritivo}-fix-spec.md`.
+- Não crie Spec.
+- Não edite arquivos em `specs/`.
+- Não inclua uma Spec dentro do Bug Report.
+- Se o usuário pedir a Spec depois, trate como uma nova tarefa usando o prompt apropriado.
 
 ---
 
@@ -93,8 +93,8 @@ Salve um único arquivo em `documentation/features/{dominio}/reports/{nome-descr
 ```md
 ---
 title: {Titulo Curto e Descritivo}
-prd: <link para o PRD referente ao bug e à spec, sendo uma milestone do GitHub>
-issue: <link para o issue referente ao bug, servindo como esboço para a spec>
+prd: <link para o PRD ou milestone referente ao bug, se houver>
+issue: <link para o issue referente ao bug>
 apps: {web|server|studio}
 status: {open|closed}
 last_updated_at: {YYYY-MM-DD}
@@ -192,35 +192,9 @@ last_updated_at: {YYYY-MM-DD}
 - **Arquivo:** `{caminho/relativo/do/arquivo}`
 - **Diagnóstico:** {Explique o que está errado neste ponto.}
 
-## Plano de Correção
+## Direcionamento de Correção
 
-### 1. O que já existe?
-
-Liste recursos existentes da codebase que estão envolvidos no bug, serão reutilizados na correção ou podem ser impactados indiretamente.
-
-- **{Camada}**
-  - `{Nome do Recurso}` — {Responsabilidade atual e relação com o bug}
-
-### 2. O que deve ser criado?
-
-Descreva novos recursos necessários **apenas se estritamente necessários**.
-
-- **{Camada}**
-  - `{Nome do Recurso}` — {Nova responsabilidade introduzida}
-
-### 3. O que deve ser modificado?
-
-Liste mudanças pontuais em código existente, explicando o motivo da alteração.
-
-- **{Camada}**
-  - `{Nome do Recurso}` — {Descrição clara da modificação}
-
-### 4. O que deve ser removido?
-
-Liste código redundante, legado ou incorreto que deve ser eliminado como parte da correção.
-
-- **{Camada}**
-  - `{Nome do Recurso}` — {Motivo da remoção}
+{Parágrafo ou lista curta com a direção provável da correção. Deve apontar camada(s) e arquivo(s) relevantes, mas não deve detalhar tarefas de implementação como uma Spec.}
 ```
 
 ---
@@ -234,5 +208,6 @@ Liste código redundante, legado ou incorreto que deve ser eliminado como parte 
 - Use apenas as camadas listadas na seção 3. Mapeamento de Camadas — não crie camadas arbitrárias.
 - Omita do template as camadas que não forem aplicáveis ao bug em questão.
 - Não incorpore Spec de correção no arquivo do bug report.
-- Quando houver necessidade de Spec formal, ela deve ser criada em fluxo separado e em arquivo próprio dentro de `specs/`.
-- A futura Spec de correção não pode contradizer o Bug Report; ela deve derivar dele.
+- Não inclua seções de planejamento de Spec, como **O que já existe**, **O que deve ser criado**, **O que deve ser modificado** ou **O que deve ser removido**.
+- Não crie, edite ou atualize arquivos em `specs/` durante esta tarefa.
+- Não trate a tarefa como incompleta por ausência de Spec; o entregável final é somente o Bug Report.

--- a/documentation/prompts/create-pr-prompt.md
+++ b/documentation/prompts/create-pr-prompt.md
@@ -69,7 +69,97 @@ refactor/
 
 ---
 
-### 3. Estrutura da Descrição (Body)
+### 3. Commits Pendentes na Branch
+
+Se a branch ainda **não** estiver com todas as alterações commitadas, antes de
+criar o PR siga o mesmo padrão do prompt `commit-code`.
+
+#### 3.1 Pré-condições
+
+Execute:
+
+```bash
+git diff --cached --name-only
+git status --porcelain
+```
+
+- Se houver arquivos previamente em stage, **aborte** e informe o problema.
+- Se não houver alterações pendentes, prossiga para a criação do PR.
+- Se houver alterações não commitadas, continue para a etapa de agrupamento.
+
+#### 3.2 Regra de agrupamento
+
+Analise **caminho e diff** de cada arquivo alterado:
+
+```bash
+git diff --stat
+git diff -- <arquivo>
+```
+
+Agrupe por **responsabilidade semântica**, não por pasta:
+
+- arquivos que implementam a mesma funcionalidade → mesmo commit
+- arquivos em camadas diferentes (ex: domain + REST) → commits separados por
+  camada
+
+Se um arquivo for ambíguo, sinalize a ambiguidade, tome a decisão e prossiga.
+
+#### 3.3 Tabela de prefixos para commit
+
+| Type                          | Prefix     | Emoji |
+| :---------------------------- | :--------- | :---- |
+| Domain layer                  | domain     | 🌐    |
+| REST API layer                | rest       | 📶    |
+| UI layer                      | ui         | 🖥️    |
+| Database layer                | db         | 💾    |
+| Work in progress              | wip        | 🚧    |
+| Artificial intelligence layer | ai         | 🤖    |
+| RPC layer                     | rpc        | 📟    |
+| Use cases                     | use case   | ✨    |
+| Interfaces                    | interface  | 📑    |
+| Typings                       | type       | 🏷️    |
+| Documentation                 | docs       | 📚    |
+| Bug fix                       | fix        | 🐛    |
+| Refactoring                   | refactor   | ♻️    |
+| Test                          | test       | 🧪    |
+| Config/Infrastructure         | config     | ⚙️    |
+| Dependencies                  | deps       | 📦    |
+| Folder structure              | ftree      | 🗃️    |
+| Provision layer               | provision  | 🧰    |
+| Response                      | response   | 📤    |
+| Design                        | design     | 🎨    |
+| Certificates/Licensing        | cert       | 📜    |
+| Validation schema             | validation | 📮    |
+| Emergency hotfix              | hotfix     | 🚑    |
+| Continuous delivery           | cd         | 🚚    |
+| Continuous integration        | ci         | 🏎️    |
+| New release                   | release    | 🔖    |
+| Docker files                  | docker     | 🐳    |
+
+#### 3.4 Padrão de mensagem e execução
+
+Formato obrigatório:
+
+```text
+emoji prefix: concise description in English
+```
+
+- mensagem obrigatoriamente em inglês
+- um commit por responsabilidade semântica
+- descrição curta, direta, no imperativo
+
+Para cada grupo identificado, execute:
+
+```bash
+git add <arquivos-do-grupo>
+git commit -m "emoji prefix: concise description in English"
+```
+
+Só avance para a criação do PR quando `git status --porcelain` estiver vazio.
+
+---
+
+### 4. Estrutura da Descrição (Body)
 
 O corpo do PR deve seguir o template abaixo.
 
@@ -134,7 +224,7 @@ Passo a passo claro para o revisor validar:
 
 ---
 
-### 4. Criação via gh CLI
+### 5. Criação via gh CLI
 
 ⚠️ Não usar GitHub MCP. ⚠️ Não usar APIs MCP. Usar exclusivamente **gh**.
 
@@ -161,7 +251,7 @@ gh pr create \
 
 ---
 
-### 5. Comentário de Code Review
+### 6. Comentário de Code Review
 
 Após criar o PR, adicione um comentário para solicitar code review do Codex:
 
@@ -171,7 +261,7 @@ gh pr comment <numero-do-pr> --body "@code review"
 
 ---
 
-### 6. Retorno
+### 7. Retorno
 
 Após criação:
 

--- a/documentation/prompts/implement-plan-prompt.md
+++ b/documentation/prompts/implement-plan-prompt.md
@@ -175,11 +175,13 @@ Instrucoes:
 
 - **MCP Serena:** utilize para buscar arquivos e implementacoes similares no projeto antes de criar algo novo.
 - **MCP Context7:** utilize quando houver duvida sobre como usar uma biblioteca especifica (ex: `shadcn/ui`, `radix-ui`, `inngest`, `supabase`, `hono`, `zod`).
+- **MCP Playwright:** utilize para validar mudancas em UI, paginas Next.js, fluxos browser, layout responsivo, formularios, modais, drawers, canvas ou estados visuais/interativos. A validacao deve abrir a rota impactada, executar o fluxo principal alterado e verificar que nao ha tela em branco, erro no console, overlay quebrado, texto sobreposto ou comportamento divergente da spec.
 
 ### 8. Progresso e reporte
 
 - Atualize o checklist de tarefas conforme implementa (marque `[x]` nas tarefas concluidas, incluindo tarefas de teste).
 - Ao final de cada fase, reporte: o que foi implementado, testes criados, arquivos tocados e pendencias.
+- Para fases que alterem UI/web, reporte tambem a validacao feita com MCP Playwright, incluindo rota validada, fluxo exercitado e screenshots quando relevantes.
 - Ao final do plano completo, entregue o reporte final (veja Saida esperada).
 
 ### 9. Atualizacao de Arquitetura e Rules (ao final da implementacao)

--- a/documentation/prompts/implement-spec-prompt.md
+++ b/documentation/prompts/implement-spec-prompt.md
@@ -1,0 +1,145 @@
+---
+description: Implementar diretamente uma spec pequena no codebase, sem criar plano formal, seguindo arquitetura e regras do Stardust.
+---
+
+# Prompt: Implementar Spec
+
+**Objetivo:** Implementar no codebase uma spec tecnica pequena ou um fix pontual descrito em spec, sem criar `plan.md` nem seguir o fluxo pesado de `implement-plan`. Este prompt serve para tarefas com baixo acoplamento, poucos arquivos impactados e ordem de execucao evidente.
+
+Use este prompt quando a spec ja estiver clara o suficiente para implementacao direta.
+
+Nao use este prompt quando a tarefa exigir fases, paralelizacao, dependencias entre apps/camadas, migrations complexas, contratos novos em multiplas bordas ou coordenacao de subagentes. Nesses casos, use `create-plan` + `implement-plan`.
+
+---
+
+## Entrada
+
+- **Spec:** caminho do arquivo em `documentation/features/**/specs/*-spec.md`.
+- **Escopo opcional:** trecho, requisito, secao ou issue especifica dentro da spec.
+- **Contexto opcional:** observacoes do usuario sobre prioridade, limite de escopo ou arquivos ja alterados.
+
+Se o caminho da spec nao for fornecido, tente descobrir automaticamente usando esta ordem:
+1. spec citada ou alterada na conversa atual;
+2. unico arquivo `documentation/features/**/specs/*-spec.md` relacionado ao dominio/feature mencionados;
+3. spec mais recentemente modificada.
+
+Se houver mais de um candidato plausivel, pare e peca confirmacao do caminho correto.
+
+---
+
+## Quando Usar
+
+Use `implement-spec` apenas se todas as condicoes abaixo forem verdadeiras:
+
+- A spec ja define claramente o comportamento esperado.
+- A implementacao cabe em uma sequencia curta de edicoes.
+- Nao ha necessidade de criar um plano por fases.
+- As dependencias entre camadas sao simples e evidentes.
+- A validacao pode ser feita com comandos locais de `codecheck`, `typecheck` e testes unitarios.
+
+Se qualquer condicao falhar, interrompa antes de editar e recomende `create-plan` + `implement-plan`.
+
+---
+
+## Diretrizes de Execucao
+
+### 1. Leitura Obrigatoria
+
+Antes de editar codigo:
+
+- Leia a spec inteira.
+- Leia `documentation/rules/rules.md`.
+- Identifique os apps e camadas tocados pela spec.
+- Leia apenas os arquivos de rules correspondentes as camadas que serao alteradas.
+- Localize no codigo os arquivos citados pela spec e implementacoes similares.
+
+Nao implemente com base em caminhos, metodos ou contratos sem confirmar que existem na codebase, exceto quando a spec marcar explicitamente como novo arquivo.
+
+### 2. Checagem de Escopo
+
+Classifique a tarefa antes de editar:
+
+- **Direta:** pode ser implementada agora com este prompt.
+- **Ampla:** exige plano formal; pare e recomende `implement-plan`.
+- **Ambigua:** falta decisao de produto ou arquitetura; pergunte ao usuario antes de editar.
+
+Uma tarefa deixa de ser direta se envolver:
+
+- duas ou mais apps com contrato novo entre elas;
+- migration com impacto de dados ou permissao;
+- nova entidade/use case/repository + UI consumidora no mesmo fluxo;
+- fila, provider externo, AI tool ou realtime;
+- alteracao de rules/arquitetura;
+- mais de uma decisao tecnica relevante ainda em aberto.
+
+### 3. Implementacao
+
+- Siga a spec como fonte de verdade.
+- Prefira a menor mudanca que entrega o comportamento especificado.
+- Siga os padroes dos arquivos vizinhos antes de criar abstracoes novas.
+- Preserve limites de camada:
+  - `core` nao importa frameworks, SDKs ou codigo de apps.
+  - UI nao acessa banco, providers externos ou infraestrutura diretamente.
+  - Auth, ownership e adaptacao de transporte ficam na borda quando esse ja for o padrao do fluxo.
+- Se encontrar divergencia factual na spec durante a implementacao, corrija a spec de forma cirurgica ou registre a pendencia quando a decisao nao for segura.
+
+### 4. Testes
+
+Adicione ou atualize testes quando a mudanca afetar regra de negocio, contrato, estado de UI, handler ou comportamento com regressao conhecida.
+
+Use as regras de teste correspondentes:
+
+| Tipo de artefato | Arquivo de regras |
+|---|---|
+| Objetos de dominio | `documentation/rules/domain-objects-testing-rules.md` |
+| Use cases | `documentation/rules/use-cases-testing-rules.md` |
+| Handlers | `documentation/rules/handlers-testing-rules.md` |
+| Rotas HTTP do server | `documentation/rules/server-routes-testing-rules.md` |
+| Rotas e pages da web | `documentation/rules/web-app-routes-testing-rules.md` |
+| Widgets | `documentation/rules/widget-tests-rules.md` |
+
+Nao crie testes fora dos padroes existentes do projeto.
+
+### 5. Validacao
+
+Apos alterar codigo, execute os comandos no workspace afetado:
+
+- `npm run typecheck`
+- `npm run codecheck`
+- `npm run test`
+
+Se a mudanca tocar UI, pagina Next.js, fluxo browser, layout responsivo, formulario, modal, drawer, canvas ou estado visual/interativo, valide tambem com **MCP Playwright**:
+
+- iniciar ou reutilizar o dev server do app afetado;
+- abrir a rota impactada no browser;
+- executar o fluxo principal alterado;
+- verificar visualmente/interativamente que nao ha tela em branco, erro no console, overlay quebrado, texto sobreposto ou comportamento divergente da spec;
+- capturar screenshot quando a validacao visual for relevante.
+
+Se o MCP Playwright nao estiver disponivel, rode os testes Playwright existentes ou registre claramente que a validacao browser ficou pendente.
+
+Se a mudanca tocar multiplos workspaces, valide cada workspace afetado ou rode os comandos equivalentes na raiz quando isso for mais adequado.
+
+Se algum comando falhar por causa da mudanca, corrija antes de encerrar. Se houver falha pre-existente fora do escopo, reporte com evidencia.
+
+### 6. Encerramento
+
+Ao final, responda com:
+
+- resumo curto do que foi implementado;
+- arquivos principais alterados;
+- comandos de validacao executados e resultado;
+- validacao Playwright/browser executada quando aplicavel;
+- pendencias, se houver.
+
+---
+
+## Restricoes
+
+- Nao crie plano formal.
+- Nao use subagentes.
+- Nao implemente alem do escopo da spec.
+- Nao invente arquivos, metodos, contratos ou schemas sem evidencia.
+- Nao reescreva specs inteiras; se precisar ajustar documento, faca edicao cirurgica.
+- Nao avance quando a spec exigir decisao arquitetural relevante sem confirmacao.
+- Nao substitua `implement-plan` em tarefas grandes; este prompt existe para tarefas menores.

--- a/documentation/rules/commit-rules.md
+++ b/documentation/rules/commit-rules.md
@@ -1,0 +1,196 @@
+# Regras de Commit
+
+Este documento define as regras para criar commits no repositório. Ele substitui
+o uso de prompts específicos de commit como fonte principal de decisão.
+
+## Objetivo
+
+Todo commit deve:
+
+- representar uma responsabilidade semântica única
+- facilitar leitura do histórico e revisão de mudanças
+- deixar claro o tipo de alteração feita
+- evitar commits ambíguos, genéricos ou misturados
+
+## Pré-condições obrigatórias
+
+Antes de criar qualquer commit, deve-se validar:
+
+- não existem arquivos previamente em stage que não façam parte do commit atual
+- existem alterações reais no worktree
+- os arquivos do grupo a ser commitado foram analisados pelo diff, não apenas pelo caminho
+
+Se já houver arquivos em stage sem relação direta com o commit pretendido, o
+processo deve parar até que o stage seja limpo ou reorganizado.
+
+## Regra de agrupamento
+
+Commits devem ser agrupados por responsabilidade semântica, não por pasta.
+
+### Deve
+
+- agrupar arquivos que implementam a mesma mudança funcional
+- separar mudanças independentes em commits diferentes
+- separar correções, refactors, testes, docs e config quando forem responsabilidades distintas
+
+### Não deve
+
+- juntar bugfix com refactor não necessário
+- juntar mudança de documentação com mudança de runtime sem relação clara
+- juntar alterações de camadas diferentes apenas porque estão no mesmo PR
+
+> ⚠️ Se um arquivo tocar mais de uma responsabilidade, a decisão deve ser feita
+> pelo conteúdo do diff. O caminho do arquivo sozinho não é suficiente.
+
+## Regra de análise
+
+Antes de classificar um commit, deve-se analisar:
+
+- o caminho do arquivo
+- o conteúdo real do diff
+- o impacto da alteração
+- se a mudança é nova feature, correção, refactor, teste, docs ou config
+
+Arquivos ambíguos devem ser classificados pela intenção predominante da mudança.
+
+## Formato obrigatório da mensagem
+
+Toda mensagem de commit deve seguir exatamente este formato:
+
+```text
+emoji prefix(scope opcional): concise description in English
+```
+
+Exemplos válidos:
+
+```text
+🐛 fix(server): align Inngest local discovery port
+📚 docs: document server commit rules
+🧪 test(web): cover notes drawer manual close flow
+⚙️ config: restore default server port
+```
+
+## Regras da mensagem
+
+### Deve
+
+- escrever a descrição em inglês
+- usar descrição curta, direta e específica
+- usar verbo no imperativo ou descrição objetiva de ação
+- usar apenas prefixos aprovados
+- incluir `scope` quando isso aumentar clareza
+
+### Não deve
+
+- usar mensagens vagas como `update code`, `fix stuff`, `changes`
+- usar português na descrição
+- inventar prefixos fora da tabela aprovada
+- descrever mais de uma mudança semântica na mesma mensagem
+
+## Tabela de prefixos aprovados
+
+| Tipo de alteração | Prefixo | Emoji |
+| --- | --- | --- |
+| Domínio | `domain` | `🌐` |
+| REST | `rest` | `📶` |
+| UI | `ui` | `🖥️` |
+| Banco de dados | `db` | `💾` |
+| Work in progress | `wip` | `🚧` |
+| Inteligência artificial | `ai` | `🤖` |
+| RPC | `rpc` | `📟` |
+| Use case | `use case` | `✨` |
+| Interfaces | `interface` | `📑` |
+| Tipos | `type` | `🏷️` |
+| Documentação | `docs` | `📚` |
+| Correção | `fix` | `🐛` |
+| Refactor | `refactor` | `♻️` |
+| Testes | `test` | `🧪` |
+| Configuração / infra | `config` | `⚙️` |
+| Dependências | `deps` | `📦` |
+| Estrutura de pastas | `ftree` | `🗃️` |
+| Providers / provision | `provision` | `🧰` |
+| Response | `response` | `📤` |
+| Design | `design` | `🎨` |
+| Certificados / licenças | `cert` | `📜` |
+| Validation | `validation` | `📮` |
+| Hotfix | `hotfix` | `🚑` |
+| Continuous delivery | `cd` | `🚚` |
+| Continuous integration | `ci` | `🏎️` |
+| Release | `release` | `🔖` |
+| Docker | `docker` | `🐳` |
+
+## Quando usar `scope`
+
+O `scope` é opcional, mas deve ser usado quando:
+
+- a mudança afeta um workspace específico como `web`, `server`, `studio` ou `core`
+- a mudança afeta um domínio claro como `auth`, `notes`, `space` ou `challenge`
+- o prefixo sozinho não deixa claro onde a mudança aconteceu
+
+Exemplos:
+
+- `🐛 fix(server): restore default port`
+- `📚 docs(rules): add commit message policy`
+- `🧪 test(profile): cover user absence controller`
+
+## Ordem recomendada de execução
+
+Para cada commit:
+
+1. analisar `git diff --stat`
+2. analisar `git diff` dos arquivos candidatos
+3. selecionar apenas o grupo semântico correto
+4. adicionar somente os arquivos do grupo
+5. criar o commit com mensagem no padrão
+6. repetir até não restarem mudanças pendentes
+
+## Critérios de qualidade
+
+Antes de executar o commit, deve-se confirmar:
+
+- a mensagem representa corretamente o diff
+- não há arquivos de outra responsabilidade no mesmo stage
+- o prefixo escolhido é consistente com a alteração
+- o commit melhora, e não piora, a legibilidade do histórico
+
+## Casos que exigem atenção extra
+
+### Mudanças ambíguas
+
+Se um arquivo puder ser classificado em mais de uma categoria:
+
+- deve-se escolher a categoria com base no conteúdo do diff
+- deve-se priorizar a responsabilidade principal entregue pelo arquivo
+
+### Mudanças grandes
+
+Se o worktree tiver alterações extensas:
+
+- deve-se preferir dividir em múltiplos commits pequenos e coerentes
+- não se deve usar um único commit "guarda-chuva"
+
+### Worktree sujo
+
+Se houver alterações não relacionadas:
+
+- deve-se evitar commitá-las juntas
+- deve-se isolar o escopo da mudança atual
+
+## O que é proibido
+
+- criar commit sem revisar o diff
+- criar commit com stage previamente contaminado
+- misturar responsabilidades independentes
+- usar mensagem genérica
+- usar prefixo fora da tabela
+- fazer `amend` sem solicitação explícita
+
+## Relação com outras regras
+
+Ao preparar um commit, também deve-se respeitar:
+
+- `documentation/rules/code-conventions-rules.md`
+- `documentation/rules/rules.md`
+
+Se a mudança envolver uma camada específica, as regras dessa camada também
+devem ser consultadas antes de definir a mensagem final.

--- a/documentation/rules/mcp-rules.md
+++ b/documentation/rules/mcp-rules.md
@@ -1,0 +1,160 @@
+# Regras de Uso de MCPs
+
+## Objetivo
+
+Os MCPs do projeto existem para acelerar leitura de contexto, validacao de
+comportamento real, integracao com servicos externos e edicao assistida de
+artefatos fora do codigo. Eles devem ser usados como extensoes operacionais do
+trabalho, nao como substitutos de analise tecnica.
+
+## MCPs suportados no projeto
+
+- **Context7**: buscar documentacao atualizada de bibliotecas, frameworks,
+  SDKs, APIs e CLIs.
+- **Serena**: navegar a codebase com leitura semantica e localizar simbolos com
+  custo menor que abrir arquivos inteiros.
+- **Pencil**: ler e editar arquivos `.pen`, validar layout e trabalhar com
+  contexto de design.
+- **Supabase Dev**: inspecionar e operar o ambiente de desenvolvimento do
+  Supabase.
+- **Supabase Prod**: inspecionar o ambiente de producao do Supabase com cuidado
+  extra.
+- **Playwright MCP**: validar fluxos reais de navegador, navegacao,
+  autenticacao, scroll, formularios e regressao visual/interativa.
+
+## Regras gerais
+
+- Sempre escolha o MCP mais especifico para a tarefa antes de recorrer a shell
+  ou web search genérico.
+- Nao use MCP quando a resposta pode ser obtida de forma mais simples e segura
+  pelo proprio codebase local.
+- Nao assuma que o MCP esta pronto para uso: confirme pre-requisitos do
+  ambiente quando a ferramenta depende de binarios, servicos locais, sessao ou
+  credenciais.
+- Trate a saida do MCP como evidencia operacional. Ainda e necessario
+  interpretar o resultado com base na arquitetura e nas regras do projeto.
+- Quando o MCP revelar falha de infraestrutura ou ambiente, registre isso
+  explicitamente em vez de concluir incorretamente que o bug esta no codigo.
+
+## Quando usar cada MCP
+
+### Context7
+
+Use quando a tarefa depender de documentacao atualizada e houver risco de
+desvio por informacao desatualizada.
+
+Use para:
+
+- sintaxe e contratos de bibliotecas;
+- opcoes de configuracao;
+- migracoes de versao;
+- comportamento atual de ferramentas externas.
+
+Nao use como fonte principal para explicar o proprio codebase do projeto.
+
+### Serena
+
+Use no inicio de tarefas de implementacao, investigacao ou review para localizar
+simbolos, dependencias e referencias sem abrir arquivos desnecessariamente.
+
+Boas praticas:
+
+- prefira localizar simbolos e referencias antes de ler arquivos inteiros;
+- leia apenas os corpos realmente necessarios;
+- use para confirmar onde um contrato e definido e onde ele e consumido.
+
+### Pencil
+
+Use somente para arquivos `.pen` ou quando a tarefa exigir contexto real de
+design do editor.
+
+Boas praticas:
+
+- obtenha primeiro o estado/schema atual do editor;
+- use screenshot apenas quando validacao visual for necessaria;
+- prefira validacao estrutural quando o objetivo for layout ou hierarquia.
+
+### Supabase Dev e Supabase Prod
+
+Use para verificar schema, logs, configuracao e dados relacionados ao fluxo
+investigado.
+
+Boas praticas:
+
+- comece por inspecao antes de alterar qualquer coisa;
+- prefira `Dev` por padrao;
+- use `Prod` apenas quando a pergunta exigir o estado real de producao;
+- em producao, evite operacoes mutativas sem necessidade objetiva e evidencia.
+
+### Playwright MCP
+
+Use quando a mudanca tocar comportamento visual ou interativo real:
+
+- paginas autenticadas;
+- navegacao;
+- formularios;
+- scroll;
+- modais e drawers;
+- regressao de layout;
+- comportamento do browser que teste unitario nao cobre bem.
+
+## Regras especificas para o Playwright MCP
+
+### Pre-requisitos
+
+Antes de abrir a pagina:
+
+- confirme que o app correto esta rodando na porta esperada;
+- confirme que o binario exigido pelo MCP existe no host;
+- confirme que a URL responde sem erro estrutural;
+- confirme se a rota exige autenticacao.
+
+### Sessao e autenticacao
+
+- O navegador do MCP usa contexto isolado. Login manual no navegador local do
+  usuario nao implica sessao autenticada no Playwright.
+- Para rotas autenticadas, autentique dentro do proprio MCP ou injete a sessao
+  explicitamente.
+- Quando for necessario autenticar no ambiente atual para validar paginas
+  protegidas, use as credenciais informadas pelo usuario neste projeto:
+  `ctrlaltdel.cursor@gmail.com` / `123456`.
+- Se a rota protegida redirecionar para login, nao trate isso como bug da tela
+  alvo sem antes validar ausencia de sessao.
+
+### Validacao correta
+
+- Nao confie apenas na URL final. Capture snapshot, console e, quando fizer
+  sentido, screenshot.
+- Diferencie erro de produto de erro de ambiente. Exemplo: assets `404`,
+  processo incorreto na porta, sessao ausente, server quebrado.
+- Quando medir bugs de scroll ou viewport, colete dimensoes reais do container
+  rolavel e do elemento alvo no contexto do browser.
+- Quando o fluxo depender de animacao, lazy-load ou layout tardio, aguarde
+  estado estavel antes de concluir que o comportamento esta correto.
+
+### Limites
+
+- Warnings de console so importam quando afetam diretamente o fluxo validado.
+- Erros auxiliares em requests paralelos devem ser registrados, mas nao devem
+  invalidar a conclusao principal sem nexo causal claro.
+- Se o MCP falhar por infraestrutura, documente a causa exata e a etapa que
+  ficou pendente.
+
+## Ordem recomendada de uso
+
+1. Confirmar o objetivo e o tipo de validacao necessario.
+2. Escolher o MCP apropriado.
+3. Verificar pre-requisitos de ambiente.
+4. Executar a leitura ou validacao.
+5. Registrar evidencias observadas.
+6. Separar problema de ambiente, problema de dados e problema de codigo.
+
+## Anti-padroes
+
+- Usar Playwright para tentar provar bug de UI sem app rodando corretamente.
+- Usar Context7 para responder pergunta sobre codigo local que Serena ou leitura
+  direta resolveriam melhor.
+- Usar Supabase Prod quando Dev e suficiente.
+- Concluir que uma rota esta quebrada sem verificar autenticacao, redirect ou
+  contexto isolado do navegador.
+- Ignorar falhas de infraestrutura do MCP e seguir com conclusoes especulativas.

--- a/documentation/rules/rules.md
+++ b/documentation/rules/rules.md
@@ -16,6 +16,16 @@ Sempre consulte os arquivos específicos abaixo com base na tarefa em questão.
 - Para regras sobre Barrel files (index.ts).
 - Ao criar classes de Evento ou Erro.
 
+## Regras de Commit
+
+**Arquivo:** `/documentation/rules/commit-rules.md`
+**Quando consultar:**
+
+- Antes de criar commits no repositório.
+- Para escolher o prefixo, emoji e formato da mensagem de commit.
+- Para agrupar alterações por responsabilidade semântica.
+- Para substituir o uso de prompts específicos de commit como fonte principal de decisão.
+
 ## Regras da Camada UI
 
 **Arquivo:** `/documentation/rules/ui-layer-rules.md`
@@ -100,6 +110,18 @@ Sempre consulte os arquivos específicos abaixo com base na tarefa em questão.
 - Ao implementar tools, agentes, prompts ou fluxos de IA.
 - Para entender as fronteiras entre adapters de IA e contratos internos do projeto.
 - Ao integrar modelos, provedores ou orchestration de inferencia.
+
+## Regras de Uso de MCPs
+
+**Arquivo:** `/documentation/rules/mcp-rules.md`
+**Quando consultar:**
+
+- Ao decidir qual MCP usar para uma tarefa.
+- Ao validar fluxos reais de browser com Playwright MCP.
+- Ao navegar a codebase com Serena.
+- Ao consultar documentacao atualizada com Context7.
+- Ao interagir com Supabase Dev/Prod.
+- Ao trabalhar com arquivos `.pen` via Pencil.
 
 ## Regras da Aplicação Web
 

--- a/documentation/rules/server-application-rules.md
+++ b/documentation/rules/server-application-rules.md
@@ -38,10 +38,11 @@ npm install
 **Execute a aplicacao em modo de desenvolvimento**
 
 ```bash
+docker compose up -d redis inngest
 npm run dev
 ```
 
-> O servidor HTTP inicia, por padrao, na porta definida em `PORT` (ex.: http://localhost:3333). O dev server do Inngest tambem e iniciado pelo script.
+> O servidor HTTP inicia, por padrao, em `http://localhost:3333` quando `PORT` nao esta definida. O runtime local do Inngest deve ser iniciado via `docker compose`, fica disponivel em `http://127.0.0.1:8288` e faz discovery em `http://host.docker.internal:3333/inngest`.
 
 ## Executando os testes
 
@@ -56,9 +57,9 @@ npm run test
 ## Tooling
 
 - Scripts do workspace `@stardust/server`:
-  - Dev (server + Inngest): `npm run dev -w @stardust/server`
-  - Dev (apenas HTTP): `npm run dev:server -w @stardust/server`
-  - Dev (apenas Inngest local): `npm run dev:queue -w @stardust/server`
+  - Dev (HTTP): `npm run dev -w @stardust/server`
+  - Dev (HTTP, alias explicito): `npm run dev:server -w @stardust/server`
+  - Inngest local: `docker compose up -d ingest`
   - Build: `npm run build -w @stardust/server`
   - Producao: `npm run prod -w @stardust/server`
   - Qualidade: `npm run codecheck -w @stardust/server` (`lint` + `format`)

--- a/documentation/sdd.md
+++ b/documentation/sdd.md
@@ -5,7 +5,7 @@
 SDD é o modelo de desenvolvimento adotado pelo Stardust em que **nenhum código é escrito antes de existir uma especificação técnica formal derivada de um PRD**. Toda feature, correção ou refatoração percorre uma cadeia documental rastreável antes de virar código:
 
 ```
-milestone → PRD → spec técnica → plano de implementação → código → revisão
+milestone → PRD → spec técnica → implementação direta ou plano → código → revisão
 ```
 
 O objetivo é eliminar ambiguidade antes da implementação, permitindo que desenvolvedores e agentes de IA executem tarefas dentro de limites bem definidos.
@@ -50,6 +50,7 @@ O pipeline é orquestrado por prompts dedicados em `documentation/prompts/`. Cad
 **Saída:** `documentation/plan.md`
 
 - Transforma a spec em fases e tarefas atômicas com dependências explícitas.
+- Use esta etapa quando a spec exigir coordenação sofisticada: múltiplas fases, múltiplos apps/camadas, dependências não triviais, paralelização, migrations complexas ou contratos novos entre bordas.
 - Ordem bottom-up obrigatória:
   - **F1 — Core:** domínio, structures, use cases.
   - **F2, F3, F4 — Apps** (server, web, studio): só iniciam após F1 concluída; podem rodar em paralelo entre si.
@@ -59,7 +60,23 @@ O pipeline é orquestrado por prompts dedicados em `documentation/prompts/`. Cad
   - Resultado observável verificável sem ambiguidade
 - Apps não impactados são omitidos do plano.
 
-### 4. Implementação — `implement-plan-prompt.md`
+### 4. Implementação Direta — `implement-spec-prompt.md`
+
+**Entrada:** spec técnica pequena.
+**Saída:** código implementado na codebase, sem plano formal.
+
+- Caminho leve para specs pequenas, fixes pontuais e mudanças com baixo acoplamento.
+- Não cria `plan.md`, não usa subagentes e não quebra a entrega em fases formais.
+- Só deve ser usado quando:
+  - a spec está clara;
+  - a ordem de execução é evidente;
+  - poucos arquivos serão alterados;
+  - não há contratos novos entre múltiplas apps;
+  - a validação cabe em `typecheck`, `codecheck` e testes locais do workspace afetado.
+- Se durante a leitura a tarefa se revelar ampla ou ambígua, o fluxo deve parar e migrar para `create-plan` + `implement-plan`.
+- Continua obrigatório ler `documentation/rules/rules.md` e as regras das camadas alteradas antes de editar código.
+
+### 5. Implementação Planejada — `implement-plan-prompt.md`
 
 **Entrada:** `documentation/plan.md` (ou caminho alternativo).
 **Saída:** código implementado na codebase, checkboxes atualizados no `plan.md`.
@@ -74,7 +91,7 @@ O pipeline é orquestrado por prompts dedicados em `documentation/prompts/`. Cad
 - O progresso é rastreado nos checkboxes do próprio `plan.md`.
 - Planos parcialmente concluídos são retomados a partir da primeira tarefa pendente.
 
-### 5. Revisão — `conclude-spec-prompt.md`
+### 6. Revisão — `conclude-spec-prompt.md`
 
 **Entrada:** spec técnica que guiou a implementação.
 **Saída:** spec fechada, PRD atualizado, resumo estruturado para PR.
@@ -109,12 +126,14 @@ Executa três fases sequenciais:
 Bugs seguem um caminho em duas etapas documentais antes de entrar no pipeline principal:
 
 ```
-relato do problema → bug report → spec de correção separada → plano → implementação → revisão
+relato do problema → bug report → spec de correção separada → implementação direta ou plano → revisão
 ```
 
-- O bug report documenta sintoma, impacto, evidências, diagnóstico e plano inicial de correção.
-- A spec de correção é criada depois, em **arquivo próprio** dentro de `documentation/features/<domínio>/specs/`, usando o bug report como insumo.
+- O bug report documenta sintoma, impacto, evidências, diagnóstico e um direcionamento curto de correção.
+- O bug report **não** contém plano de implementação, tarefas, fases ou seções do tipo “o que criar/modificar/remover”.
+- A spec de correção é criada depois, apenas quando solicitada, em **arquivo próprio** dentro de `documentation/features/<domínio>/specs/`, usando o bug report como insumo.
 - Bug report e spec **não** coexistem no mesmo `.md`.
+- Specs de correção pequenas podem seguir direto para `implement-spec`; specs complexas devem passar por `create-plan` + `implement-plan`.
 
 ---
 
@@ -129,6 +148,8 @@ relato do problema → bug report → spec de correção separada → plano → 
 | Plano de implementação | `documentation/plan.md` |
 | Regras por camada | `documentation/rules/` (índice em `rules.md`) |
 | Prompts do pipeline | `documentation/prompts/` |
+| Implementação direta | `documentation/prompts/implement-spec-prompt.md` |
+| Implementação planejada | `documentation/prompts/implement-plan-prompt.md` |
 
 ---
 
@@ -137,6 +158,7 @@ relato do problema → bug report → spec de correção separada → plano → 
 1. **Código é derivado, nunca ponto de partida.** Toda mudança nasce de uma cadeia documental rastreável.
 2. **Ambiguidade se resolve antes do código.** Se a spec tem lacunas, registrar em pendências e perguntar — nunca inventar.
 3. **Cada camada tem suas regras.** Ler as regras antes de implementar é obrigatório, não opcional.
-4. **Bottom-up sempre.** Core antes de infra, infra antes de API, API antes de UI.
-5. **Verificação contínua.** Lint, typecheck e testes passam após cada tarefa, não apenas no final.
-6. **Documentação acompanha o código.** Spec, PRD, arquitetura e rules são atualizados junto com a implementação, nunca depois.
+4. **Escolha o peso certo.** Specs pequenas podem ir direto para `implement-spec`; specs com dependências relevantes exigem plano formal.
+5. **Bottom-up sempre que houver dependência entre camadas.** Core antes de infra, infra antes de API, API antes de UI.
+6. **Verificação contínua.** Lint, typecheck e testes passam no escopo afetado; em plano formal, passam após cada tarefa.
+7. **Documentação acompanha o código.** Spec, PRD, arquitetura e rules são atualizados junto com a implementação, nunca depois.

--- a/documentation/tooling.md
+++ b/documentation/tooling.md
@@ -103,8 +103,8 @@ Workspaces comuns:
 ## Server (API + Queue)
 
 ```bash
+docker compose up -d redis inngest
 npm run dev -w @stardust/server
-npm run dev:queue -w @stardust/server
 ```
 
 ## Database (workspace `@stardust/server`)
@@ -123,6 +123,7 @@ npm run db:types -w @stardust/server
 
 Notas:
 - A fonte de verdade da Supabase CLI do server é `apps/server/supabase/`.
+- O runtime local do Inngest sobe via `docker compose` no servico `inngest`, exposto em `http://127.0.0.1:8288`, e deve apontar para `http://host.docker.internal:3333/inngest` quando o server roda com a porta default.
 - Em produção, as migrations devem rodar no workflow de deploy antes do release da aplicação.
 
 ## Hooks

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,6 @@
         "@types/supertest": "^7.2.0",
         "jest": "^29.7.0",
         "jest-environment-node": "^29.7.0",
-        "npm-run-all": "^4.1.5",
         "supabase": "^2.98.2",
         "supertest": "^7.2.2",
         "ts-jest": "^29.4.4",
@@ -3354,6 +3353,80 @@
         "@biomejs/cli-win32-x64": "2.2.3"
       }
     },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.2.3.tgz",
+      "integrity": "sha512-OrqQVBpadB5eqzinXN4+Q6honBz+tTlKVCsbEuEpljK8ASSItzIRZUA02mTikl3H/1nO2BMPFiJ0nkEZNy3B1w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.2.3.tgz",
+      "integrity": "sha512-OCdBpb1TmyfsTgBAM1kPMXyYKTohQ48WpiN9tkt9xvU6gKVKHY4oVwteBebiOqyfyzCNaSiuKIPjmHjUZ2ZNMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.2.3.tgz",
+      "integrity": "sha512-g/Uta2DqYpECxG+vUmTAmUKlVhnGEcY7DXWgKP8ruLRa8Si1QHsWknPY3B/wCo0KgYiFIOAZ9hjsHfNb9L85+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.2.3.tgz",
+      "integrity": "sha512-q3w9jJ6JFPZPeqyvwwPeaiS/6NEszZ+pXKF+IczNo8Xj6fsii45a4gEEicKyKIytalV+s829ACZujQlXAiVLBQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
     "node_modules/@biomejs/cli-linux-x64": {
       "version": "2.2.3",
       "cpu": [
@@ -3379,6 +3452,40 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.2.3.tgz",
+      "integrity": "sha512-Ms9zFYzjcJK7LV+AOMYnjN3pV3xL8Prxf9aWdDVL74onLn5kcvZ1ZMQswE5XHtnd/r/0bnUd928Rpbs14BzVmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.2.3.tgz",
+      "integrity": "sha512-gvCpewE7mBwBIpqk1YrUqNR4mCiyJm6UI3YWQQXkedSSEwzRdodRpaKhbdbHw1/hmTWOVXQ+Eih5Qctf4TCVOQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=14.21.3"
@@ -3833,7 +3940,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -3856,7 +3962,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -7859,7 +7964,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@tybys/wasm-util": "^0.10.3"
       },
@@ -12671,7 +12775,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -13193,8 +13296,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-android-arm64": {
       "version": "1.12.2",
@@ -13208,8 +13310,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
       "version": "1.12.2",
@@ -13223,8 +13324,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-darwin-x64": {
       "version": "1.12.2",
@@ -13238,8 +13338,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-freebsd-x64": {
       "version": "1.12.2",
@@ -13253,8 +13352,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
       "version": "1.12.2",
@@ -13268,8 +13366,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
       "version": "1.12.2",
@@ -13283,8 +13380,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
       "version": "1.12.2",
@@ -13298,8 +13394,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
       "version": "1.12.2",
@@ -13313,8 +13408,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
       "version": "1.12.2",
@@ -13328,8 +13422,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-loong64-musl": {
       "version": "1.12.2",
@@ -13343,8 +13436,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
       "version": "1.12.2",
@@ -13358,8 +13450,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
       "version": "1.12.2",
@@ -13373,8 +13464,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
       "version": "1.12.2",
@@ -13388,8 +13478,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
       "version": "1.12.2",
@@ -13403,8 +13492,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
       "version": "1.12.2",
@@ -13418,8 +13506,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-musl": {
       "version": "1.12.2",
@@ -13433,8 +13520,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-openharmony-arm64": {
       "version": "1.12.2",
@@ -13448,8 +13534,7 @@
       "optional": true,
       "os": [
         "openharmony"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-wasm32-wasi": {
       "version": "1.12.2",
@@ -13461,7 +13546,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.10.0",
         "@emnapi/runtime": "1.10.0",
@@ -13483,8 +13567,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
       "version": "1.12.2",
@@ -13498,8 +13581,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
       "version": "1.12.2",
@@ -13513,8 +13595,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@use-gesture/core": {
       "version": "10.3.1",
@@ -13788,21 +13869,6 @@
         "dequal": "^2.0.3"
       }
     },
-    "node_modules/array-buffer-byte-length": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "is-array-buffer": "^3.0.5"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "license": "MIT"
@@ -13811,26 +13877,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/arraybuffer.prototype.slice": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.1",
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "is-array-buffer": "^3.0.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/asap": {
       "version": "2.0.6",
@@ -13859,14 +13905,6 @@
       "license": "MIT",
       "bin": {
         "astring": "bin/astring"
-      }
-    },
-    "node_modules/async-function": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/async-retry": {
@@ -13925,20 +13963,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/available-typed-arrays": {
-      "version": "1.0.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "possible-typed-array-names": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/axios": {
@@ -14547,23 +14571,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/call-bind": {
-      "version": "1.0.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -15574,54 +15581,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/data-view-buffer": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "is-data-view": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/data-view-byte-length": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "is-data-view": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/inspect-js"
-      }
-    },
-    "node_modules/data-view-byte-offset": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "is-data-view": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/date-fns": {
       "version": "4.1.0",
       "license": "MIT",
@@ -15752,22 +15711,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/define-lazy-prop": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
@@ -15779,22 +15722,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/define-properties": {
-      "version": "1.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.0.1",
-        "has-property-descriptors": "^1.0.0",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/defu": {
@@ -16232,73 +16159,6 @@
         "is-arrayish": "^0.2.1"
       }
     },
-    "node_modules/es-abstract": {
-      "version": "1.24.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.2",
-        "arraybuffer.prototype.slice": "^1.0.4",
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "data-view-buffer": "^1.0.2",
-        "data-view-byte-length": "^1.0.2",
-        "data-view-byte-offset": "^1.0.1",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "es-set-tostringtag": "^2.1.0",
-        "es-to-primitive": "^1.3.0",
-        "function.prototype.name": "^1.1.8",
-        "get-intrinsic": "^1.3.0",
-        "get-proto": "^1.0.1",
-        "get-symbol-description": "^1.1.0",
-        "globalthis": "^1.0.4",
-        "gopd": "^1.2.0",
-        "has-property-descriptors": "^1.0.2",
-        "has-proto": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "internal-slot": "^1.1.0",
-        "is-array-buffer": "^3.0.5",
-        "is-callable": "^1.2.7",
-        "is-data-view": "^1.0.2",
-        "is-negative-zero": "^2.0.3",
-        "is-regex": "^1.2.1",
-        "is-set": "^2.0.3",
-        "is-shared-array-buffer": "^1.0.4",
-        "is-string": "^1.1.1",
-        "is-typed-array": "^1.1.15",
-        "is-weakref": "^1.1.1",
-        "math-intrinsics": "^1.1.0",
-        "object-inspect": "^1.13.4",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.7",
-        "own-keys": "^1.0.1",
-        "regexp.prototype.flags": "^1.5.4",
-        "safe-array-concat": "^1.1.3",
-        "safe-push-apply": "^1.0.0",
-        "safe-regex-test": "^1.1.0",
-        "set-proto": "^1.0.0",
-        "stop-iteration-iterator": "^1.1.0",
-        "string.prototype.trim": "^1.2.10",
-        "string.prototype.trimend": "^1.0.9",
-        "string.prototype.trimstart": "^1.0.8",
-        "typed-array-buffer": "^1.0.3",
-        "typed-array-byte-length": "^1.0.3",
-        "typed-array-byte-offset": "^1.0.4",
-        "typed-array-length": "^1.0.7",
-        "unbox-primitive": "^1.1.0",
-        "which-typed-array": "^1.1.19"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "license": "MIT",
@@ -16339,22 +16199,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-to-primitive": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-callable": "^1.2.7",
-        "is-date-object": "^1.0.5",
-        "is-symbol": "^1.0.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/esbuild": {
@@ -17471,20 +17315,6 @@
         }
       }
     },
-    "node_modules/for-each": {
-      "version": "0.3.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-callable": "^1.2.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "license": "ISC",
@@ -17640,33 +17470,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/function.prototype.name": {
-      "version": "1.1.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
-        "functions-have-names": "^1.2.3",
-        "hasown": "^2.0.2",
-        "is-callable": "^1.2.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/functions-have-names": {
-      "version": "1.2.3",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/gaxios": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
@@ -17743,14 +17546,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/generator-function": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/gensync": {
@@ -17849,22 +17644,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/get-symbol-description": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-tsconfig": {
@@ -18014,21 +17793,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/globalthis": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-properties": "^1.2.1",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/globrex": {
       "version": "0.1.2",
       "dev": true,
@@ -18166,47 +17930,11 @@
         "uglify-js": "^3.1.4"
       }
     },
-    "node_modules/has-bigints": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-proto": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -18264,11 +17992,6 @@
       "engines": {
         "node": ">=16.9.0"
       }
-    },
-    "node_modules/hosted-git-info": {
-      "version": "2.8.9",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
@@ -18637,19 +18360,6 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
-    "node_modules/internal-slot": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "hasown": "^2.0.2",
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/internmap": {
       "version": "2.0.3",
       "license": "ISC",
@@ -18713,58 +18423,10 @@
         "url": "https://github.com/sponsors/brc-dd"
       }
     },
-    "node_modules/is-array-buffer": {
-      "version": "3.0.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "get-intrinsic": "^1.2.6"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/is-async-function": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "async-function": "^1.0.0",
-        "call-bound": "^1.0.3",
-        "get-proto": "^1.0.1",
-        "has-tostringtag": "^1.0.2",
-        "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-bigint": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-bigints": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -18776,68 +18438,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-boolean-object": {
-      "version": "1.2.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-callable": {
-      "version": "1.2.7",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-core-module": {
       "version": "2.16.1",
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-data-view": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "get-intrinsic": "^1.2.6",
-        "is-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-date-object": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -18876,20 +18481,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-finalizationregistry": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "license": "MIT",
@@ -18905,24 +18496,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/is-generator-function": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.4",
-        "generator-function": "^2.0.0",
-        "get-proto": "^1.0.1",
-        "has-tostringtag": "^1.0.2",
-        "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -18980,28 +18553,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-map": {
-      "version": "2.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-negative-zero": {
-      "version": "2.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-network-error": {
       "version": "1.3.0",
       "license": "MIT",
@@ -19017,21 +18568,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
-      }
-    },
-    "node_modules/is-number-object": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-obj": {
@@ -19061,48 +18597,6 @@
       "version": "2.2.2",
       "license": "MIT"
     },
-    "node_modules/is-regex": {
-      "version": "1.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-set": {
-      "version": "2.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-shared-array-buffer": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-ssh": {
       "version": "1.4.1",
       "dev": true,
@@ -19122,37 +18616,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-string": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-symbol": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-symbols": "^1.1.0",
-        "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-text-path": {
       "version": "2.0.0",
       "dev": true,
@@ -19164,20 +18627,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-typed-array": {
-      "version": "1.1.15",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "which-typed-array": "^1.1.16"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-unicode-supported": {
       "version": "2.1.0",
       "license": "MIT",
@@ -19186,46 +18635,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-weakmap": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-weakref": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-weakset": {
-      "version": "2.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "get-intrinsic": "^1.2.6"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-wsl": {
@@ -19243,11 +18652,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/isarray": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/isbot": {
       "version": "5.1.32",
@@ -22760,11 +22164,6 @@
         "bignumber.js": "^9.0.0"
       }
     },
-    "node_modules/json-parse-better-errors": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "dev": true,
@@ -23030,48 +22429,6 @@
       "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
       "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
       "license": "MIT"
-    },
-    "node_modules/load-json-file": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^4.0.0",
-        "pify": "^3.0.0",
-        "strip-bom": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/load-json-file/node_modules/parse-json": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/load-json-file/node_modules/pify": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/load-json-file/node_modules/strip-bom": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/load-tsconfig": {
       "version": "0.2.5",
@@ -23655,13 +23012,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/memorystream": {
-      "version": "0.3.1",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.10.0"
       }
     },
     "node_modules/meow": {
@@ -24728,11 +24078,6 @@
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
-    "node_modules/nice-try": {
-      "version": "1.0.5",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "funding": [
@@ -24804,25 +24149,6 @@
       "version": "2.0.27",
       "license": "MIT"
     },
-    "node_modules/normalize-package-data": {
-      "version": "2.5.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "5.7.2",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "license": "MIT",
@@ -24840,179 +24166,6 @@
     "node_modules/normalize-wheel": {
       "version": "1.0.1",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/npm-run-all": {
-      "version": "4.1.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "chalk": "^2.4.1",
-        "cross-spawn": "^6.0.5",
-        "memorystream": "^0.3.1",
-        "minimatch": "^3.0.4",
-        "pidtree": "^0.3.0",
-        "read-pkg": "^3.0.0",
-        "shell-quote": "^1.6.1",
-        "string.prototype.padend": "^3.0.0"
-      },
-      "bin": {
-        "npm-run-all": "bin/npm-run-all/index.js",
-        "run-p": "bin/run-p/index.js",
-        "run-s": "bin/run-s/index.js"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/npm-run-all/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/npm-run-all/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/npm-run-all/node_modules/chalk": {
-      "version": "2.4.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/npm-run-all/node_modules/color-convert": {
-      "version": "1.9.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/npm-run-all/node_modules/color-name": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/npm-run-all/node_modules/cross-spawn": {
-      "version": "6.0.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      },
-      "engines": {
-        "node": ">=4.8"
-      }
-    },
-    "node_modules/npm-run-all/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/npm-run-all/node_modules/has-flag": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/npm-run-all/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/npm-run-all/node_modules/path-key": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/npm-run-all/node_modules/semver": {
-      "version": "5.7.2",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/npm-run-all/node_modules/shebang-command": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/npm-run-all/node_modules/shebang-regex": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/npm-run-all/node_modules/supports-color": {
-      "version": "5.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/npm-run-all/node_modules/which": {
-      "version": "1.3.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
     },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
@@ -25118,33 +24271,6 @@
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object-keys": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/object.assign": {
-      "version": "4.1.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0",
-        "has-symbols": "^1.1.0",
-        "object-keys": "^1.1.1"
-      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -25306,22 +24432,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/own-keys": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.2.6",
-        "object-keys": "^1.1.1",
-        "safe-push-apply": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/p-limit": {
@@ -25633,25 +24743,6 @@
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
-    "node_modules/path-type": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pify": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/path-type/node_modules/pify": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/pathe": {
       "version": "1.1.2",
       "dev": true,
@@ -25699,17 +24790,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/pidtree": {
-      "version": "0.3.1",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "pidtree": "bin/pidtree.js"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/pify": {
@@ -25855,7 +24935,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -25864,14 +24943,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/possible-typed-array-names": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -27313,19 +26384,6 @@
         "pify": "^2.3.0"
       }
     },
-    "node_modules/read-pkg": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "load-json-file": "^4.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -27440,27 +26498,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/reflect.getprototypeof": {
-      "version": "1.0.10",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.9",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
-        "get-intrinsic": "^1.2.7",
-        "get-proto": "^1.0.1",
-        "which-builtin-type": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "dev": true,
@@ -27475,25 +26512,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/regexp.prototype.flags": {
-      "version": "1.5.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-errors": "^1.3.0",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "set-function-name": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/release-it": {
@@ -27916,24 +26934,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/safe-array-concat": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
-        "get-intrinsic": "^1.2.6",
-        "has-symbols": "^1.1.0",
-        "isarray": "^2.0.5"
-      },
-      "engines": {
-        "node": ">=0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "funding": [
@@ -27951,37 +26951,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/safe-push-apply": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "isarray": "^2.0.5"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/safe-regex-test": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "is-regex": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -28100,49 +27069,6 @@
       "version": "2.7.2",
       "license": "MIT"
     },
-    "node_modules/set-function-length": {
-      "version": "1.2.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/set-function-name": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "functions-have-names": "^1.2.3",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/set-proto": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
@@ -28215,19 +27141,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/shell-quote": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
-      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/side-channel": {
@@ -28456,34 +27369,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/spdx-correct": {
-      "version": "3.2.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/spdx-exceptions": {
-      "version": "2.5.0",
-      "dev": true,
-      "license": "CC-BY-3.0"
-    },
-    "node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/spdx-license-ids": {
-      "version": "3.0.22",
-      "dev": true,
-      "license": "CC0-1.0"
-    },
     "node_modules/split2": {
       "version": "4.2.0",
       "dev": true,
@@ -28555,18 +27440,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/stop-iteration-iterator": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "internal-slot": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/string_decoder": {
@@ -28672,76 +27545,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/string.prototype.padend": {
-      "version": "3.1.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/string.prototype.trim": {
-      "version": "1.2.10",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
-        "define-data-property": "^1.1.4",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-object-atoms": "^1.0.0",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/string.prototype.trimend": {
-      "version": "1.0.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/string.prototype.trimstart": {
-      "version": "1.0.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/strip-ansi": {
@@ -29908,76 +28711,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/typed-array-buffer": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "is-typed-array": "^1.1.14"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/typed-array-byte-length": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "for-each": "^0.3.3",
-        "gopd": "^1.2.0",
-        "has-proto": "^1.2.0",
-        "is-typed-array": "^1.1.14"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/typed-array-byte-offset": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
-        "for-each": "^0.3.3",
-        "gopd": "^1.2.0",
-        "has-proto": "^1.2.0",
-        "is-typed-array": "^1.1.15",
-        "reflect.getprototypeof": "^1.0.9"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/typed-array-length": {
-      "version": "1.0.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "is-typed-array": "^1.1.13",
-        "possible-typed-array-names": "^1.0.0",
-        "reflect.getprototypeof": "^1.0.6"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
@@ -30038,23 +28771,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/unbox-primitive": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "has-bigints": "^1.0.2",
-        "has-symbols": "^1.1.0",
-        "which-boxed-primitive": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/uncrypto": {
@@ -30418,15 +29134,6 @@
         }
       }
     },
-    "node_modules/validate-npm-package-license": {
-      "version": "3.0.4",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
-    },
     "node_modules/vary": {
       "version": "1.1.2",
       "license": "MIT",
@@ -30709,87 +29416,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/which-boxed-primitive": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-bigint": "^1.1.0",
-        "is-boolean-object": "^1.2.1",
-        "is-number-object": "^1.1.1",
-        "is-string": "^1.1.1",
-        "is-symbol": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/which-builtin-type": {
-      "version": "1.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "function.prototype.name": "^1.1.6",
-        "has-tostringtag": "^1.0.2",
-        "is-async-function": "^2.0.0",
-        "is-date-object": "^1.1.0",
-        "is-finalizationregistry": "^1.1.0",
-        "is-generator-function": "^1.0.10",
-        "is-regex": "^1.2.1",
-        "is-weakref": "^1.0.2",
-        "isarray": "^2.0.5",
-        "which-boxed-primitive": "^1.1.0",
-        "which-collection": "^1.0.2",
-        "which-typed-array": "^1.1.16"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/which-collection": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-map": "^2.0.3",
-        "is-set": "^2.0.3",
-        "is-weakmap": "^2.0.2",
-        "is-weakset": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/which-typed-array": {
-      "version": "1.1.19",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "for-each": "^0.3.5",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/wildcard-match": {

--- a/scripts/create-worktree.sh
+++ b/scripts/create-worktree.sh
@@ -101,6 +101,7 @@ copy_env_files() {
   local worktree_parent="$3"
   local copied_count=0
   local skipped_tracked_count=0
+  local skipped_unignored_count=0
 
   log "Copiando arquivos .env* locais do projeto original..."
 
@@ -112,6 +113,11 @@ copy_env_files() {
 
     if git -C "$source_root" ls-files --error-unmatch -- "$relative_path" >/dev/null 2>&1; then
       skipped_tracked_count=$((skipped_tracked_count + 1))
+      continue
+    fi
+
+    if ! git -C "$source_root" check-ignore --quiet -- "$relative_path"; then
+      skipped_unignored_count=$((skipped_unignored_count + 1))
       continue
     fi
 
@@ -137,6 +143,10 @@ copy_env_files() {
 
   if [[ "$skipped_tracked_count" -gt 0 ]]; then
     log "$skipped_tracked_count arquivo(s) .env* rastreado(s) pelo Git foram ignorado(s)."
+  fi
+
+  if [[ "$skipped_unignored_count" -gt 0 ]]; then
+    log "$skipped_unignored_count arquivo(s) .env* nao ignorado(s) pelo Git foram ignorado(s)."
   fi
 }
 


### PR DESCRIPTION
## Objetivo

Configurar o Dependabot para automatizar a verificação de atualizações de dependências do projeto, mantendo o controle de volume de PRs e respeitando os padrões de commit aceitos pelo repositório.

## Changelog

- Adicionado o arquivo `.github/dependabot.yml`.
- Configurado o ecossistema `npm` para monitorar o workspace raiz e o `package-lock.json`.
- Configurado o ecossistema `github-actions` para atualizar actions dos workflows em `.github/workflows`.
- Configurado o ecossistema `docker-compose` para monitorar imagens declaradas no `docker-compose.yml`.
- Definida agenda semanal às segundas-feiras no fuso `America/Sao_Paulo`.
- Agrupadas atualizações minor e patch por ecossistema para reduzir ruído de PRs.
- Mantidas atualizações major separadas para facilitar análise de breaking changes.
- Definido o prefixo de commit `📦 deps`, compatível com o `commitlint` do projeto.

## Como testar

1. Validar a sintaxe YAML com `npx --yes js-yaml .github/dependabot.yml > /dev/null`.
2. Executar `npm run typecheck`.
3. Executar `npm run codecheck`.
4. Executar `npm run test:unit -- --output-logs=errors-only`.
5. Após merge na branch principal, verificar a aba de Dependabot no GitHub para confirmar o carregamento da configuração.

## Observações

- O primeiro commit tentou usar o prefixo `📚 deps`, mas o hook de commit rejeitou esse tipo. A configuração foi ajustada para `📦 deps`, que é o tipo de dependências aceito pelo projeto.
- O comando `npm run test:unit` sem logs reduzidos excedeu o timeout local de 180s, mas a suíte passou ao ser reexecutada com timeout maior e `--output-logs=errors-only`.
