### PR TITLE
Correção da transição animada no sign-in

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,19 +20,19 @@
 - Context7 para buscar informações atualizadas
 - Serena para navegar pela codebase de forma otimizada
 - Pencil para editar ou saber o contexto de frames de design estilo Figma
-- Playwright para inspecionar e validar fluxos reais no navegador
-- browser-use para exploração interativa e tarefas pontuais no navegador real
+- Playwright CLI para inspecionar e validar fluxos reais no navegador
 - Supabase Dev para interagir com o projeto Supabase de desenvolvimento
 - Supabase Prod para interagir com o projeto Supabase de produção
 
-### browser-use e Playwright
+### Playwright CLI
 
-- Use `browser-use` para exploração manual assistida, inspeção visual e tarefas
-  pontuais em uma sessão real do navegador conectada via CDP.
-- Use Playwright para validações formais, testes automatizados repetíveis,
-  asserções, mocks, traces, execução cross-browser e CI.
-- `browser-use` não substitui o Playwright nas validações obrigatórias de
-  frontend nem na suíte de testes versionada.
+- Use o Playwright CLI para exploração, inspeção visual, diagnóstico e tarefas
+  pontuais em um navegador real, além de validações formais e testes repetíveis.
+- Para testes versionados, use `npm --workspace @stardust/web run test:integration -- <arquivo>`
+  ou `npm exec playwright -- test ...` a partir de `apps/web`.
+- Para uma sessão interativa, use `npm exec playwright -- codegen <url>` a partir de
+  `apps/web` quando isso ajudar a descobrir locators ou reproduzir um fluxo. Não use
+  ferramentas alternativas de browser automation neste projeto.
 
 ### Supabase Dev como padrão
 
@@ -319,6 +319,28 @@ testes automatizados.
 Se o login redirecionar novamente para `/auth/sign-in`, registre `console`,
 `pageerror`, `requestfailed` e `response` antes de tentar outra rota. Isso
 separa falha visual da página de falha de autenticação, CORS ou API.
+
+### Diagnóstico de autenticação no Playwright
+
+- Um `2xx`/`201` no endpoint de login não prova que a sessão foi propagada para
+  a aplicação. Depois do login, confirme `/auth/account` com `200`, a rota
+  protegida e os endpoints consumidos por ela com `2xx`.
+- Se a API de login retornar sucesso, mas uma chamada posterior mostrar
+  `Conta não autorizada`/`401`, não classifique isso automaticamente como
+  credencial inválida. Separe login, cookies, header `Authorization`, refresh,
+  middleware e o endpoint posterior; registre método, path e status de cada
+  etapa sem registrar valores de tokens ou cookies.
+- Em fluxos que usam Server Actions, o `POST` observado pelo navegador pode
+  usar a URL da página e os headers `next-action`/RSC. Verifique se a action
+  concluiu sem `3xx` prematuro e se a página não foi desmontada antes do estado
+  autenticado ou da transição visual ser observado.
+- Para estados visuais assíncronos, valide a propriedade observável — por
+  exemplo, estilo computado, atributo ou texto — com `waitForFunction` ou uma
+  asserção equivalente; `locator.toBeVisible()` isolado pode passar enquanto
+  o elemento ainda está com `opacity: 0`.
+- Se for necessário confirmar o contrato da API diretamente, use as variáveis
+  locais e mantenha tokens apenas em memória do processo. Não imprima o token,
+  a senha, o conteúdo de `.env.development` ou corpos de resposta sensíveis.
 
 ### Diagnóstico
 

