### PR TITLE
Correção do clique na aba Soluções bloqueada

### DIFF
--- a/apps/web/src/ui/challenging/widgets/components/ChallengeContentLink/ChallengeContentLinkView.tsx
+++ b/apps/web/src/ui/challenging/widgets/components/ChallengeContentLink/ChallengeContentLinkView.tsx
@@ -1,23 +1,44 @@
 'use client'
 
 import Link from 'next/link'
+import {
+  type ComponentPropsWithoutRef,
+  type ForwardedRef,
+  forwardRef,
+  type HTMLAttributes,
+} from 'react'
 import { twMerge } from 'tailwind-merge'
 
 import { Icon } from '@/ui/global/widgets/components/Icon'
 
-type Props = {
+type ExternalProps = Omit<HTMLAttributes<HTMLElement>, 'children'> & {
+  [dataAttribute: `data-${string}`]: string | number | boolean | undefined
+}
+
+export type Props = {
   href: string
   title: string
   isActive: boolean
   isBlocked: boolean
-}
+} & ExternalProps
 
-export const ChallengeContentLinkView = ({ href, title, isActive, isBlocked }: Props) => {
+const View = (
+  { href, title, isActive, isBlocked, className, ...rest }: Props,
+  ref: ForwardedRef<HTMLAnchorElement | HTMLButtonElement>,
+) => {
+  const buttonProps = rest as ComponentPropsWithoutRef<'button'>
+  const linkProps = rest as ComponentPropsWithoutRef<'a'>
+
   if (isBlocked) {
     return (
       <button
+        ref={ref as ForwardedRef<HTMLButtonElement>}
         type='button'
-        className='flex items-center gap-2 rounded-md bg-gray-700 p-2 text-sm text-gray-500'
+        className={twMerge(
+          'flex items-center gap-2 rounded-md bg-gray-700 p-2 text-sm text-gray-500',
+          className,
+        )}
+        {...buttonProps}
       >
         {title}
         <Icon name='lock' size={16} className='text-gray-500' />
@@ -27,13 +48,18 @@ export const ChallengeContentLinkView = ({ href, title, isActive, isBlocked }: P
 
   return (
     <Link
+      ref={ref as ForwardedRef<HTMLAnchorElement>}
       href={href}
       className={twMerge(
         'rounded-md bg-gray-700 p-2 text-sm',
         isActive ? 'p-2 text-green-500' : 'text-gray-100',
+        className,
       )}
+      {...linkProps}
     >
       {title}
     </Link>
   )
 }
+
+export const ChallengeContentLinkView = forwardRef(View)

--- a/apps/web/src/ui/challenging/widgets/components/ChallengeContentLink/index.tsx
+++ b/apps/web/src/ui/challenging/widgets/components/ChallengeContentLink/index.tsx
@@ -1,30 +1,36 @@
 'use client'
 
+import { type ForwardedRef, forwardRef, type HTMLAttributes } from 'react'
+
 import type { ChallengeContent } from '@/ui/challenging/stores/ChallengeStore/types'
 import { ChallengeContentLinkView } from './ChallengeContentLinkView'
 import { useChallengeContentLink } from './useChallengeContentLink'
+
+type ExternalProps = Omit<HTMLAttributes<HTMLElement>, 'children'>
 
 type Props = {
   contentType: ChallengeContent
   isActive: boolean
   title: string
   isBlocked?: boolean
-}
+} & ExternalProps
 
-export const ChallengeContentLink = ({
-  contentType,
-  isActive,
-  title,
-  isBlocked = false,
-}: Props) => {
+const Component = (
+  { contentType, isActive, title, isBlocked = false, ...rest }: Props,
+  ref: ForwardedRef<HTMLAnchorElement | HTMLButtonElement>,
+) => {
   const { href } = useChallengeContentLink({ contentType })
 
   return (
     <ChallengeContentLinkView
+      ref={ref}
       href={href}
       title={title}
       isActive={isActive}
       isBlocked={isBlocked}
+      {...rest}
     />
   )
 }
+
+export const ChallengeContentLink = forwardRef(Component)

--- a/apps/web/src/ui/challenging/widgets/components/ChallengeContentLink/tests/ChallengeContentLinkView.test.tsx
+++ b/apps/web/src/ui/challenging/widgets/components/ChallengeContentLink/tests/ChallengeContentLinkView.test.tsx
@@ -1,0 +1,81 @@
+import { createRef } from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { ChallengeContentLinkView, type Props } from '../ChallengeContentLinkView'
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+jest.mock('@/ui/global/widgets/components/Icon', () => ({
+  Icon: () => <span data-testid='lock-icon' />,
+}))
+
+describe('ChallengeContentLinkView', () => {
+  const View = (props?: Partial<Props>) => {
+    render(
+      <ChallengeContentLinkView
+        href='/desafios/desafio'
+        title='Soluções'
+        isActive={false}
+        isBlocked={false}
+        {...props}
+      />,
+    )
+  }
+
+  it('should forward external props to the blocked button', async () => {
+    const user = userEvent.setup()
+    const onClick = jest.fn()
+    const ref = createRef<HTMLButtonElement>()
+
+    render(
+      <ChallengeContentLinkView
+        ref={ref}
+        href='/desafios/desafio/solutions'
+        title='Soluções'
+        isActive={false}
+        isBlocked={true}
+        aria-label='Abrir soluções bloqueadas'
+        data-testid='blocked-solutions-link'
+        onClick={onClick}
+      />,
+    )
+
+    const button = screen.getByRole('button', { name: 'Abrir soluções bloqueadas' })
+
+    expect(button).toHaveAttribute('data-testid', 'blocked-solutions-link')
+    expect(ref.current).toBe(button)
+
+    await user.click(button)
+
+    expect(onClick).toHaveBeenCalled()
+  })
+
+  it('should forward external props to the unlocked link', async () => {
+    const user = userEvent.setup()
+    const onClick = jest.fn((event) => event.preventDefault())
+
+    View({
+      isBlocked: false,
+      href: '/desafios/desafio/solutions',
+      'data-testid': 'solutions-link',
+      onClick,
+    })
+
+    const link = screen.getByRole('link', { name: 'Soluções' })
+
+    expect(link).toHaveAttribute('href', '/desafios/desafio/solutions')
+    expect(link).toHaveAttribute('data-testid', 'solutions-link')
+
+    await user.click(link)
+
+    expect(onClick).toHaveBeenCalled()
+  })
+})

--- a/documentation/features/challenging/challenge-solutions/reports/solution-button-bug-report.md
+++ b/documentation/features/challenging/challenge-solutions/reports/solution-button-bug-report.md
@@ -1,0 +1,52 @@
+---
+title: Clique na aba Solucoes bloqueada nao abre dialogo
+prd: https://github.com/JohnPetros/stardust/milestone/40
+issue: https://github.com/JohnPetros/stardust/issues/491
+apps: web
+status: open
+last_updated_at: 2026-07-16
+---
+
+# Bug Report: Clique na aba Solucoes bloqueada nao abre dialogo
+
+## Problema Identificado
+
+Ao acessar um desafio como usuario autenticado sem permissao para ver solucoes (`canShowSolutions = false`), a aba `Solucoes` aparece bloqueada com icone de cadeado, mas o clique no botao bloqueado nao abre o dialogo de desbloqueio. O usuario permanece na mesma tela sem modal, toast, navegacao ou feedback visual.
+
+O comportamento esperado e abrir o `BlockedSolutionsAlertDialog`, explicar a regra de acesso e permitir que o usuario confirme o desbloqueio por `10` starcoins quando tiver saldo suficiente.
+
+## Causas
+
+- O `trigger` do `AlertDialog` depende de `AlertDialog.Trigger asChild`, mas as props/event handlers injetados pelo Radix nao chegam ao elemento DOM final.
+- `ChallengeContentLink` aceita apenas props de dominio da aba (`contentType`, `isActive`, `title`, `isBlocked`) e descarta props externas recebidas por composicao.
+- `ChallengeContentLinkView` renderiza o botao bloqueado sem espalhar props externas e sem encaminhar `ref`, impedindo que o `AlertDialog` controle a abertura pelo clique.
+- O teste de `ChallengeTabsView` aciona `onShowSolutions` por um botao mockado separado, sem cobrir a interacao real no botao bloqueado da aba `Solucoes`.
+
+## Contexto e Analise
+
+### Camada UI (Widgets)
+
+- **Arquivo:** `apps/web/src/ui/challenging/widgets/layouts/Challenge/ChallengeTabs/ChallengeTabsView.tsx`
+- **Diagnostico:** Fato: quando `isAccountAuthenticated` e verdadeiro e `craftsVislibility?.canShowSolutions.isFalse`, a view envolve `TabButton value='solutions' asChild` com `BlockedSolutionsAlertDialog` e renderiza `ChallengeContentLink` bloqueado como filho. Essa composicao depende da propagacao de props/event handlers do Radix ate o botao final.
+
+- **Arquivo:** `apps/web/src/ui/challenging/widgets/components/BlockedSolutionsAlertDialog/BlockedSolutionsAlertDialogView.tsx`
+- **Diagnostico:** Fato: a view passa o `trigger` recebido como filho de `AlertDialog`. A acao `onShowSolutions` fica vinculada ao botao de confirmacao do dialogo, entao o clique inicial na aba bloqueada deve apenas abrir o `AlertDialog`.
+
+- **Arquivo:** `apps/web/src/ui/global/widgets/components/AlertDialog/index.tsx`
+- **Diagnostico:** Fato: o dialogo usa `AlertDialog.Trigger asChild`, que clona o filho e injeta props/event handlers no elemento recebido. Quando esse filho nao repassa as props ao DOM final, o trigger fica visualmente clicavel, mas perde o comportamento de abertura.
+
+- **Arquivo:** `apps/web/src/ui/challenging/widgets/components/ChallengeContentLink/index.tsx`
+- **Diagnostico:** Fato: o entry point tipa e repassa apenas `contentType`, `isActive`, `title` e `isBlocked` para a view. Props externas vindas de `asChild`, como handlers de clique, atributos ARIA e `ref`, nao fazem parte do contrato atual e sao descartadas.
+
+- **Arquivo:** `apps/web/src/ui/challenging/widgets/components/ChallengeContentLink/ChallengeContentLinkView.tsx`
+- **Diagnostico:** Fato: no estado bloqueado, a view renderiza um `<button type='button'>` sem receber ou espalhar props externas. Hipotese tecnica: o handler do `AlertDialog.Trigger` nao e anexado ao botao bloqueado, resultando no clique sem efeito observado.
+
+- **Arquivo:** `apps/web/src/ui/challenging/widgets/layouts/Challenge/ChallengeTabs/useChallengeTabs.ts`
+- **Diagnostico:** Fato: `handleShowSolutions` ja concentra a regra posterior a confirmacao: valida saldo, exibe toast de saldo insuficiente, debita starcoins, atualiza usuario, libera visibilidade e navega para a listagem. O bug ocorre antes dessa funcao ser acionada, na abertura do dialogo.
+
+- **Arquivo:** `apps/web/src/ui/challenging/widgets/layouts/Challenge/ChallengeTabs/tests/ChallengeTabsView.test.tsx`
+- **Diagnostico:** Fato: o mock de `BlockedSolutionsAlertDialog` cria um botao `data-testid='show-solutions'` separado e o teste clica nele para validar `onShowSolutions`. Esse teste nao reproduz a composicao real entre `AlertDialog.Trigger asChild`, `TabButton asChild`, `ChallengeContentLink` e o botao bloqueado.
+
+## Direcionamento de Correcao
+
+A correcao deve atuar na camada UI, principalmente em `ChallengeContentLink` e `ChallengeContentLinkView`, para que o componente usado como `trigger` aceite e propague props/ref externas ate o elemento DOM final em composicoes `asChild`. A validacao deve cobrir o clique real no botao bloqueado da aba `Solucoes`, garantindo que ele abra o `BlockedSolutionsAlertDialog` antes de executar `handleShowSolutions` pela acao de confirmacao.

--- a/documentation/features/challenging/challenge-solutions/specs/solution-button-fix-spec.md
+++ b/documentation/features/challenging/challenge-solutions/specs/solution-button-fix-spec.md
@@ -3,7 +3,7 @@ title: Correcao do clique na aba Solucoes bloqueada
 prd: https://github.com/JohnPetros/stardust/milestone/40
 issue: https://github.com/JohnPetros/stardust/issues/491
 apps: web
-status: open
+status: closed
 last_updated_at: 2026-07-16
 ---
 

--- a/documentation/features/challenging/challenge-solutions/specs/solution-button-fix-spec.md
+++ b/documentation/features/challenging/challenge-solutions/specs/solution-button-fix-spec.md
@@ -1,0 +1,220 @@
+---
+title: Correcao do clique na aba Solucoes bloqueada
+prd: https://github.com/JohnPetros/stardust/milestone/40
+issue: https://github.com/JohnPetros/stardust/issues/491
+apps: web
+status: open
+last_updated_at: 2026-07-16
+---
+
+# 1. Objetivo
+
+Corrigir a aba `Solucoes` bloqueada na pagina de desafio para que o clique no botao com cadeado abra o `BlockedSolutionsAlertDialog` para usuarios autenticados sem acesso liberado. A implementacao deve ajustar a composicao de componentes UI usados como `trigger` em `asChild`, preservando a regra atual de desbloqueio em `useChallengeTabs` e sem alterar contratos de `core`, `rest`, `rpc`, rotas ou banco de dados.
+
+---
+
+# 2. Escopo
+
+## 2.1 In-scope
+
+- Fazer o `ChallengeContentLink` aceitar e propagar props externas recebidas por composicoes `asChild`.
+- Encaminhar `ref` e event handlers ate o elemento DOM final renderizado por `ChallengeContentLinkView`.
+- Manter o visual atual da aba bloqueada (`Solucoes` + icone de cadeado).
+- Preservar a abertura do `BlockedSolutionsAlertDialog` antes da execucao de `handleShowSolutions`.
+- Preservar a regra existente de saldo, debito de starcoins, atualizacao de usuario, liberacao de visibilidade e navegacao.
+
+## 2.2 Out-of-scope
+
+- Alterar regras de negocio de liberacao de solucoes.
+- Alterar o custo de desbloqueio de solucoes.
+- Criar novos use cases, actions, services, schemas, rotas ou migrations.
+- Alterar o fluxo de acesso direto por URL para listagem ou detalhe de solucoes.
+- Reestruturar o componente global `AlertDialog`.
+- Corrigir comportamentos nao descritos na issue `#491`, como condicoes de renderizacao da navegacao mobile fora da aba desktop.
+
+---
+
+# 3. Requisitos
+
+## 3.1 Funcionais
+
+- Quando `canShowSolutions = false` para usuario autenticado, a aba `Solucoes` deve continuar aparecendo bloqueada com icone de cadeado.
+- O clique na aba bloqueada deve abrir o `BlockedSolutionsAlertDialog`.
+- A confirmacao no dialogo deve continuar delegando para `handleShowSolutions`.
+- Com saldo suficiente, o fluxo atual deve debitar `10` starcoins, liberar a visibilidade de solucoes e navegar para a listagem.
+- Com saldo insuficiente, o fluxo atual deve exibir feedback de erro e manter as solucoes bloqueadas.
+
+## 3.2 Nao funcionais
+
+- Compatibilidade: a correcao nao deve alterar o contrato publico de `ChallengeTabsView`, `BlockedSolutionsAlertDialog` ou `AlertDialog`.
+- Acessibilidade: atributos e event handlers injetados por Radix em composicoes `asChild` devem chegar ao elemento interativo final.
+- Baixo impacto: a mudanca deve ficar restrita a componentes da camada UI do `web`.
+- Sem mudanca de schema: nenhuma migration de banco de dados deve ser criada.
+
+---
+
+# 4. O que ja existe?
+
+## Camada UI (Widgets)
+
+* **`ChallengeTabs`** (`apps/web/src/ui/challenging/widgets/layouts/Challenge/ChallengeTabs/index.tsx`) - *Entry point da aba desktop do desafio; resolve autenticacao, visibilidade de crafts e `handleShowSolutions`, repassando tudo para `ChallengeTabsView`.*
+* **`ChallengeTabsView`** (`apps/web/src/ui/challenging/widgets/layouts/Challenge/ChallengeTabs/ChallengeTabsView.tsx`) - *Renderiza a aba `Solucoes` bloqueada dentro de `BlockedSolutionsAlertDialog` usando `TabButton value='solutions' asChild`.*
+* **`useChallengeTabs`** (`apps/web/src/ui/challenging/widgets/layouts/Challenge/ChallengeTabs/useChallengeTabs.ts`) - *Concentra o fluxo posterior a confirmacao do dialogo: valida saldo, mostra toast de saldo insuficiente, debita moedas, atualiza usuario, libera visibilidade e navega para a listagem de solucoes.*
+* **`BlockedSolutionsAlertDialog`** (`apps/web/src/ui/challenging/widgets/components/BlockedSolutionsAlertDialog/index.tsx`) - *Entry point do dialogo; resolve saldo e permissao de aquisicao pelo usuario autenticado e delega a renderizacao para a view.*
+* **`BlockedSolutionsAlertDialogView`** (`apps/web/src/ui/challenging/widgets/components/BlockedSolutionsAlertDialog/BlockedSolutionsAlertDialogView.tsx`) - *Envelopa o `trigger` recebido em `AlertDialog` e define a acao de confirmacao com `onShowSolutions`.*
+* **`AlertDialog`** (`apps/web/src/ui/global/widgets/components/AlertDialog/index.tsx`) - *Componente global que usa `AlertDialog.Trigger asChild`; depende do filho final receber props/event handlers e `ref` para abrir o modal pelo clique.*
+* **`ChallengeContentLink`** (`apps/web/src/ui/challenging/widgets/components/ChallengeContentLink/index.tsx`) - *Entry point do link de conteudo do desafio; calcula `href` via `useChallengeContentLink` e repassa apenas props proprias para a view.*
+* **`ChallengeContentLinkView`** (`apps/web/src/ui/challenging/widgets/components/ChallengeContentLink/ChallengeContentLinkView.tsx`) - *Renderiza `Link` quando o conteudo esta liberado e `<button type='button'>` com cadeado quando `isBlocked` e verdadeiro.*
+* **`Button`** (`apps/web/src/ui/global/widgets/components/Button/index.tsx`) - *Referencia local de componente com `forwardRef`, `...rest` e suporte a `asChild` via `Slot`, demonstrando o padrao usado para preservar props externas em composicoes Radix.*
+* **`StyledButtonView`** (`apps/web/src/ui/global/widgets/components/VerificationButton/StyledButton/StyledButtonView.tsx`) - *Referencia local de view que encaminha `ref` e espalha props para um componente base.*
+* **`ChallengeContentNavView`** (`apps/web/src/ui/challenging/widgets/components/ChallengeContentNav/ChallengeContentNavView.tsx`) - *Tambem consome `ChallengeContentLink`; deve continuar compativel com o contrato ajustado, embora a issue trate a aba desktop do `ChallengeTabsView`.*
+
+---
+
+# 5. O que deve ser criado?
+
+**Nao aplicavel**.
+
+---
+
+# 6. O que deve ser modificado?
+
+## Camada UI (Widgets)
+
+* **Arquivo:** `apps/web/src/ui/challenging/widgets/components/ChallengeContentLink/index.tsx`
+* **Mudanca:** Transformar `ChallengeContentLink` em componente com `forwardRef`, aceitar props HTML externas alem de `contentType`, `isActive`, `title` e `isBlocked`, e repassar `ref` e `...rest` para `ChallengeContentLinkView`.
+* **Justificativa:** `ChallengeContentLink` e o componente intermediario usado como filho de `TabButton asChild`; se ele nao aceitar props externas, os handlers injetados por Radix sao descartados antes de chegar ao DOM final.
+* **Camada:** `ui`
+
+## Camada UI (Widgets)
+
+* **Arquivo:** `apps/web/src/ui/challenging/widgets/components/ChallengeContentLink/ChallengeContentLinkView.tsx`
+* **Mudanca:** Transformar a view em componente com `forwardRef`, receber props HTML externas e espalha-las no elemento final renderizado. Quando `isBlocked` for verdadeiro, aplicar props/ref no `<button type='button'>`; quando `isBlocked` for falso, aplicar props/ref no `Link` do Next.js sem perder `href` nem as classes atuais.
+* **Justificativa:** `AlertDialog.Trigger asChild` e `TabButton asChild` dependem de propagacao ate o elemento interativo final. O botao bloqueado hoje nao recebe `onClick`, atributos ARIA nem `ref`, por isso o clique visual nao abre o dialogo.
+* **Camada:** `ui`
+
+## Camada UI (Widgets)
+
+* **Arquivo:** `apps/web/src/ui/challenging/widgets/layouts/Challenge/ChallengeTabs/ChallengeTabsView.tsx`
+* **Mudanca:** Preservar a composicao atual `BlockedSolutionsAlertDialog -> TabButton asChild -> ChallengeContentLink`, fazendo apenas ajustes pontuais se forem necessarios para compatibilizar os tipos apos `ChallengeContentLink` passar a encaminhar props/ref.
+* **Justificativa:** A composicao expressa corretamente o requisito de produto: a aba bloqueada e o trigger do dialogo sao o mesmo controle visual. O bug esta na perda de props no componente intermediario, nao na regra de renderizacao da aba.
+* **Camada:** `ui`
+
+## Camada UI (Widgets)
+
+* **Arquivo:** `apps/web/src/ui/challenging/widgets/layouts/Challenge/ChallengeTabs/useChallengeTabs.ts`
+* **Mudanca:** Nao alterar a regra de `handleShowSolutions`; manter o fluxo atual de saldo, debito, atualizacao de usuario, visibilidade e navegacao.
+* **Justificativa:** O bug ocorre antes da execucao de `handleShowSolutions`, na abertura do dialogo. Alterar essa funcao aumentaria o risco de regressao em uma regra que ja atende ao fluxo esperado apos confirmacao.
+* **Camada:** `ui`
+
+---
+
+# 7. O que deve ser removido?
+
+**Nao aplicavel**.
+
+---
+
+# 8. Decisoes Tecnicas
+
+* **Decisao**
+  - Corrigir o bug no contrato de composicao de `ChallengeContentLink` e `ChallengeContentLinkView`, encaminhando props/ref externas ate o elemento DOM final.
+* **Alternativas consideradas**
+  - Substituir `ChallengeContentLink` por um `<button>` inline apenas no caso de solucoes bloqueadas.
+  - Alterar `AlertDialog` para nao usar `Trigger asChild`.
+  - Disparar `handleShowSolutions` diretamente no clique da aba bloqueada.
+* **Motivo da escolha**
+  - A causa raiz esta no descarte de props por um componente intermediario usado com Radix `asChild`. Ajustar esse contrato preserva a composicao existente, melhora a compatibilidade do componente compartilhado e evita duplicar markup da aba.
+* **Impactos / trade-offs**
+  - O tipo de props do `ChallengeContentLink` fica mais amplo para suportar atributos/event handlers de elementos interativos.
+  - A view passa a lidar com dois elementos finais (`button` bloqueado e `Link` liberado), exigindo cuidado no tipo de `ref`.
+
+* **Decisao**
+  - Manter `useChallengeTabs.handleShowSolutions` sem mudancas funcionais.
+* **Alternativas consideradas**
+  - Mover validacao de saldo para o dialogo.
+  - Executar desbloqueio no clique do trigger.
+* **Motivo da escolha**
+  - O PRD exige que o clique abra o dialogo e que o desbloqueio ocorra apenas depois da confirmacao. A funcao atual ja implementa a regra posterior a confirmacao.
+* **Impactos / trade-offs**
+  - A correcao fica restrita a UI/renderizacao e nao altera o comportamento de negocio.
+
+* **Decisao**
+  - Nao criar migrations, schemas, actions, services ou use cases.
+* **Alternativas consideradas**
+  - Nenhuma camada fora da UI foi indicada pela issue ou pelo bug report como origem do problema.
+* **Motivo da escolha**
+  - A falha ocorre na propagacao de props/event handlers em componentes React; nao ha mudanca de contrato de dados ou persistencia.
+* **Impactos / trade-offs**
+  - O escopo permanece pequeno e diretamente implementavel.
+
+---
+
+# 9. Diagramas e Referencias
+
+## Fluxo de dados
+
+```mermaid
+flowchart TD
+  A["Usuario autenticado clica na aba Solucoes bloqueada"] --> B["ChallengeTabsView"]
+  B --> C["BlockedSolutionsAlertDialog"]
+  C --> D["AlertDialog.Trigger asChild"]
+  D --> E["TabButton asChild"]
+  E --> F["ChallengeContentLink"]
+  F --> G["ChallengeContentLinkView"]
+  G --> H["button DOM bloqueado recebe props/ref do Radix"]
+  H --> I["BlockedSolutionsAlertDialog abre"]
+  I --> J["Usuario confirma no dialogo"]
+  J --> K["useChallengeTabs.handleShowSolutions"]
+  K --> L{"Saldo suficiente?"}
+  L -->|"sim"| M["Debita starcoins, atualiza usuario, libera solucoes e navega"]
+  L -->|"nao"| N["Exibe toast e mantem solucoes bloqueadas"]
+```
+
+## Fluxo cross-app
+
+**Nao aplicavel**. A correcao fica restrita ao app `web` e nao altera contratos com `server`, `studio`, `core`, `rest`, `rpc` ou banco de dados.
+
+## Layout
+
+```ascii
+ChallengeLayoutView
+`- ChallengeTabs
+   `- ChallengeTabsView
+      `- BlockedSolutionsAlertDialog
+         `- AlertDialog
+            `- AlertDialog.Trigger asChild
+               `- TabButton value="solutions" asChild
+                  `- ChallengeContentLink isBlocked
+                     `- ChallengeContentLinkView
+                        `- button[type="button"] Solucoes + lock
+```
+
+## Referencias
+
+- `apps/web/src/ui/challenging/widgets/layouts/Challenge/ChallengeTabs/index.tsx`
+- `apps/web/src/ui/challenging/widgets/layouts/Challenge/ChallengeTabs/ChallengeTabsView.tsx`
+- `apps/web/src/ui/challenging/widgets/layouts/Challenge/ChallengeTabs/useChallengeTabs.ts`
+- `apps/web/src/ui/challenging/widgets/components/BlockedSolutionsAlertDialog/index.tsx`
+- `apps/web/src/ui/challenging/widgets/components/BlockedSolutionsAlertDialog/BlockedSolutionsAlertDialogView.tsx`
+- `apps/web/src/ui/global/widgets/components/AlertDialog/index.tsx`
+- `apps/web/src/ui/challenging/widgets/components/ChallengeContentLink/index.tsx`
+- `apps/web/src/ui/challenging/widgets/components/ChallengeContentLink/ChallengeContentLinkView.tsx`
+- `apps/web/src/ui/challenging/widgets/components/ChallengeContentLink/useChallengeContentLink.ts`
+- `apps/web/src/ui/challenging/widgets/components/ChallengeContentNav/ChallengeContentNavView.tsx`
+- `apps/web/src/ui/global/widgets/components/Button/index.tsx`
+- `apps/web/src/ui/global/widgets/components/VerificationButton/StyledButton/StyledButtonView.tsx`
+
+---
+
+# 10. Pendencias / Duvidas
+
+**Sem pendencias**.
+
+---
+
+# 11. Execucao Recomendada
+
+Use **`implement-spec`**.
+
+Justificativa: a spec e diretamente implementavel, o escopo e pequeno, a mudanca esta concentrada em componentes UI existentes e nao exige decomposicao em fases, coordenacao multi-app, migrations ou contratos novos.


### PR DESCRIPTION
## Objetivo

Corrigir o clique na aba `Solucoes` bloqueada da pagina de desafio para que usuarios autenticados sem acesso liberado vejam o dialogo de desbloqueio antes de qualquer tentativa de navegacao ou execucao do fluxo de compra.

## Issues relacionadas

resolve #491

## Causa do bug

`ChallengeContentLink` era usado dentro de composicoes `asChild` do Radix, mas nao aceitava nem propagava props externas, event handlers ou `ref`. Com isso, o `AlertDialog.Trigger asChild` injetava `onClick` no filho, mas esse handler era descartado antes de chegar ao `<button>` bloqueado renderizado no DOM.

## Changelog

- `ChallengeContentLink` agora usa `forwardRef`, aceita props HTML externas e repassa `ref`/handlers para a view.
- `ChallengeContentLinkView` agora encaminha props externas para o elemento final, seja o `<button>` bloqueado ou o `Link` liberado.
- Adicionada cobertura de widget para garantir propagacao de `onClick`, `data-*`, `aria-*` e `ref` no estado bloqueado, alem de props no link liberado.
- Spec tecnica `solution-button-fix-spec.md` marcada como `closed`.
- Milestone #40 atualizada no REQ-01 para explicitar que clicar na aba `Solucoes` bloqueada deve abrir o dialogo de desbloqueio.

## Como testar

1. Acesse um desafio como usuario autenticado sem solucoes liberadas.
2. Clique na aba `Solucoes` bloqueada com cadeado.
3. Confirme que o dialogo de desbloqueio abre imediatamente.
4. Confirme que a acao de desbloqueio continua debitando `10` starcoins e navegando para a listagem apenas apos confirmacao.
5. Confirme que saldo insuficiente exibe erro e mantem as solucoes bloqueadas.

## Validacao executada

- `npm run codecheck` passou.
- `npm run typecheck` passou.
- `npm run quality-gate -- --workspace=web` passou.
- `npm --prefix apps/web run test:unit -- --runInBand` passou: 76 suites, 333 testes.
- `npm --prefix apps/server run test:unit -- --runInBand` passou: 214 suites, 467 testes.
- `npm --prefix packages/core run test:unit -- --runInBand` passou: 163 suites, 570 testes.
- `npm --prefix apps/studio run test:unit -- --runInBand` passou: 18 suites, 128 testes.
- `npm --prefix packages/lsp run test:unit` passou: 1 suite, 1 teste.

## Observacoes

- `npm run test` agregado foi executado. No runner paralelo do Turbo houve uma falha flakey fora do escopo em `apps/server/src/tests/routes/shop/insignias/CreateInsigniaRoute.test.ts`, com erro de fixture ao autenticar conta de teste. A branch nao altera `server`, e a suite `server` completa passou isoladamente em modo sequencial; o proprio teste citado tambem passou quando reexecutado.
- Arquitetura: sem alteracoes necessarias.
- Rules: sem alteracoes necessarias.