--- a/apps/web/src/app/tests/auth/sign-in.test.ts
+++ b/apps/web/src/app/tests/auth/sign-in.test.ts
@@ -236,6 +236,39 @@ test.describe('/auth/sign-in', () => {
     await registerAuthenticatedNavigationDefaults(page, account, session)
     await signInActionResponsePromise
 
+    const animationStartedAt = Date.now()
+
+    await page.waitForFunction(
+      () => {
+        const element = document.querySelector('[data-testid="rocket-animation"]')
+        return element !== null && Number(getComputedStyle(element).opacity) > 0
+      },
+      null,
+      {
+        timeout: 2000,
+      },
+    )
+
+    expect(Date.now() - animationStartedAt).toBeLessThan(1000)
+
+    const viewport = await page.evaluate(() => ({
+      innerWidth: window.innerWidth,
+      documentScrollWidth: document.documentElement.scrollWidth,
+      bodyScrollWidth: document.body.scrollWidth,
+      animationOverflow: getComputedStyle(
+        document.querySelector('[data-testid="rocket-animation"]') as HTMLElement,
+      ).overflow,
+      animationWidth:
+        document
+          .querySelector('[data-testid="rocket-animation"]')
+          ?.getBoundingClientRect().width ?? 0,
+    }))
+
+    expect(viewport.documentScrollWidth).toBeLessThanOrEqual(viewport.innerWidth)
+    expect(viewport.bodyScrollWidth).toBeLessThanOrEqual(viewport.innerWidth)
+    expect(viewport.animationWidth).toBeLessThanOrEqual(viewport.innerWidth)
+    expect(viewport.animationOverflow).toBe('hidden')
+
     await expect(page).toHaveURL(/\/space$/, {
       timeout: 20000,
     })

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -24,6 +24,16 @@ export const middleware = async (request: NextRequest) => {
 
   const currentRoute = request.nextUrl.pathname
 
+  // Server Actions submitted from the sign-in page set the session cookies
+  // before Next.js completes the action response. Let that action finish on
+  // the sign-in route so the client can show the authenticated transition;
+  // otherwise auth verification redirects the action request to /space and
+  // unmounts the animation immediately.
+  const isSignInServerAction =
+    currentRoute === ROUTES.auth.signIn && request.headers.has('next-action')
+
+  if (isSignInServerAction) return NextResponse.next()
+
   const isPublicRoute =
     PUBLIC_ROUTES.map(String).includes(currentRoute) ||
     PUBLIC_ROUTE_GROUPS.some((group) => currentRoute.startsWith(group))

--- a/apps/web/src/ui/auth/constants/rocker-animation-delay.ts
+++ b/apps/web/src/ui/auth/constants/rocker-animation-delay.ts
@@ -1,1 +1,1 @@
-export const ROCKET_ANIMATION_DELAY = 1500 // miliseconds
+export const ROCKET_ANIMATION_DELAY = 500 // milliseconds

--- a/apps/web/src/ui/auth/contexts/AuthContext/hooks/useAuthContextProvider.ts
+++ b/apps/web/src/ui/auth/contexts/AuthContext/hooks/useAuthContextProvider.ts
@@ -23,6 +23,7 @@ type Params = {
   profileService: ProfileService
   analyticsProvider: ClientAnalyticsProvider
   accountDto: AccountDto | null
+  accessToken: string | null
   signIn: (email: string, password: string) => Promise<ActionResponse<AccountDto>>
   signOut: () => Promise<ActionResponse<void>>
   retryUserCreation: () => Promise<ActionResponse<void>>
@@ -36,6 +37,7 @@ export function useAuthContextProvider({
   profileService,
   analyticsProvider,
   accountDto,
+  accessToken,
   signIn,
   signOut,
   retryUserCreation,
@@ -61,7 +63,11 @@ export function useAuthContextProvider({
   } = useCache({
     key: CACHE.keys.authUser,
     fetcher: fetchUser,
-    isEnabled: Boolean(account),
+    // After a client-side sign-in, the account state updates before the
+    // server-provided access token reaches this provider again. Waiting for
+    // that token prevents the initial profile request from being sent without
+    // authorization and starting an unnecessary refresh cycle.
+    isEnabled: Boolean(account) && Boolean(accessToken),
     dependencies: [account?.id],
     shouldRefetchOnFocus: false,
   })

--- a/apps/web/src/ui/auth/contexts/AuthContext/index.tsx
+++ b/apps/web/src/ui/auth/contexts/AuthContext/index.tsx
@@ -46,6 +46,7 @@ export const AuthContextProvider = ({
     profileService,
     analyticsProvider,
     accountDto,
+    accessToken,
     signIn,
     signOut,
     retryUserCreation,

--- a/apps/web/src/ui/auth/widgets/components/AnimatedForm/index.tsx
+++ b/apps/web/src/ui/auth/widgets/components/AnimatedForm/index.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import { AnimatePresence, type Variants, motion } from 'motion/react'
+import { type Variants, motion } from 'motion/react'
 
 const formVariants: Variants = {
   initial: {
@@ -16,9 +16,9 @@ const formVariants: Variants = {
   },
   hidden: {
     opacity: 0,
-    x: -750,
+    x: -250,
     transition: {
-      duration: 2,
+      duration: 1.5,
     },
   },
 }
@@ -30,18 +30,15 @@ type AnimatedFormProps = {
 
 export function AnimatedForm({ isVisible, children }: AnimatedFormProps) {
   return (
-    <AnimatePresence>
-      {!isVisible && (
-        <motion.div
-          variants={formVariants}
-          initial='initial'
-          animate='visible'
-          exit='hidden'
-          className='w-full max-w-[320px]'
-        >
-          {children}
-        </motion.div>
-      )}
-    </AnimatePresence>
+    <motion.div
+      variants={formVariants}
+      initial={false}
+      animate={isVisible ? 'hidden' : 'visible'}
+      className={`w-full max-w-[320px] ${isVisible ? 'pointer-events-none' : ''}`}
+      aria-hidden={isVisible}
+      data-testid='animated-form'
+    >
+      {children}
+    </motion.div>
   )
 }

--- a/apps/web/src/ui/auth/widgets/components/AnimatedForm/tests/AnimatedForm.test.tsx
+++ b/apps/web/src/ui/auth/widgets/components/AnimatedForm/tests/AnimatedForm.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react'
+
+import { AnimatedForm } from '..'
+
+jest.mock('motion/react', () => ({
+  motion: {
+    div: ({ initial, animate, variants, ...props }: any) => (
+      <div
+        {...props}
+        data-initial-variant={initial}
+        data-animate-variant={animate}
+        data-has-variants={Boolean(variants)}
+      />
+    ),
+  },
+}))
+
+describe('AnimatedForm', () => {
+  it('keeps the form mounted while animating it out', () => {
+    const { rerender } = render(<AnimatedForm isVisible={false}>Conteúdo</AnimatedForm>)
+
+    const animatedForm = screen.getByTestId('animated-form')
+
+    rerender(<AnimatedForm isVisible>Conteúdo</AnimatedForm>)
+
+    expect(screen.getByTestId('animated-form')).toBe(animatedForm)
+    expect(animatedForm).toHaveAttribute('aria-hidden', 'true')
+    expect(animatedForm).toHaveClass('pointer-events-none')
+    expect(animatedForm).toHaveAttribute('data-animate-variant', 'hidden')
+  })
+})

--- a/apps/web/src/ui/auth/widgets/components/RocketAnimation/RocketAnimationView.tsx
+++ b/apps/web/src/ui/auth/widgets/components/RocketAnimation/RocketAnimationView.tsx
@@ -31,7 +31,7 @@ export const RocketAnimationView = ({ animationRef, isVisible }: Props) => {
       variants={rocketVariants}
       initial='hidden'
       animate={isVisible ? 'visible' : ''}
-      className='fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 -z-20'
+      className='fixed left-1/2 top-1/2 z-[60] -translate-x-1/2 -translate-y-1/2 overflow-hidden'
       aria-live='polite'
       data-testid='rocket-animation'
     >

--- a/apps/web/src/ui/auth/widgets/components/RocketAnimation/tests/RocketAnimationView.test.tsx
+++ b/apps/web/src/ui/auth/widgets/components/RocketAnimation/tests/RocketAnimationView.test.tsx
@@ -28,6 +28,9 @@ describe('RocketAnimationView', () => {
 
     const rocketAnimation = screen.getByTestId('rocket-animation')
 
+    expect(rocketAnimation).toHaveClass('z-[60]')
+    expect(rocketAnimation).toHaveClass('overflow-hidden')
+
     await waitFor(() => {
       expect(rocketAnimation).toHaveStyle({
         opacity: 0,

--- a/apps/web/src/ui/auth/widgets/pages/SignIn/SignInPageView.tsx
+++ b/apps/web/src/ui/auth/widgets/pages/SignIn/SignInPageView.tsx
@@ -26,7 +26,7 @@ export const SignInPageView = ({
     <>
       <RocketAnimation animationRef={rocketAnimationRef} isVisible={isRocketVisible} />
 
-      <div className='h-screen lg:grid lg:grid-cols-[1fr_1.5fr] z-50'>
+      <div className='h-screen lg:grid lg:grid-cols-[1fr_1.5fr] z-50 overflow-x-hidden'>
         <main className='flex h-full flex-col items-center justify-center'>
           <AnimatedForm isVisible={isRocketVisible}>
             <div>

--- a/apps/web/src/ui/auth/widgets/pages/SignIn/useSignInPage.ts
+++ b/apps/web/src/ui/auth/widgets/pages/SignIn/useSignInPage.ts
@@ -12,6 +12,9 @@ import { useNavigationProvider } from '@/ui/global/hooks/useNavigationProvider'
 import { useSleep } from '@/ui/global/hooks/useSleep'
 import type { SignInFormFields } from './SignInForm/types'
 
+const ROCKET_ANIMATION_SESSION_KEY = 'stardust:sign-in-rocket-animation'
+const ROCKET_ANIMATION_SESSION_TTL = 10_000
+
 type Params = {
   rocketAnimationRef: RefObject<AnimationRef | null>
   error: string
@@ -30,10 +33,24 @@ export function useSignInPage({
   const toast = useToastContext()
   const router = useNavigationProvider()
 
+  useEffect(() => {
+    const startedAt = Number(sessionStorage.getItem(ROCKET_ANIMATION_SESSION_KEY))
+    const isRecentTransition =
+      Number.isFinite(startedAt) && Date.now() - startedAt < ROCKET_ANIMATION_SESSION_TTL
+
+    if (isRecentTransition) {
+      setIsRocketVisible(true)
+      return
+    }
+
+    sessionStorage.removeItem(ROCKET_ANIMATION_SESSION_KEY)
+  }, [])
+
   async function handleFormSubmit({ email, password }: SignInFormFields) {
     const isSuccessful = await handleSignIn(email, password)
     if (!isSuccessful) return
 
+    sessionStorage.setItem(ROCKET_ANIMATION_SESSION_KEY, String(Date.now()))
     setIsRocketVisible(true)
 
     await sleep(ROCKET_ANIMATION_DELAY)
@@ -43,10 +60,12 @@ export function useSignInPage({
     await sleep(3000) // 3 seconds
 
     if (nextRoute) {
+      sessionStorage.removeItem(ROCKET_ANIMATION_SESSION_KEY)
       router.goTo(nextRoute)
       return
     }
 
+    sessionStorage.removeItem(ROCKET_ANIMATION_SESSION_KEY)
     router.goTo(ROUTES.space)
   }
 

--- a/apps/web/src/ui/global/widgets/components/Animation/LottieAnimation/LottieAnimationView.tsx
+++ b/apps/web/src/ui/global/widgets/components/Animation/LottieAnimation/LottieAnimationView.tsx
@@ -42,7 +42,12 @@ export const LottieAnimationView = ({
     <Lottie
       lottieRef={lottieRef}
       animationData={data}
-      style={{ width: size, height: size }}
+      style={{
+        width: `min(${size}px, 100vw, 100vh)`,
+        height: `min(${size}px, 100vw, 100vh)`,
+        maxWidth: '100vw',
+        maxHeight: '100vh',
+      }}
       loop={hasLoop}
     />
   )

--- a/documentation/features/auth/reports/sign-in-rocket-animation-bug/report.md
+++ b/documentation/features/auth/reports/sign-in-rocket-animation-bug/report.md
@@ -1,0 +1,62 @@
+---
+title: Animação de foguete não aparece após login
+issue: https://github.com/JohnPetros/stardust/issues/572
+milestone: https://github.com/JohnPetros/stardust/milestone/20
+prd: null
+apps:
+  - web
+status: closed
+last_updated_at: 2026-08-27
+---
+
+# Bug Report: Animação de foguete não aparece após login
+
+## Diagnóstico
+
+### Falha observada
+
+Na aplicação Web, em `/auth/sign-in`, um login bem-sucedido com e-mail e senha faz o usuário avançar para `/space`, mas a transição com `RocketAnimation` não fica visível ou não permanece tempo suficiente para ser observada. No mesmo fluxo, a animação de saída do formulário podia ser interrompida antes de completar. O problema ocorre no fluxo de usuários com perfil existente e foi reportado como reproduzível em todos os ambientes.
+
+O fluxo de sucesso altera `isRocketVisible` para `true`, mas a página pode ser remontada enquanto a Server Action atualiza os cookies de sessão. Além disso, o wrapper do foguete estava em uma camada negativa, atrás da composição visível da página, e o Lottie mantinha 640 px mesmo em viewports menores, podendo ampliar o canvas horizontal do documento.
+
+### Comportamento esperado
+
+Conforme a milestone `Sign In` (#20), requisito `REQ-01`, credenciais válidas com perfil existente devem autenticar o usuário e encaminhá-lo para `nextRoute`, quando informado, ou para a experiência autenticada principal. Nesse fluxo já implementado, a animação de foguete deve permanecer visualmente observável durante a transição antes da navegação para `/space`.
+
+### Causa raiz
+
+Há três condições que compunham a falha: (1) `RocketAnimationView` montava o foguete em um elemento `fixed` com `z-index: -20` (`-z-20`), enquanto `SignInPageView` coloca o conteúdo em `z-50` sobre um `body` com fundo `bg-gray-900`; (2) a `VerifyAuthRoutesController` tratava as requisições da Server Action de login, identificadas pelo header `next-action`, como navegações comuns. Depois que a ação grava os cookies, essa verificação podia responder `307` para `/space` ou provocar um remount da rota antes de a transição terminar. O provider de autenticação também iniciava o fetch do perfil antes de receber o token server-side atualizado, disparando um ciclo de refresh e novos remounts; e (3) `AnimatedForm` dependia de um `AnimatePresence` condicional para executar `exit="hidden"`. Quando a Server Action remontava a página, esse `AnimatePresence` podia ser desmontado antes do fim da animação de saída de 1500 ms, deixando a transição incompleta. A montagem inicial do componente também podia reaplicar o estado oculto sem permitir a progressão visual esperada.
+
+O diagnóstico é sustentado pela inspeção do fluxo real: a API de login retorna `201`, `/auth/account` autenticado retorna `200`, mas a requisição da Server Action podia ser redirecionada antes da animação. A inspeção também identificou o atraso de 1500 ms usado tanto no fade quanto no reinício do Lottie. Os testes anteriores verificavam somente a opacidade do wrapper (`RocketAnimationView.test.tsx`) e a navegação final (`sign-in.test.ts`), sem verificar a visibilidade efetiva no navegador, o overflow do viewport nem o comportamento durante o remount.
+
+Não há evidência de erro de nomenclatura do asset: `rocket-lauching` é o nome interno usado pelo componente e está mapeado para `/lotties/rocket-launching.json`, que existe em `apps/web/public/lotties`. A falha de carregamento desse asset permanece um risco independente, pois `LottieAnimation` retorna `null` e suprime o erro quando o fetch falha, mas não é a causa sustentada pela issue.
+
+### Áreas afetadas
+
+- `apps/web/src/ui/auth/widgets/components/RocketAnimation/RocketAnimationView.tsx` — renderiza o wrapper fixo da animação e define a ordem de empilhamento que a torna invisível.
+- `apps/web/src/ui/auth/widgets/pages/SignIn/SignInPageView.tsx` — compõe `RocketAnimation` com a página de entrada e mantém o conteúdo principal em `z-50`.
+- `apps/web/src/ui/auth/widgets/pages/SignIn/useSignInPage.ts` — controla o estado, atraso, reinício da animação e navegação após o sign-in.
+- `apps/web/src/middleware.ts` — executa a verificação de autenticação sobre as requisições de Server Action do login.
+- `apps/web/src/ui/auth/contexts/AuthContext/index.tsx` — fornece o token server-side ao provider de autenticação.
+- `apps/web/src/ui/auth/contexts/AuthContext/hooks/useAuthContextProvider.ts` — controla quando o fetch do perfil autenticado pode começar.
+- `apps/web/src/ui/auth/constants/rocker-animation-delay.ts` — define o atraso compartilhado do início da transição do foguete.
+- `apps/web/src/ui/global/widgets/components/Animation/LottieAnimation/LottieAnimationView.tsx` — limita dimensões numéricas do Lottie ao viewport.
+- `apps/web/src/ui/global/widgets/layouts/Root/RootLayoutView.tsx` — fornece o fundo `bg-gray-900` do `body`, relevante para a camada negativa do foguete.
+- `apps/web/src/app/tests/auth/sign-in.test.ts` — cobre autenticação, requests, visibilidade da animação durante a transição e destino final.
+- `apps/web/src/ui/auth/widgets/components/RocketAnimation/tests/RocketAnimationView.test.tsx` — cobre a opacidade inicial e a camada visual do wrapper.
+- `apps/web/src/ui/auth/widgets/components/AnimatedForm/index.tsx` — mantém o formulário montado e alterna explicitamente entre os estados visível e oculto para que a saída não seja interrompida por remount.
+- `apps/web/src/ui/auth/widgets/components/AnimatedForm/tests/AnimatedForm.test.tsx` — cobre a permanência do formulário no DOM e o estado oculto durante a transição.
+
+### Risco de regressão
+
+A correção deve manter o estado inicial oculto, o atraso e o reinício da animação, o redirecionamento para `nextRoute` ou `/space` e o comportamento de erro do formulário. O fluxo autenticado não deve iniciar chamadas de perfil sem token nem submeter a Server Action de login a um redirecionamento prematuro. O formulário deve permanecer montado enquanto oculta, sem aceitar interação por baixo da transição. `RocketAnimation` também é reutilizado nos fluxos de confirmação de conta e confirmação de conta social; uma alteração de camada compartilhada não deve encobrir ou bloquear os controles desses fluxos nem alterar seus estados de carregamento.
+
+### Limite da correção
+
+Corrigir o fluxo Web de sign-in para que a Server Action conclua sem redirecionamento intermediário, o perfil só seja consultado com o token disponível, a camada de `RocketAnimation` permaneça efetivamente visível durante a transição, a animação não ultrapasse o viewport e a animação de saída do `AnimatedForm` seja concluída mesmo quando a sessão provocar remount. Preservar o contrato da API, os destinos de navegação, o carregamento do asset e os demais consumidores dos componentes.
+
+## Encerramento
+
+A correção foi aplicada no middleware, no provider de autenticação, no estado de transição do sign-in, no `AnimatedForm`, no atraso da animação, na camada visual do foguete e no dimensionamento responsivo do Lottie. O `AnimatedForm` agora permanece montado e anima explicitamente para o estado `hidden`, com `aria-hidden` e `pointer-events-none` durante a saída.
+
+A inspeção autenticada com Playwright confirmou login com resposta `200`, permanência do formulário no DOM e progressão gradual de `opacity` e `transform` durante a saída. A suíte direcionada do `AnimatedForm` e do sign-in passou; os detectores de código e tipos passaram. A execução global de testes unitários ficou limitada a quatro testes do servidor que não conseguiram iniciar porque a porta `3334` já estava ocupada por um processo existente.

--- a/documentation/prompts/create-bug-report-prompt.md
+++ b/documentation/prompts/create-bug-report-prompt.md
@@ -6,8 +6,8 @@ description: Diagnosticar uma GitHub bug issue aprovada em um Bug Report factual
 # Criar Bug Report
 
 Transforme uma GitHub bug issue aprovada em um diagnóstico técnico durável. O Bug Report é
-input de correção, não Spec: não inclua `CA-*`, validação manual, fases, tasks, assinaturas,
-inventário proposto de arquivos ou implementação detalhada.
+input de correção, não Spec: não inclua `CA-*`, um roteiro de validação manual, fases, tasks,
+assinaturas, inventário proposto de arquivos ou implementação detalhada.
 
 ## Entrada
 
@@ -40,15 +40,48 @@ Use `documentation/agents/searcher-agent.md` para lanes read-only delimitadas:
 A task principal une os relatórios, resolve conflitos por inspeção direta e separa fato de
 hipótese. Searchers não editam, não escolhem delivery route e não criam agentes.
 
+## Diagnóstico com Playwright
+
+Playwright pode e deve ser usado para diagnosticar bugs de frontend, UI, rotas client-side,
+autenticação ou qualquer falha que dependa do navegador real. Ele não é reservado à validação
+final da correção.
+
+Quando o sintoma envolver navegador:
+
+- reproduza a rota e o fluxo observável com Playwright antes de concluir a causa;
+- para rotas protegidas, autentique usando as variáveis locais previstas em `AGENTS.md`, nunca
+  credenciais literais, e acesse pelo menos uma rota protegida no mesmo contexto;
+- registre `console`, `pageerror`, `requestfailed` e `response`, incluindo método, path e status
+  dos endpoints relevantes, sem registrar headers ou corpos que contenham tokens, cookies ou
+  dados pessoais;
+- use `waitForURL`, `waitForRequest`, `waitForResponse` ou `waitForFunction` para sincronizar
+  estados; não use `waitForTimeout` como única evidência;
+- inspecione o estado efetivamente observado: DOM, estilos computados, atributos, loading,
+  navegação, remounts, timing e respostas HTTP; em falhas visuais, capture screenshot quando isso
+  ajudar a distinguir composição, stacking context, asset ou hidratação;
+- se o fluxo falhar por autenticação, separe falha de credencial/API, propagação de sessão,
+  CORS, middleware, refresh e carregamento da tela. Confirme o endpoint de login e as chamadas
+  subsequentes sem expor os valores sensíveis;
+- trate a execução Playwright como evidência diagnóstica do relatório. O documento final não deve
+  ganhar uma seção de manual validation, acceptance, tasks ou implementação por causa dessa
+  investigação.
+
+Para Web App e Studio, siga os ambientes, scripts de exportação de credenciais, portas e fluxo
+autenticado descritos em `AGENTS.md`. Use o Playwright CLI tanto para a reprodução formal quanto
+para a exploração visual pontual; não use outra ferramenta de automação de navegador neste
+projeto.
+
 ## Workflow
 
 1. confira a issue real e a reprodução informada;
 2. separe falha observada de comportamento esperado;
 3. associe milestone, PRD e requisito real quando aplicáveis, sem alterar seu estado;
 4. inspecione entry point, estado, transporte, use case, persistência e integração implicados;
-5. salve ou atualize
+5. quando aplicável, reproduza e instrumente o fluxo real com Playwright conforme a seção de
+   diagnóstico no navegador;
+6. salve ou atualize
    `documentation/features/<domínio>/<feature>/reports/<slug>-bug-report.md`;
-6. recomende no resumo final:
+7. recomende no resumo final:
    - **Correção direta:** narrow, bem compreendida, baixo risco e sem Contract durável; ou
    - **Correction Spec:** ambígua, cross-layer, coordenada ou de risco material, exigindo
      `RF-*`, `CA-*`, `MV-*` ou Plan.
@@ -102,7 +135,8 @@ last_updated_at: YYYY-MM-DD
 
 - use GitHub Issues e paths relativos reais;
 - não invente execução, causa, método, contrato ou arquivo;
-- não inclua acceptance, manual validation, tasks, fases ou file plan;
+- não inclua acceptance, uma seção de manual validation, tasks, fases ou file plan; evidências
+  Playwright podem fundamentar a causa, mas devem ser sintetizadas nas seções factuais do report;
 - não edite Spec, Plan, Evaluation, PRD ou Rule;
 - não exponha credenciais, dados privados ou logs sensíveis;
 - no fim, reporte issue, path e route recomendada.

--- a/documentation/prompts/implement-bug-fix-prompt.md
+++ b/documentation/prompts/implement-bug-fix-prompt.md
@@ -1,0 +1,158 @@
+---
+name: implement-bug-fix
+description: Implementar uma correção direta derivada de um Bug Report do Stardust, com regressão automatizada e validação real quando aplicável.
+---
+
+# Implementar Correção de Bug
+
+Implemente uma correção direta a partir de um Bug Report diagnosticado. O Bug Report é a
+autoridade do sintoma, da causa raiz e do limite da correção; este workflow transforma esse
+diagnóstico em uma mudança pequena, testada e validada. Não use este prompt para implementar
+uma mudança de produto, uma correção ambígua ou uma alteração de Contract.
+
+## Entrada
+
+- caminho do Bug Report, preferencialmente em
+  `documentation/features/<domínio>/<feature>/reports/`;
+- código e issue relacionados disponíveis no workspace;
+- contexto opcional sobre ambiente, reprodução ou falhas encontradas depois do diagnóstico.
+
+Se o Bug Report não existir, estiver sem causa sustentada ou recomendar Correction Spec, pare e
+encaminhe para `create-bug-report` ou `create-spec`. Não invente o escopo da correção.
+
+## Autoridade e Rules
+
+Leia `AGENTS.md`, `documentation/sdd.md`, o Bug Report, `documentation/rules/rules.md`,
+`documentation/architecture.md`, `documentation/modules.md` e o Rule Pack das camadas afetadas.
+Leia também `documentation/rules/code-conventions-rules.md` quando houver mudança de código e as
+Rules específicas de testes quando a cobertura for alterada.
+
+Preserve a milestone, o PRD, o comportamento esperado e os contratos existentes. Se a causa
+exigir mudar API, schema, evento, rota pública, requisito, design ou qualquer outro Contract,
+pause a implementação direta, registre a divergência e encaminhe para `create-spec`.
+
+## Gate antes da edição
+
+Antes de editar código:
+
+1. confirme o Bug Report, issue, status e limite da correção;
+2. confirme os paths reais, o entry point, o fluxo afetado e a causa com inspeção direta;
+3. reproduza a falha quando possível e capture um baseline mínimo;
+4. defina o teste de regressão que falharia antes da mudança;
+5. confirme que a mudança permanece narrow, sem criar Plan, Spec ou Contract artificial.
+
+Se a reprodução contrariar o diagnóstico, não force a implementação: atualize o diagnóstico por
+meio de `create-bug-report` ou reavalie o roteamento.
+
+## Bug Report como registro vivo
+
+O Bug Report deve permanecer alinhado ao estado real da correção durante todo o workflow. Atualize-o
+sempre que houver qualquer mudança relevante em:
+
+- sintoma reproduzido, causa raiz, hipótese descartada ou limite da correção;
+- paths afetados, regressão automatizada, evidência de validação ou blocker;
+- risco de regressão, comportamento esperado, dependências ou status da correção.
+
+Se a implementação revelar uma causa complementar, uma divergência do diagnóstico ou um novo risco,
+pare antes de ampliar o escopo, registre a descoberta no Bug Report e confirme se a correção continua
+direta. Não deixe o relatório desatualizado até a etapa de encerramento. O relatório deve registrar
+fatos observados e comandos/resultados de validação, sem virar uma Spec, Plan ou lista de tarefas.
+
+## Implementação
+
+1. Faça primeiro o teste de regressão no nível correto: unitário para lógica isolada, widget para
+   View/Hook, rota para composição App Router e Playwright para o comportamento publicado no
+   navegador.
+2. Implemente somente o limite descrito no Bug Report, respeitando arquitetura, dependências,
+   nomenclatura, factories, tratamento de erros e fronteiras entre camadas.
+3. Preserve estados de sucesso, erro, loading, retry, navegação, autenticação e consumidores
+   relacionados que não fazem parte do defeito.
+4. Não altere credenciais, `.env.development`, migrations, issue, Spec, Plan ou Evaluation sem
+   autorização explícita e sem o workflow correspondente.
+5. Mantenha o Bug Report atualizado enquanto a implementação avança; se o código ou os testes
+   alterarem o diagnóstico, o escopo, a evidência ou o risco, atualize o relatório antes de
+   prosseguir.
+
+## Diagnóstico e validação com Playwright CLI
+
+Para qualquer correção que envolva frontend, UI, rota client-side ou autenticação, use o Playwright
+CLI também como instrumento de diagnóstico e de validação final.
+
+Durante a reprodução e o rerun:
+
+- carregue as credenciais somente pelas variáveis e scripts locais definidos em `AGENTS.md`;
+- autentique no mesmo contexto do navegador e exercite a rota protegida relevante;
+- registre `console`, `pageerror`, `requestfailed` e `response`, mantendo apenas método, path,
+  status e evidência não sensível;
+- aguarde autenticação, requests, estados visuais e navegação com `waitForResponse`,
+  `waitForFunction` e `waitForURL`, sem depender de `waitForTimeout` isolado;
+- confirme estados observáveis de sucesso e erro, além de loading e navegação quando fizerem
+  parte do fluxo;
+- execute testes versionados com `npm --workspace @stardust/web run test:integration -- <arquivo>` ou
+  `npm exec playwright -- test ...` a partir de `apps/web`; use o ambiente de integração com
+  `ServerMock` nos testes versionados e o fluxo real em `localhost:3000`/API local para inspeção
+  autenticada fora da suíte;
+- para Studio, use o servidor, a porta e as credenciais definidos em `AGENTS.md`, valide login e
+  pelo menos uma rota protegida;
+- após cada correção, repita o fluxo autenticado completo pelo Playwright CLI. Tela de login, mock isolado ou
+  renderização unitária não bastam para declarar a correção funcional.
+
+Não registre tokens, cookies, senhas, corpos sensíveis, valores de `.env` ou logs que permitam
+reconstruí-los.
+
+## Detectores e testes
+
+Após qualquer alteração, execute os detectores obrigatórios de `AGENTS.md`:
+
+- `npm run check:code`;
+- `npm run check:types`;
+- `npm run test:unit`;
+- testes específicos do bug e o fluxo Playwright aplicável.
+
+Se um detector falhar por estado externo, como porta ocupada, preserve o processo alheio, registre
+o bloqueio exato e execute todas as alternativas seguras. Não declare sucesso global com base em
+um teste parcial.
+
+## Conclusão
+
+Depois de validar a mudança:
+
+1. inspecione `git diff` e `git diff --check`;
+2. confirme que não há arquivos ou credenciais acidentais no diff;
+3. atualize obrigatoriamente o Bug Report com todas as descobertas, paths, testes, evidências,
+   blockers e mudanças de status relevantes; mesmo sem divergência de causa, registre a evidência
+   final quando ela ainda não estiver documentada;
+4. invoque `conclude-bug-report` para consolidar as evidências e fechar o report somente quando a
+   correção estiver realmente validada;
+5. informe paths alterados, testes executados, validação manual/Playwright, blockers e o status
+   final do Bug Report.
+
+## Restrições
+
+- não implemente uma Correction Spec neste workflow;
+- não transforme relato em evidência: registre comandos, cenários e resultados observados;
+- não invente paths, testes, contratos, respostas HTTP ou causa raiz;
+- não faça mudanças destrutivas nem mate processos externos para liberar portas;
+- não faça commit, push, issue update ou PR sem solicitação explícita;
+- mantenha a correção mínima e reversível, com regressão automatizada proporcional ao risco.
+
+## Template de saída
+
+```md
+## Correção implementada
+
+- Bug Report: <path>
+- Causa confirmada: <resumo>
+- Paths alterados: <paths>
+
+## Evidências
+
+- Testes automatizados: <comandos e resultados>
+- Playwright/manual: <cenário, endpoints/status e estado observado>
+- Blockers: <nenhum ou descrição exata>
+
+## Encaminhamento
+
+- Bug Report: <open|closed|blocked>
+- Próximo passo: <conclude-bug-report|create-spec|nenhum>
+```


### PR DESCRIPTION
## Objetivo

Corrigir a transição do sign-in da Web para que a animação de foguete apareça rapidamente, não gere overflow horizontal e não seja interrompida por remounts causados pela Server Action de autenticação.

## Issues relacionadas

Closes #572

## Causa do bug

- O foguete era renderizado atrás da composição principal com z-index negativo.
- A verificação de autenticação podia redirecionar uma Server Action de sign-in antes de a transição terminar, enquanto o provider iniciava o carregamento do perfil sem o token atualizado.
- O AnimatedForm usava um AnimatePresence condicional; um remount podia desmontá-lo antes da animação de saída completar.
- O Lottie mantinha dimensões fixas em viewports menores e o atraso compartilhado era excessivo.

## Changelog

- Permite que a Server Action de sign-in conclua sem redirect intermediário.
- Aguarda o token disponível antes de iniciar o carregamento do perfil.
- Mantém o estado da transição do sign-in entre remounts.
- Ajusta a camada do foguete, limita o Lottie ao viewport e reduz o atraso de início.
- Mantém o AnimatedForm montado durante a animação de saída, com estado acessível e sem interação durante a transição.
- Adiciona regressões unitárias e de integração para visibilidade, timing, overflow, navegação e permanência do formulário.
- Atualiza AGENTS.md, os prompts de diagnóstico/correção e o Bug Report.

## Como testar

1. Execute npm run check:code.
2. Execute npm run check:types.
3. Execute npm run check:architecture.
4. Execute npm run test:unit.
5. Execute npm --workspace @stardust/web run test:integration -- src/app/tests/auth/sign-in.test.ts.
6. Para inspeção manual, carregue as credenciais locais pelo script definido em AGENTS.md, autentique em /auth/sign-in com Playwright CLI e confirme a resposta de login, a animação visível, a ausência de overflow horizontal, a conclusão da saída do formulário e a navegação para /space.

## Observações

A validação local de code, types e architecture passou. Os testes unitários tiveram 177 suítes aprovadas no servidor e 113 na Web; quatro testes de workers ficaram bloqueados porque a porta 3334 já estava ocupada. A suíte de integração não iniciou porque o servidor Web existente ocupava a porta 5000. Esses processos foram preservados. Quality Gate e build serão confirmados pelo CI.